### PR TITLE
Add reusable meeting points module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # FP Experiences Plugin
 
 This repository contains the source code for the FP Experiences WordPress plugin. Development follows the phased playbook documented in [`docs/PLAYBOOK.md`](docs/PLAYBOOK.md).
+
+## Meeting Points module
+
+* Enable or disable the feature from **FP Experiences → Settings → General → Meeting points module**.
+* Manage meeting point entries under **FP Experiences → Meeting Points** with address, notes, contact details, and optional coordinates.
+* Bulk create locations by pasting a CSV into **FP Experiences → Import Meeting Points** (`title,address,lat,lng,notes,phone,email,opening_hours`).
+* Associate meeting points with experiences from the dedicated meta box when editing an experience (primary + alternative).
+* Render the output with the `[fp_exp_meeting_points id="123"]` shortcode or the Elementor “FP Meeting Points” widget; both display the primary location with optional collapsible alternatives and Google Maps links built client-side.

--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -542,6 +542,75 @@
     background: var(--fp-exp-color-secondary, #405F3B);
 }
 
+.fp-exp-meeting-points {
+    background: var(--fp-exp-color-surface, #f7f4f0);
+    border-radius: var(--fp-exp-radius-base, 12px);
+    padding: 1.5rem;
+    box-shadow: var(--fp-exp-shadow-base, 0 10px 30px rgba(0,0,0,0.08));
+}
+
+.fp-exp-meeting-points__primary,
+.fp-exp-meeting-points__list {
+    display: grid;
+    gap: 1rem;
+}
+
+.fp-exp-meeting-point {
+    background: #fff;
+    border-radius: calc(var(--fp-exp-radius-base, 12px) / 1.25);
+    padding: 1rem 1.25rem;
+    border: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.fp-exp-meeting-point__title {
+    margin: 0 0 0.5rem;
+    font-size: 1.1rem;
+}
+
+.fp-exp-meeting-point__address {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: baseline;
+    margin: 0 0 0.5rem;
+}
+
+.fp-exp-meeting-point__map-link {
+    font-weight: 600;
+    text-decoration: underline;
+    color: var(--fp-exp-color-primary, #8B1E3F);
+}
+
+.fp-exp-meeting-point__map-link.is-disabled {
+    color: var(--fp-exp-color-muted, #6f6f6f);
+    text-decoration: none;
+    pointer-events: none;
+}
+
+.fp-exp-meeting-point__contacts {
+    margin: 0.5rem 0;
+    padding-left: 1rem;
+}
+
+.fp-exp-meeting-point__notes {
+    margin-top: 0.75rem;
+    font-size: 0.95rem;
+}
+
+.fp-exp-meeting-points__alternatives {
+    margin-top: 1.5rem;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    border-radius: calc(var(--fp-exp-radius-base, 12px) / 1.25);
+    background: #fff;
+    padding: 1rem 1.25rem;
+}
+
+.fp-exp-meeting-points__alternatives > summary {
+    cursor: pointer;
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+}
+
 @media (max-width: 768px) {
     .fp-exp-card__media {
         padding-top: 50%;

--- a/assets/js/front.js
+++ b/assets/js/front.js
@@ -301,6 +301,41 @@
         }
     }
 
+    function setupMeetingPoints() {
+        const containers = document.querySelectorAll('[data-fp-meeting-point]');
+        if (!containers.length) {
+            return;
+        }
+
+        containers.forEach((container) => {
+            const link = container.querySelector('[data-fp-map-link]');
+            if (!(link instanceof HTMLAnchorElement)) {
+                return;
+            }
+
+            const lat = (container.getAttribute('data-lat') || '').trim();
+            const lng = (container.getAttribute('data-lng') || '').trim();
+            const address = (container.getAttribute('data-address') || '').trim();
+
+            let query = '';
+            if (lat && lng) {
+                query = `${lat},${lng}`;
+            } else if (address) {
+                query = address;
+            }
+
+            if (!query) {
+                link.removeAttribute('href');
+                link.classList.add('is-disabled');
+                link.setAttribute('aria-disabled', 'true');
+                return;
+            }
+
+            const url = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`;
+            link.href = url;
+        });
+    }
+
     function pushTrackingEvent(eventName, data) {
         const channels = trackingConfig.enabled || {};
 
@@ -408,6 +443,7 @@
         captureUtm();
         document.querySelectorAll('[data-fp-shortcode="widget"]').forEach(setupWidget);
         document.querySelectorAll('[data-fp-shortcode="list"]').forEach(setupListFilters);
+        setupMeetingPoints();
     }
 
     function setupListFilters(section) {

--- a/readme.txt
+++ b/readme.txt
@@ -15,6 +15,7 @@ FP Experiences brings GetYourGuide-style booking flows to WooCommerce without to
 
 * Isolated booking cart that never mixes with WooCommerce products and uses a dedicated checkout shortcode.
 * Experience discovery widgets with availability calendars, ticket types, add-ons, and schema-ready markup.
+* Reusable meeting points with CSV import, experience linking, shortcode, and Elementor widget.
 * Optional Brevo transactional email delivery, Google Calendar sync, and marketing pixels (GA4, Google Ads, Meta, Clarity).
 * Admin calendar with drag-and-drop rescheduling, manual booking creation with payment links, and operations roles for managers, operators, and guides.
 * Consent-aware tracking, theming presets, CSS variable overrides, and Elementor controls for editors.
@@ -32,19 +33,20 @@ FP Experiences brings GetYourGuide-style booking flows to WooCommerce without to
 * `[fp_exp_widget id="123"]` – Booking widget for a specific experience. Attributes: `sticky`, `show_calendar`, `primary`, `accent`, `radius`.
 * `[fp_exp_calendar id="123" months="2"]` – Inline availability calendar for a single experience.
 * `[fp_exp_checkout]` – Isolated checkout that finalises the FP Experiences cart only.
+* `[fp_exp_meeting_points id="123"]` – Outputs the primary meeting point and optional alternatives for an experience, with map links built client-side.
 
 == Elementor Widgets ==
 
-Four Elementor widgets mirror the shortcodes: List, Widget, Calendar, and Checkout. Each exposes theming controls (colors, radius, fonts) plus behavioural toggles (sticky mode, inline calendar, consent defaults).
+Five Elementor widgets mirror the shortcodes: List, Widget, Calendar, Checkout, and Meeting Points. Each exposes theming controls (colors, radius, fonts) plus behavioural toggles (sticky mode, inline calendar, consent defaults).
 
 == Settings & Tools ==
 
-* **General** – Structure and webmaster emails, locale preferences, VAT class filters.
+* **General** – Structure and webmaster emails, locale preferences, VAT class filters, meeting points toggle.
 * **Branding** – Color palette, button radius, shadows, presets, contrast checker, optional Google Font.
 * **Tracking** – Enable/disable GA4, Google Ads, Meta Pixel, Clarity, enhanced conversions, and consent defaults.
 * **Brevo** – API key, list ID, attribute mappings, transactional template IDs, webhook diagnostics.
 * **Calendar** – Google OAuth client credentials, redirect URI, connect/disconnect, target calendar.
-* **Tools** – Brevo resync, event replay, REST API ping, and cache/log clearance with rate-limited REST endpoints.
+* **Tools** – Brevo resync, event replay, REST API ping, meeting point CSV import, and cache/log clearance with rate-limited REST endpoints.
 
 == Hooks ==
 

--- a/src/Booking/Emails.php
+++ b/src/Booking/Emails.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace FP_Exp\Booking;
 
 use FP_Exp\Integrations\Brevo;
+use FP_Exp\MeetingPoints\Repository;
 use WC_Order;
 
 use function __;
@@ -207,7 +208,7 @@ final class Emails
         $billing_meta = $order->get_meta('_fp_exp_billing');
         $billing = $this->normalize_billing($billing_meta, $order);
 
-        $meeting_point = get_post_meta($experience->ID, '_fp_meeting_point', true);
+        $meeting_point = Repository::get_primary_summary_for_experience((int) $experience->ID);
         $short_desc = get_post_meta($experience->ID, '_fp_short_desc', true);
         $tickets = $this->normalize_tickets($experience->ID, $reservation['pax'] ?? []);
         $addons = $this->normalize_addons($experience->ID, $reservation['addons'] ?? []);

--- a/src/Booking/RequestToBook.php
+++ b/src/Booking/RequestToBook.php
@@ -6,6 +6,7 @@ namespace FP_Exp\Booking;
 
 use Exception;
 use FP_Exp\Integrations\Brevo;
+use FP_Exp\MeetingPoints\Repository;
 use FP_Exp\Utils\Helpers;
 use FP_Exp\Utils\Logger;
 use WC_Order;
@@ -637,7 +638,7 @@ final class RequestToBook
                 'id' => $experience_id,
                 'title' => $experience ? $experience->post_title : '',
                 'permalink' => $experience ? get_permalink($experience) : '',
-                'meeting_point' => sanitize_text_field((string) get_post_meta($experience_id, '_fp_meeting_point', true)),
+                'meeting_point' => Repository::get_primary_summary_for_experience($experience_id),
             ],
             'slot' => $slot,
             'customer' => $contact,

--- a/src/Elementor/WidgetMeetingPoints.php
+++ b/src/Elementor/WidgetMeetingPoints.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP_Exp\Elementor;
+
+use Elementor\Controls_Manager;
+use Elementor\Widget_Base;
+use FP_Exp\Utils\Helpers;
+
+use function do_shortcode;
+use function esc_html__;
+
+final class WidgetMeetingPoints extends Widget_Base
+{
+    public function get_name(): string
+    {
+        return 'fp-exp-meeting-points';
+    }
+
+    public function get_title(): string
+    {
+        return esc_html__('FP Meeting Points', 'fp-experiences');
+    }
+
+    public function get_icon(): string
+    {
+        return 'eicon-pin';
+    }
+
+    public function get_categories(): array
+    {
+        return ['fp-exp'];
+    }
+
+    public function get_keywords(): array
+    {
+        return ['experience', 'meeting point', 'location'];
+    }
+
+    protected function register_controls(): void
+    {
+        $this->start_controls_section(
+            'section_content',
+            [
+                'label' => esc_html__('Content', 'fp-experiences'),
+            ]
+        );
+
+        $this->add_control(
+            'experience_id',
+            [
+                'label' => esc_html__('Experience ID', 'fp-experiences'),
+                'type' => Controls_Manager::NUMBER,
+                'min' => 1,
+                'default' => 0,
+            ]
+        );
+
+        $this->end_controls_section();
+    }
+
+    protected function render(): void
+    {
+        if (! Helpers::meeting_points_enabled()) {
+            return;
+        }
+
+        $settings = $this->get_settings_for_display();
+        $experience_id = (int) ($settings['experience_id'] ?? 0);
+
+        if ($experience_id <= 0) {
+            return;
+        }
+
+        echo do_shortcode('[fp_exp_meeting_points id="' . $experience_id . '"]');
+    }
+}

--- a/src/Elementor/WidgetsRegistrar.php
+++ b/src/Elementor/WidgetsRegistrar.php
@@ -6,6 +6,7 @@ namespace FP_Exp\Elementor;
 
 use Elementor\Elements_Manager;
 use Elementor\Widgets_Manager;
+use FP_Exp\Utils\Helpers;
 
 use function __;
 use function add_action;
@@ -34,6 +35,10 @@ final class WidgetsRegistrar
         $widgets_manager->register(new WidgetWidget());
         $widgets_manager->register(new WidgetCalendar());
         $widgets_manager->register(new WidgetCheckout());
+
+        if (Helpers::meeting_points_enabled()) {
+            $widgets_manager->register(new WidgetMeetingPoints());
+        }
     }
 
     public function register_category(Elements_Manager $elements_manager): void

--- a/src/MeetingPoints/ExperienceMetaBox.php
+++ b/src/MeetingPoints/ExperienceMetaBox.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP_Exp\MeetingPoints;
+
+use FP_Exp\Utils\Helpers;
+use FP_Exp\MeetingPoints\Repository;
+use WP_Post;
+
+use function absint;
+use function array_unique;
+use function array_values;
+use function add_action;
+use function add_meta_box;
+use function current_user_can;
+use function esc_attr;
+use function esc_html__;
+use function esc_html_e;
+use function delete_post_meta;
+use function get_post_meta;
+use function get_posts;
+use function in_array;
+use function is_array;
+use function selected;
+use function update_post_meta;
+use function wp_is_post_autosave;
+use function wp_is_post_revision;
+use function wp_nonce_field;
+use function wp_verify_nonce;
+
+final class ExperienceMetaBox
+{
+    public function register_hooks(): void
+    {
+        add_action('add_meta_boxes_fp_experience', [$this, 'add_meta_box']);
+        add_action('save_post_fp_experience', [$this, 'save_meta_box'], 10, 3);
+    }
+
+    public function add_meta_box(): void
+    {
+        if (! Helpers::meeting_points_enabled()) {
+            return;
+        }
+
+        add_meta_box(
+            'fp-exp-experience-meeting-point',
+            esc_html__('Meeting Point', 'fp-experiences'),
+            [$this, 'render_meta_box'],
+            'fp_experience',
+            'side',
+            'default'
+        );
+    }
+
+    public function render_meta_box(WP_Post $post): void
+    {
+        $primary_id = absint((string) get_post_meta($post->ID, '_fp_meeting_point_id', true));
+        $alt_ids = get_post_meta($post->ID, '_fp_meeting_point_alt', true);
+        $alt_ids = is_array($alt_ids) ? array_map('absint', $alt_ids) : [];
+
+        $meeting_points = $this->get_meeting_points();
+
+        wp_nonce_field('fp_exp_experience_meeting_point', 'fp_exp_experience_meeting_point_nonce');
+        ?>
+        <p>
+            <label for="fp-exp-meeting-point-primary"><?php esc_html_e('Meeting point principale', 'fp-experiences'); ?></label>
+            <select id="fp-exp-meeting-point-primary" name="fp_exp_meeting_point_primary" class="widefat">
+                <option value="0">&mdash; <?php esc_html_e('Nessuno', 'fp-experiences'); ?> &mdash;</option>
+                <?php foreach ($meeting_points as $point) : ?>
+                    <option value="<?php echo esc_attr((string) $point['id']); ?>" <?php selected($primary_id, $point['id']); ?>><?php echo esc_html($point['title']); ?></option>
+                <?php endforeach; ?>
+            </select>
+        </p>
+        <?php if (! empty($meeting_points)) : ?>
+            <p>
+                <label for="fp-exp-meeting-point-alt"><?php esc_html_e('Meeting point alternativi', 'fp-experiences'); ?></label>
+                <select id="fp-exp-meeting-point-alt" name="fp_exp_meeting_point_alt[]" multiple size="5" class="widefat">
+                    <?php foreach ($meeting_points as $point) : ?>
+                        <option value="<?php echo esc_attr((string) $point['id']); ?>" <?php selected(in_array($point['id'], $alt_ids, true), true); ?>><?php echo esc_html($point['title']); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </p>
+        <?php endif; ?>
+        <?php
+    }
+
+    public function save_meta_box(int $post_id, WP_Post $post, bool $update): void
+    {
+        if (wp_is_post_autosave($post_id) || wp_is_post_revision($post_id)) {
+            return;
+        }
+
+        if (! isset($_POST['fp_exp_experience_meeting_point_nonce']) || ! wp_verify_nonce((string) $_POST['fp_exp_experience_meeting_point_nonce'], 'fp_exp_experience_meeting_point')) {
+            return;
+        }
+
+        if (! current_user_can('edit_post', $post_id)) {
+            return;
+        }
+
+        $primary_id = isset($_POST['fp_exp_meeting_point_primary']) ? absint((string) $_POST['fp_exp_meeting_point_primary']) : 0;
+        $alt_raw = $_POST['fp_exp_meeting_point_alt'] ?? [];
+        $alt_ids = [];
+
+        if (is_array($alt_raw)) {
+            foreach ($alt_raw as $value) {
+                $alt_id = absint((string) $value);
+                if ($alt_id > 0 && $alt_id !== $primary_id) {
+                    $alt_ids[] = $alt_id;
+                }
+            }
+        }
+
+        $alt_ids = array_values(array_unique($alt_ids));
+
+        if ($primary_id > 0) {
+            update_post_meta($post_id, '_fp_meeting_point_id', $primary_id);
+        } else {
+            delete_post_meta($post_id, '_fp_meeting_point_id');
+        }
+
+        if (! empty($alt_ids)) {
+            update_post_meta($post_id, '_fp_meeting_point_alt', $alt_ids);
+        } else {
+            delete_post_meta($post_id, '_fp_meeting_point_alt');
+        }
+
+        $summary = Repository::get_primary_summary_for_experience($post_id, $primary_id);
+        if ($summary) {
+            update_post_meta($post_id, '_fp_meeting_point', $summary);
+        } else {
+            delete_post_meta($post_id, '_fp_meeting_point');
+        }
+    }
+
+    /**
+     * @return array<int, array{id:int,title:string}>
+     */
+    private function get_meeting_points(): array
+    {
+        $posts = get_posts([
+            'post_type' => MeetingPointCPT::POST_TYPE,
+            'posts_per_page' => -1,
+            'orderby' => 'title',
+            'order' => 'ASC',
+            'post_status' => ['publish'],
+            'fields' => 'ids',
+        ]);
+
+        $points = [];
+        foreach ($posts as $post_id) {
+            $point = Repository::get_meeting_point((int) $post_id);
+            if (! $point) {
+                continue;
+            }
+
+            $points[] = [
+                'id' => $point['id'],
+                'title' => $point['title'],
+            ];
+        }
+
+        return $points;
+    }
+}

--- a/src/MeetingPoints/Manager.php
+++ b/src/MeetingPoints/Manager.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP_Exp\MeetingPoints;
+
+use function is_admin;
+
+final class Manager
+{
+    private MeetingPointCPT $cpt;
+
+    private RestController $rest_controller;
+
+    private ?MeetingPointMetaBoxes $meta_boxes = null;
+
+    private ?ExperienceMetaBox $experience_meta_box = null;
+
+    private ?MeetingPointImporter $importer = null;
+
+    public function __construct()
+    {
+        $this->cpt = new MeetingPointCPT();
+        $this->rest_controller = new RestController();
+
+        if (is_admin()) {
+            $this->meta_boxes = new MeetingPointMetaBoxes();
+            $this->experience_meta_box = new ExperienceMetaBox();
+            $this->importer = new MeetingPointImporter();
+        }
+    }
+
+    public function register_hooks(): void
+    {
+        $this->cpt->register_hooks();
+        $this->rest_controller->register_hooks();
+
+        if ($this->meta_boxes instanceof MeetingPointMetaBoxes) {
+            $this->meta_boxes->register_hooks();
+        }
+
+        if ($this->experience_meta_box instanceof ExperienceMetaBox) {
+            $this->experience_meta_box->register_hooks();
+        }
+
+        if ($this->importer instanceof MeetingPointImporter) {
+            $this->importer->register_hooks();
+        }
+    }
+}

--- a/src/MeetingPoints/MeetingPointCPT.php
+++ b/src/MeetingPoints/MeetingPointCPT.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP_Exp\MeetingPoints;
+
+use FP_Exp\Utils\Helpers;
+use WP_Query;
+
+use function add_action;
+use function add_filter;
+use function esc_html;
+use function esc_html__;
+use function get_post_meta;
+use function register_post_type;
+use function sanitize_text_field;
+use function is_admin;
+use function wp_kses_post;
+use function wp_parse_args;
+
+final class MeetingPointCPT
+{
+    public const POST_TYPE = 'fp_meeting_point';
+
+    public function register_hooks(): void
+    {
+        add_action('init', [$this, 'register_post_type']);
+        add_filter('manage_' . self::POST_TYPE . '_posts_columns', [$this, 'register_columns']);
+        add_action('manage_' . self::POST_TYPE . '_posts_custom_column', [$this, 'render_column'], 10, 2);
+        add_action('pre_get_posts', [$this, 'extend_admin_search']);
+    }
+
+    public function register_post_type(): void
+    {
+        $labels = [
+            'name' => esc_html__('Meeting Points', 'fp-experiences'),
+            'singular_name' => esc_html__('Meeting Point', 'fp-experiences'),
+            'add_new' => esc_html__('Add Meeting Point', 'fp-experiences'),
+            'add_new_item' => esc_html__('Add Meeting Point', 'fp-experiences'),
+            'edit_item' => esc_html__('Edit Meeting Point', 'fp-experiences'),
+            'new_item' => esc_html__('New Meeting Point', 'fp-experiences'),
+            'view_item' => esc_html__('View Meeting Point', 'fp-experiences'),
+            'search_items' => esc_html__('Search Meeting Points', 'fp-experiences'),
+            'not_found' => esc_html__('No meeting points found.', 'fp-experiences'),
+            'menu_name' => esc_html__('Meeting Points', 'fp-experiences'),
+        ];
+
+        register_post_type(self::POST_TYPE, [
+            'labels' => $labels,
+            'public' => false,
+            'show_ui' => true,
+            'show_in_menu' => Helpers::meeting_points_enabled() ? 'fp-exp-settings' : false,
+            'supports' => ['title'],
+            'show_in_rest' => false,
+            'rewrite' => false,
+            'capability_type' => 'post',
+            'map_meta_cap' => true,
+        ]);
+    }
+
+    /**
+     * @param array<string, string> $columns
+     *
+     * @return array<string, string>
+     */
+    public function register_columns(array $columns): array
+    {
+        $positioned = [];
+        foreach ($columns as $key => $label) {
+            $positioned[$key] = $label;
+            if ('title' === $key) {
+                $positioned['fp_mp_address'] = esc_html__('Address', 'fp-experiences');
+                $positioned['fp_mp_geo'] = esc_html__('Lat/Lng', 'fp-experiences');
+            }
+        }
+
+        return $positioned;
+    }
+
+    public function render_column(string $column, int $post_id): void
+    {
+        if ('fp_mp_address' === $column) {
+            $address = sanitize_text_field((string) get_post_meta($post_id, '_fp_mp_address', true));
+            echo esc_html($address);
+
+            return;
+        }
+
+        if ('fp_mp_geo' === $column) {
+            $lat = sanitize_text_field((string) get_post_meta($post_id, '_fp_mp_lat', true));
+            $lng = sanitize_text_field((string) get_post_meta($post_id, '_fp_mp_lng', true));
+            $value = trim($lat . ($lat && $lng ? ', ' : '') . $lng);
+            echo esc_html($value);
+        }
+    }
+
+    public function extend_admin_search(WP_Query $query): void
+    {
+        if (! is_admin() || ! $query->is_main_query() || self::POST_TYPE !== $query->get('post_type')) {
+            return;
+        }
+
+        $search = $query->get('s');
+        if (! is_string($search) || '' === $search) {
+            return;
+        }
+
+        $meta_query = (array) $query->get('meta_query');
+        $meta_query[] = [
+            'key' => '_fp_mp_address',
+            'value' => $search,
+            'compare' => 'LIKE',
+        ];
+
+        $query->set('meta_query', $meta_query);
+    }
+}

--- a/src/MeetingPoints/MeetingPointImporter.php
+++ b/src/MeetingPoints/MeetingPointImporter.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP_Exp\MeetingPoints;
+
+use FP_Exp\Utils\Helpers;
+use WP_Error;
+
+use function add_action;
+use function add_query_arg;
+use function add_submenu_page;
+use function admin_url;
+use function current_user_can;
+use function esc_attr;
+use function esc_html;
+use function esc_html__;
+use function esc_html_e;
+use function get_transient;
+use function delete_transient;
+use function is_array;
+use function sanitize_email;
+use function sanitize_text_field;
+use function set_transient;
+use function sprintf;
+use function submit_button;
+use function update_post_meta;
+use function wp_insert_post;
+use function wp_safe_redirect;
+use function wp_unslash;
+use function wp_verify_nonce;
+use function wp_nonce_field;
+use function wp_die;
+use function wp_kses_post;
+use function preg_split;
+use function str_getcsv;
+use function strtolower;
+
+use const MINUTE_IN_SECONDS;
+
+final class MeetingPointImporter
+{
+    private const TRANSIENT_KEY = 'fp_exp_meeting_point_import_notice';
+
+    public function register_hooks(): void
+    {
+        add_action('admin_menu', [$this, 'register_menu']);
+        add_action('admin_post_fp_exp_import_meeting_points', [$this, 'handle_import']);
+    }
+
+    public function register_menu(): void
+    {
+        if (! Helpers::meeting_points_enabled()) {
+            return;
+        }
+
+        add_submenu_page(
+            'fp-exp-settings',
+            esc_html__('Import Meeting Points', 'fp-experiences'),
+            esc_html__('Import Meeting Points', 'fp-experiences'),
+            'manage_options',
+            'fp-exp-meeting-points-import',
+            [$this, 'render_page']
+        );
+    }
+
+    public function render_page(): void
+    {
+        if (! current_user_can('manage_options')) {
+            wp_die(esc_html__('You do not have permission to access this page.', 'fp-experiences'));
+        }
+
+        $notice = get_transient(self::TRANSIENT_KEY);
+        if (is_array($notice) && ! empty($notice['message'])) {
+            $class = 'notice';
+            if (! empty($notice['type'])) {
+                $class .= ' notice-' . sanitize_text_field((string) $notice['type']);
+            }
+            echo '<div class="' . esc_attr($class) . '"><p>' . esc_html((string) $notice['message']) . '</p></div>';
+            delete_transient(self::TRANSIENT_KEY);
+        }
+
+        $action = admin_url('admin-post.php');
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e('Import meeting points', 'fp-experiences'); ?></h1>
+            <p><?php esc_html_e('Incolla qui un CSV con le colonne: title,address,lat,lng,notes,phone,email,opening_hours.', 'fp-experiences'); ?></p>
+            <form method="post" action="<?php echo esc_attr($action); ?>">
+                <?php wp_nonce_field('fp_exp_meeting_point_import', 'fp_exp_meeting_point_import_nonce'); ?>
+                <input type="hidden" name="action" value="fp_exp_import_meeting_points" />
+                <p>
+                    <textarea name="fp_exp_meeting_point_csv" rows="12" class="large-text" placeholder="Titolo,Indirizzo,Lat,Lng,Note,Telefono,Email,Orari"></textarea>
+                </p>
+                <?php submit_button(esc_html__('Import CSV', 'fp-experiences')); ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    public function handle_import(): void
+    {
+        if (! Helpers::meeting_points_enabled()) {
+            wp_die(esc_html__('Meeting points are disabled.', 'fp-experiences'));
+        }
+
+        if (! current_user_can('manage_options')) {
+            wp_die(esc_html__('You do not have permission to import meeting points.', 'fp-experiences'));
+        }
+
+        if (! isset($_POST['fp_exp_meeting_point_import_nonce']) || ! wp_verify_nonce((string) $_POST['fp_exp_meeting_point_import_nonce'], 'fp_exp_meeting_point_import')) {
+            wp_die(esc_html__('Security check failed.', 'fp-experiences'));
+        }
+
+        $raw = isset($_POST['fp_exp_meeting_point_csv']) ? (string) wp_unslash($_POST['fp_exp_meeting_point_csv']) : '';
+        $rows = preg_split('/\r?\n/', trim($raw));
+
+        $imported = 0;
+        $skipped = 0;
+
+        if (is_array($rows)) {
+            foreach ($rows as $row) {
+                $row = trim($row);
+                if ('' === $row) {
+                    continue;
+                }
+
+                $columns = str_getcsv($row);
+                if (count($columns) < 2) {
+                    $skipped++;
+                    continue;
+                }
+
+                $title = sanitize_text_field($columns[0] ?? '');
+                $address = sanitize_text_field($columns[1] ?? '');
+                $lat = sanitize_text_field($columns[2] ?? '');
+                $lng = sanitize_text_field($columns[3] ?? '');
+                $notes = $columns[4] ?? '';
+                $phone = sanitize_text_field($columns[5] ?? '');
+                $email = sanitize_email($columns[6] ?? '');
+                $opening_hours = sanitize_text_field($columns[7] ?? '');
+
+                if ('' === $title) {
+                    $skipped++;
+                    continue;
+                }
+
+                if (0 === $imported && strtolower($title) === 'title') {
+                    $skipped++;
+                    continue;
+                }
+
+                $post_id = wp_insert_post([
+                    'post_type' => MeetingPointCPT::POST_TYPE,
+                    'post_status' => 'publish',
+                    'post_title' => $title,
+                ]);
+
+                if (! $post_id || $post_id instanceof WP_Error) {
+                    $skipped++;
+                    continue;
+                }
+
+                update_post_meta($post_id, '_fp_mp_address', $address);
+                update_post_meta($post_id, '_fp_mp_lat', $lat);
+                update_post_meta($post_id, '_fp_mp_lng', $lng);
+                update_post_meta($post_id, '_fp_mp_notes', wp_kses_post($notes));
+                update_post_meta($post_id, '_fp_mp_phone', $phone);
+                update_post_meta($post_id, '_fp_mp_email', $email);
+                update_post_meta($post_id, '_fp_mp_opening_hours', $opening_hours);
+
+                $imported++;
+            }
+        }
+
+        set_transient(
+            self::TRANSIENT_KEY,
+            [
+                'type' => 'success',
+                'message' => sprintf(
+                    esc_html__('%1$d meeting points imported, %2$d skipped.', 'fp-experiences'),
+                    $imported,
+                    $skipped
+                ),
+            ],
+            MINUTE_IN_SECONDS
+        );
+
+        wp_safe_redirect(add_query_arg(['page' => 'fp-exp-meeting-points-import'], admin_url('admin.php')));
+        exit;
+    }
+}

--- a/src/MeetingPoints/MeetingPointMetaBoxes.php
+++ b/src/MeetingPoints/MeetingPointMetaBoxes.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP_Exp\MeetingPoints;
+
+use FP_Exp\Utils\Helpers;
+use WP_Post;
+
+use function add_action;
+use function add_meta_box;
+use function current_user_can;
+use function esc_attr;
+use function esc_html__;
+use function esc_html_e;
+use function esc_textarea;
+use function get_post_meta;
+use function is_array;
+use function sanitize_email;
+use function sanitize_text_field;
+use function update_post_meta;
+use function wp_is_post_autosave;
+use function wp_is_post_revision;
+use function wp_nonce_field;
+use function wp_verify_nonce;
+use function wp_kses_post;
+
+final class MeetingPointMetaBoxes
+{
+    public function register_hooks(): void
+    {
+        add_action('add_meta_boxes_' . MeetingPointCPT::POST_TYPE, [$this, 'add_meta_boxes']);
+        add_action('save_post_' . MeetingPointCPT::POST_TYPE, [$this, 'save_meta_box'], 10, 2);
+    }
+
+    public function add_meta_boxes(): void
+    {
+        if (! Helpers::meeting_points_enabled()) {
+            return;
+        }
+
+        add_meta_box(
+            'fp-exp-meeting-point-details',
+            esc_html__('Dettagli meeting point', 'fp-experiences'),
+            [$this, 'render_meta_box'],
+            MeetingPointCPT::POST_TYPE,
+            'normal',
+            'high'
+        );
+    }
+
+    public function render_meta_box(WP_Post $post): void
+    {
+        $address = sanitize_text_field((string) get_post_meta($post->ID, '_fp_mp_address', true));
+        $lat = sanitize_text_field((string) get_post_meta($post->ID, '_fp_mp_lat', true));
+        $lng = sanitize_text_field((string) get_post_meta($post->ID, '_fp_mp_lng', true));
+        $notes = wp_kses_post((string) get_post_meta($post->ID, '_fp_mp_notes', true));
+        $phone = sanitize_text_field((string) get_post_meta($post->ID, '_fp_mp_phone', true));
+        $email = sanitize_email((string) get_post_meta($post->ID, '_fp_mp_email', true));
+        $opening_hours = sanitize_text_field((string) get_post_meta($post->ID, '_fp_mp_opening_hours', true));
+
+        wp_nonce_field('fp_exp_meeting_point_meta', 'fp_exp_meeting_point_meta_nonce');
+        ?>
+        <div class="fp-exp-meta-box fp-exp-meta-box--meeting-point">
+            <p>
+                <label for="fp-exp-mp-address"><?php esc_html_e('Indirizzo completo', 'fp-experiences'); ?></label><br />
+                <input type="text" id="fp-exp-mp-address" name="fp_exp_mp[address]" class="widefat" value="<?php echo esc_attr($address); ?>" />
+            </p>
+            <p class="fp-exp-meta-box__inline">
+                <label>
+                    <?php esc_html_e('Latitudine', 'fp-experiences'); ?><br />
+                    <input type="text" name="fp_exp_mp[lat]" value="<?php echo esc_attr($lat); ?>" placeholder="41.9028" />
+                </label>
+                <label>
+                    <?php esc_html_e('Longitudine', 'fp-experiences'); ?><br />
+                    <input type="text" name="fp_exp_mp[lng]" value="<?php echo esc_attr($lng); ?>" placeholder="12.4964" />
+                </label>
+            </p>
+            <p>
+                <label for="fp-exp-mp-notes"><?php esc_html_e('Note per i partecipanti', 'fp-experiences'); ?></label>
+                <textarea id="fp-exp-mp-notes" name="fp_exp_mp[notes]" class="widefat" rows="4"><?php echo esc_textarea($notes); ?></textarea>
+            </p>
+            <p class="fp-exp-meta-box__inline">
+                <label>
+                    <?php esc_html_e('Telefono', 'fp-experiences'); ?><br />
+                    <input type="text" name="fp_exp_mp[phone]" value="<?php echo esc_attr($phone); ?>" />
+                </label>
+                <label>
+                    <?php esc_html_e('Email', 'fp-experiences'); ?><br />
+                    <input type="email" name="fp_exp_mp[email]" value="<?php echo esc_attr($email); ?>" />
+                </label>
+            </p>
+            <p>
+                <label for="fp-exp-mp-opening-hours"><?php esc_html_e('Orari di apertura', 'fp-experiences'); ?></label>
+                <input type="text" id="fp-exp-mp-opening-hours" name="fp_exp_mp[opening_hours]" class="widefat" value="<?php echo esc_attr($opening_hours); ?>" />
+            </p>
+        </div>
+        <?php
+    }
+
+    public function save_meta_box(int $post_id, WP_Post $post): void
+    {
+        if (wp_is_post_autosave($post_id) || wp_is_post_revision($post_id)) {
+            return;
+        }
+
+        if (! isset($_POST['fp_exp_meeting_point_meta_nonce']) || ! wp_verify_nonce((string) $_POST['fp_exp_meeting_point_meta_nonce'], 'fp_exp_meeting_point_meta')) {
+            return;
+        }
+
+        if (! current_user_can('edit_post', $post_id)) {
+            return;
+        }
+
+        $data = $_POST['fp_exp_mp'] ?? [];
+        if (! is_array($data)) {
+            return;
+        }
+
+        $address = sanitize_text_field((string) ($data['address'] ?? ''));
+        $lat = sanitize_text_field((string) ($data['lat'] ?? ''));
+        $lng = sanitize_text_field((string) ($data['lng'] ?? ''));
+        $notes = wp_kses_post((string) ($data['notes'] ?? ''));
+        $phone = sanitize_text_field((string) ($data['phone'] ?? ''));
+        $email = sanitize_email((string) ($data['email'] ?? ''));
+        $opening_hours = sanitize_text_field((string) ($data['opening_hours'] ?? ''));
+
+        update_post_meta($post_id, '_fp_mp_address', $address);
+        update_post_meta($post_id, '_fp_mp_lat', $lat);
+        update_post_meta($post_id, '_fp_mp_lng', $lng);
+        update_post_meta($post_id, '_fp_mp_notes', $notes);
+        update_post_meta($post_id, '_fp_mp_phone', $phone);
+        update_post_meta($post_id, '_fp_mp_email', $email);
+        update_post_meta($post_id, '_fp_mp_opening_hours', $opening_hours);
+    }
+}

--- a/src/MeetingPoints/Repository.php
+++ b/src/MeetingPoints/Repository.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP_Exp\MeetingPoints;
+
+use WP_Post;
+
+use function absint;
+use function get_post;
+use function get_post_meta;
+use function is_array;
+use function array_map;
+use function sanitize_email;
+use function sanitize_text_field;
+use function wp_kses_post;
+use function is_finite;
+
+final class Repository
+{
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    private static array $cache = [];
+
+    public static function get_meeting_point(int $id): ?array
+    {
+        $id = absint($id);
+        if ($id <= 0) {
+            return null;
+        }
+
+        if (isset(self::$cache[$id])) {
+            return self::$cache[$id];
+        }
+
+        $post = get_post($id);
+        if (! $post instanceof WP_Post || MeetingPointCPT::POST_TYPE !== $post->post_type) {
+            return null;
+        }
+
+        $data = [
+            'id' => $post->ID,
+            'title' => $post->post_title,
+            'address' => sanitize_text_field((string) get_post_meta($post->ID, '_fp_mp_address', true)),
+            'lat' => self::normalize_float_meta(get_post_meta($post->ID, '_fp_mp_lat', true)),
+            'lng' => self::normalize_float_meta(get_post_meta($post->ID, '_fp_mp_lng', true)),
+            'notes' => wp_kses_post((string) get_post_meta($post->ID, '_fp_mp_notes', true)),
+            'phone' => sanitize_text_field((string) get_post_meta($post->ID, '_fp_mp_phone', true)),
+            'email' => sanitize_email((string) get_post_meta($post->ID, '_fp_mp_email', true)),
+            'opening_hours' => sanitize_text_field((string) get_post_meta($post->ID, '_fp_mp_opening_hours', true)),
+        ];
+
+        self::$cache[$id] = $data;
+
+        return $data;
+    }
+
+    /**
+     * @return array{primary: ?array<string, mixed>, alternatives: array<int, array<string, mixed>>}
+     */
+    public static function get_meeting_points_for_experience(int $experience_id): array
+    {
+        $primary_id = absint((string) get_post_meta($experience_id, '_fp_meeting_point_id', true));
+        $alt_ids = get_post_meta($experience_id, '_fp_meeting_point_alt', true);
+        $alt_ids = is_array($alt_ids) ? array_map('absint', $alt_ids) : [];
+
+        $primary = $primary_id > 0 ? self::get_meeting_point($primary_id) : null;
+
+        $alternatives = [];
+        if (! empty($alt_ids)) {
+            foreach ($alt_ids as $alt_id) {
+                if ($alt_id <= 0 || ($primary && $alt_id === $primary['id'])) {
+                    continue;
+                }
+
+                $point = self::get_meeting_point($alt_id);
+                if ($point) {
+                    $alternatives[] = $point;
+                }
+            }
+        }
+
+        if (! $primary) {
+            $legacy = sanitize_text_field((string) get_post_meta($experience_id, '_fp_meeting_point', true));
+            if ($legacy) {
+                $primary = [
+                    'id' => 0,
+                    'title' => $legacy,
+                    'address' => $legacy,
+                    'lat' => null,
+                    'lng' => null,
+                    'notes' => '',
+                    'phone' => '',
+                    'email' => '',
+                    'opening_hours' => '',
+                ];
+            }
+        }
+
+        return [
+            'primary' => $primary,
+            'alternatives' => $alternatives,
+        ];
+    }
+
+    public static function get_primary_summary_for_experience(int $experience_id, int $primary_id = 0): string
+    {
+        $primary = $primary_id > 0 ? self::get_meeting_point($primary_id) : null;
+
+        if (! $primary) {
+            $data = self::get_meeting_points_for_experience($experience_id);
+            $primary = $data['primary'];
+        }
+
+        if (! $primary) {
+            return '';
+        }
+
+        $title = trim((string) $primary['title']);
+        $address = trim((string) $primary['address']);
+
+        if ($title && $address && $title !== $address) {
+            return $title . ' - ' . $address;
+        }
+
+        return $address ?: $title;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function normalize_float_meta($value): ?float
+    {
+        if ('' === $value || null === $value) {
+            return null;
+        }
+
+        $value = (float) $value;
+
+        return is_finite($value) ? $value : null;
+    }
+}

--- a/src/MeetingPoints/RestController.php
+++ b/src/MeetingPoints/RestController.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP_Exp\MeetingPoints;
+
+use FP_Exp\Utils\Helpers;
+use WP_REST_Request;
+use WP_REST_Response;
+
+use function add_action;
+use function array_filter;
+use function array_map;
+use function array_values;
+use function rest_ensure_response;
+use function absint;
+use function register_rest_route;
+
+final class RestController
+{
+    public function register_hooks(): void
+    {
+        add_action('rest_api_init', [$this, 'register_routes']);
+    }
+
+    public function register_routes(): void
+    {
+        register_rest_route(
+            'fp-exp/v1',
+            '/meeting-points/(?P<experience_id>\d+)',
+            [
+                'methods' => 'GET',
+                'permission_callback' => '__return_true',
+                'callback' => [$this, 'get_meeting_points'],
+                'args' => [
+                    'experience_id' => [
+                        'required' => true,
+                        'sanitize_callback' => 'absint',
+                    ],
+                ],
+            ]
+        );
+    }
+
+    public function get_meeting_points(WP_REST_Request $request)
+    {
+        if (! Helpers::meeting_points_enabled()) {
+            return rest_ensure_response([
+                'primary' => null,
+                'alternatives' => [],
+            ]);
+        }
+
+        $experience_id = absint((string) $request->get_param('experience_id'));
+
+        $data = Repository::get_meeting_points_for_experience($experience_id);
+
+        return rest_ensure_response([
+            'primary' => $this->prepare_point($data['primary']),
+            'alternatives' => array_values(array_filter(array_map([$this, 'prepare_point'], $data['alternatives']))),
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed>|null $point
+     *
+     * @return array<string, mixed>|null
+     */
+    private function prepare_point(?array $point): ?array
+    {
+        if (! $point) {
+            return null;
+        }
+
+        return [
+            'id' => (int) $point['id'],
+            'title' => (string) $point['title'],
+            'address' => (string) $point['address'],
+            'lat' => isset($point['lat']) ? (float) $point['lat'] : null,
+            'lng' => isset($point['lng']) ? (float) $point['lng'] : null,
+            'notes' => (string) ($point['notes'] ?? ''),
+            'phone' => (string) ($point['phone'] ?? ''),
+            'email' => (string) ($point['email'] ?? ''),
+            'opening_hours' => (string) ($point['opening_hours'] ?? ''),
+        ];
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -20,6 +20,7 @@ use FP_Exp\Booking\RequestToBook;
 use FP_Exp\Booking\Resources;
 use FP_Exp\Booking\Slots;
 use FP_Exp\Elementor\WidgetsRegistrar as ElementorWidgetsRegistrar;
+use FP_Exp\MeetingPoints\Manager as MeetingPointsManager;
 use FP_Exp\Integrations\Brevo;
 use FP_Exp\Integrations\Clarity;
 use FP_Exp\Integrations\GA4;
@@ -82,6 +83,8 @@ final class Plugin
 
     private ?Webhooks $webhooks = null;
 
+    private ?MeetingPointsManager $meeting_points = null;
+
     public static function instance(): Plugin
     {
         if (null === self::$instance) {
@@ -111,6 +114,7 @@ final class Plugin
         $this->elementor_widgets = new ElementorWidgetsRegistrar();
         $this->rest_routes = new RestRoutes();
         $this->webhooks = new Webhooks();
+        $this->meeting_points = new MeetingPointsManager();
 
         if (is_admin()) {
             $this->settings_page = new SettingsPage();
@@ -148,6 +152,10 @@ final class Plugin
 
         if ($this->rest_routes instanceof RestRoutes) {
             $this->rest_routes->register_hooks();
+        }
+
+        if ($this->meeting_points instanceof MeetingPointsManager) {
+            $this->meeting_points->register_hooks();
         }
 
         if ($this->webhooks instanceof Webhooks) {

--- a/src/PostTypes/ExperienceCPT.php
+++ b/src/PostTypes/ExperienceCPT.php
@@ -207,6 +207,14 @@ final class ExperienceCPT
             '_fp_meeting_point' => [
                 'type' => 'string',
             ],
+            '_fp_meeting_point_id' => [
+                'type' => 'integer',
+            ],
+            '_fp_meeting_point_alt' => [
+                'type' => 'array',
+                'items' => 'integer',
+                'default' => [],
+            ],
             '_fp_inclusions' => [
                 'type' => 'array',
                 'items' => 'string',

--- a/src/Shortcodes/MeetingPointsShortcode.php
+++ b/src/Shortcodes/MeetingPointsShortcode.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP_Exp\Shortcodes;
+
+use FP_Exp\MeetingPoints\Repository;
+use FP_Exp\Utils\Helpers;
+use FP_Exp\Utils\Theme;
+use WP_Error;
+
+use function absint;
+use function esc_html__;
+
+final class MeetingPointsShortcode extends BaseShortcode
+{
+    protected string $tag = 'fp_exp_meeting_points';
+
+    protected string $template = 'front/meeting-points.php';
+
+    protected array $defaults = [
+        'id' => '',
+    ];
+
+    /**
+     * @param array<string, mixed> $attributes
+     *
+     * @return array<string, mixed>|WP_Error
+     */
+    protected function get_context(array $attributes, ?string $content = null)
+    {
+        $experience_id = absint($attributes['id']);
+
+        if ($experience_id <= 0) {
+            return new WP_Error('fp_exp_meeting_points_invalid', esc_html__('Missing experience ID.', 'fp-experiences'));
+        }
+
+        if (! Helpers::meeting_points_enabled()) {
+            return [
+                'experience_id' => $experience_id,
+                'primary' => null,
+                'alternatives' => [],
+                'theme' => Theme::resolve_palette([]),
+            ];
+        }
+
+        $data = Repository::get_meeting_points_for_experience($experience_id);
+
+        if (! $data['primary']) {
+            return new WP_Error('fp_exp_meeting_points_empty', esc_html__('No meeting point configured for this experience.', 'fp-experiences'));
+        }
+
+        return [
+            'experience_id' => $experience_id,
+            'primary' => $data['primary'],
+            'alternatives' => $data['alternatives'],
+            'theme' => Theme::resolve_palette([]),
+        ];
+    }
+}

--- a/src/Shortcodes/Registrar.php
+++ b/src/Shortcodes/Registrar.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace FP_Exp\Shortcodes;
 
+use FP_Exp\Utils\Helpers;
+
 final class Registrar
 {
     /**
@@ -19,6 +21,10 @@ final class Registrar
             new CalendarShortcode(),
             new CheckoutShortcode(),
         ];
+
+        if (Helpers::meeting_points_enabled()) {
+            $this->shortcodes[] = new MeetingPointsShortcode();
+        }
     }
 
     public function register(): void

--- a/src/Shortcodes/WidgetShortcode.php
+++ b/src/Shortcodes/WidgetShortcode.php
@@ -9,6 +9,7 @@ use DateTimeInterface;
 use DateTimeZone;
 use Exception;
 use FP_Exp\Booking\Slots;
+use FP_Exp\MeetingPoints\Repository;
 use FP_Exp\Utils\Helpers;
 use FP_Exp\Utils\Theme;
 use WP_Error;
@@ -91,7 +92,7 @@ final class WidgetShortcode extends BaseShortcode
         $tickets = $this->prepare_tickets(get_post_meta($experience_id, '_fp_ticket_types', true));
         $addons = $this->prepare_addons(get_post_meta($experience_id, '_fp_addons', true));
         $highlights = get_post_meta($experience_id, '_fp_highlights', true);
-        $meeting_point = sanitize_text_field((string) get_post_meta($experience_id, '_fp_meeting_point', true));
+        $meeting_point = Repository::get_primary_summary_for_experience($experience_id);
         $duration = absint((string) get_post_meta($experience_id, '_fp_duration_minutes', true));
         $languages = get_post_meta($experience_id, '_fp_languages', true);
 

--- a/src/Utils/Helpers.php
+++ b/src/Utils/Helpers.php
@@ -13,6 +13,9 @@ use function get_post_meta;
 use function get_transient;
 use function in_array;
 use function is_array;
+use function is_bool;
+use function is_numeric;
+use function is_string;
 use function json_decode;
 use function sanitize_text_field;
 use function set_transient;
@@ -160,6 +163,27 @@ final class Helpers
         }
 
         return ! empty($settings['block_capacity']);
+    }
+
+    public static function meeting_points_enabled(): bool
+    {
+        $value = get_option('fp_exp_enable_meeting_points', 'yes');
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_numeric($value)) {
+            return (int) $value > 0;
+        }
+
+        if (is_string($value)) {
+            $normalized = strtolower(trim($value));
+
+            return ! in_array($normalized, ['0', 'no', 'off', 'false', ''], true);
+        }
+
+        return (bool) $value;
     }
 
     /**

--- a/templates/front/meeting-points.php
+++ b/templates/front/meeting-points.php
@@ -1,0 +1,33 @@
+<?php
+/** @var array $primary */
+/** @var array $alternatives */
+/** @var string $scope_class */
+
+if (! isset($primary) || ! is_array($primary)) {
+    return;
+}
+
+$wrapper_classes = trim('fp-exp-meeting-points ' . ($scope_class ?? ''));
+?>
+<section class="<?php echo esc_attr($wrapper_classes); ?>" data-fp-shortcode="meeting-points">
+    <div class="fp-exp-meeting-points__primary">
+        <?php
+        $meeting_point = $primary;
+        include __DIR__ . '/partials/meeting-point.php';
+        ?>
+    </div>
+
+    <?php if (! empty($alternatives)) : ?>
+        <details class="fp-exp-meeting-points__alternatives">
+            <summary><?php esc_html_e('Punti di ritrovo alternativi', 'fp-experiences'); ?></summary>
+            <div class="fp-exp-meeting-points__list">
+                <?php foreach ($alternatives as $alternative) : ?>
+                    <?php
+                    $meeting_point = $alternative;
+                    include __DIR__ . '/partials/meeting-point.php';
+                    ?>
+                <?php endforeach; ?>
+            </div>
+        </details>
+    <?php endif; ?>
+</section>

--- a/templates/front/partials/meeting-point.php
+++ b/templates/front/partials/meeting-point.php
@@ -1,0 +1,49 @@
+<?php
+
+if (! isset($meeting_point) || ! is_array($meeting_point)) {
+    return;
+}
+
+$address = $meeting_point['address'] ?? '';
+$notes = $meeting_point['notes'] ?? '';
+$phone = $meeting_point['phone'] ?? '';
+$email = $meeting_point['email'] ?? '';
+$opening_hours = $meeting_point['opening_hours'] ?? '';
+$lat = isset($meeting_point['lat']) && '' !== $meeting_point['lat'] ? $meeting_point['lat'] : null;
+$lng = isset($meeting_point['lng']) && '' !== $meeting_point['lng'] ? $meeting_point['lng'] : null;
+?>
+<div class="fp-exp-meeting-point" data-fp-meeting-point data-address="<?php echo esc_attr((string) $address); ?>" data-lat="<?php echo esc_attr(null === $lat ? '' : (string) $lat); ?>" data-lng="<?php echo esc_attr(null === $lng ? '' : (string) $lng); ?>">
+    <h3 class="fp-exp-meeting-point__title"><?php echo esc_html((string) ($meeting_point['title'] ?? '')); ?></h3>
+    <?php if ($address) : ?>
+        <p class="fp-exp-meeting-point__address">
+            <span><?php echo esc_html((string) $address); ?></span>
+            <a href="#" class="fp-exp-meeting-point__map-link" data-fp-map-link target="_blank" rel="noopener">
+                <?php esc_html_e('Apri in Maps', 'fp-experiences'); ?>
+            </a>
+        </p>
+    <?php endif; ?>
+
+    <?php if ($opening_hours) : ?>
+        <p class="fp-exp-meeting-point__hours">
+            <strong><?php esc_html_e('Orari', 'fp-experiences'); ?>:</strong>
+            <span><?php echo esc_html((string) $opening_hours); ?></span>
+        </p>
+    <?php endif; ?>
+
+    <?php if ($phone || $email) : ?>
+        <ul class="fp-exp-meeting-point__contacts">
+            <?php if ($phone) : ?>
+                <li><strong><?php esc_html_e('Tel', 'fp-experiences'); ?>:</strong> <a href="tel:<?php echo esc_attr(preg_replace('/\s+/', '', (string) $phone)); ?>"><?php echo esc_html((string) $phone); ?></a></li>
+            <?php endif; ?>
+            <?php if ($email) : ?>
+                <li><strong><?php esc_html_e('Email', 'fp-experiences'); ?>:</strong> <a href="mailto:<?php echo esc_attr((string) $email); ?>"><?php echo esc_html((string) $email); ?></a></li>
+            <?php endif; ?>
+        </ul>
+    <?php endif; ?>
+
+    <?php if ($notes) : ?>
+        <div class="fp-exp-meeting-point__notes"><?php echo wp_kses_post($notes); ?></div>
+    <?php endif; ?>
+
+    <div class="fp-meeting-map" aria-hidden="true"></div>
+</div>


### PR DESCRIPTION
## Summary
- introduce a dedicated meeting point post type with admin meta boxes, CSV importer, and settings toggle
- link experiences to primary/alternative meeting points and expose the data via REST, shortcode, and Elementor widget
- add front-end templates/assets for meeting point rendering and document shortcode usage

## Testing
- find src/MeetingPoints -name '*.php' -exec php -l {} +
- php -l src/Admin/SettingsPage.php


------
https://chatgpt.com/codex/tasks/task_e_68da61817020832f8c93edf5ae7ebbec