### PR TITLE
Add experience detail page shortcode and Elementor layout

### DIFF
--- a/.rebuild-state.json
+++ b/.rebuild-state.json
@@ -44,5 +44,9 @@
       "ok": true,
       "notes": "Documentation & checklist updated"
     }
+  },
+  "rebuild": {
+    "feature": "experience-page",
+    "step": "complete"
   }
 }

--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -622,3 +622,456 @@
         padding: 1.25rem;
     }
 }
+
+.fp-exp-page {
+    position: relative;
+    display: block;
+    --fp-exp-spacing: clamp(1.5rem, 4vw, 3rem);
+}
+
+.fp-exp-page__layout {
+    display: flex;
+    flex-direction: column;
+    gap: var(--fp-exp-spacing);
+}
+
+.fp-exp-page__main {
+    display: flex;
+    flex-direction: column;
+    gap: var(--fp-exp-spacing);
+}
+
+.fp-exp-page__hero {
+    display: grid;
+    gap: clamp(1.5rem, 4vw, 2.5rem);
+    background: var(--fp-exp-color-surface, #f7f4f0);
+    padding: clamp(1.5rem, 4vw, 2.75rem);
+    border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
+    box-shadow: var(--fp-exp-shadow-base, 0 14px 40px rgba(0,0,0,0.08));
+}
+
+.fp-exp-page__hero-media {
+    position: relative;
+    border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
+    overflow: hidden;
+    min-height: 220px;
+    background: linear-gradient(135deg, var(--fp-exp-color-primary, #8B1E3F), var(--fp-exp-color-accent, #5B8C5A));
+}
+
+.fp-exp-gallery {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.75rem;
+    width: 100%;
+    height: 100%;
+}
+
+.fp-exp-gallery__item {
+    margin: 0;
+    position: relative;
+    border-radius: var(--fp-exp-radius-base, 12px);
+    overflow: hidden;
+    background: rgba(0, 0, 0, 0.08);
+}
+
+.fp-exp-gallery__item img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.fp-exp-gallery--placeholder {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    min-height: 220px;
+}
+
+.fp-exp-gallery--placeholder span {
+    position: absolute;
+    inset: 0;
+    background: repeating-linear-gradient(
+        135deg,
+        rgba(255, 255, 255, 0.1) 0,
+        rgba(255, 255, 255, 0.1) 12px,
+        rgba(255, 255, 255, 0.2) 12px,
+        rgba(255, 255, 255, 0.2) 24px
+    );
+}
+
+.fp-exp-page__hero-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.fp-exp-page__eyebrow {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--fp-exp-color-muted, #666666);
+}
+
+.fp-exp-page__title {
+    margin: 0;
+    font-size: clamp(2rem, 5vw, 3.25rem);
+    line-height: 1.05;
+    color: var(--fp-exp-color-text, #1F1F1F);
+}
+
+.fp-exp-page__badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+.fp-exp-page__badge-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(0, 0, 0, 0.05);
+    color: var(--fp-exp-color-text, #1F1F1F);
+    padding: 0.45rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.875rem;
+}
+
+.fp-exp-icon {
+    display: inline-flex;
+    width: 1.25rem;
+    height: 1.25rem;
+    align-items: center;
+    justify-content: center;
+    color: var(--fp-exp-color-primary, #8B1E3F);
+}
+
+.fp-exp-page__summary {
+    margin: 0;
+    font-size: 1.125rem;
+    line-height: 1.6;
+    color: var(--fp-exp-color-text, #1F1F1F);
+}
+
+.fp-exp-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.85rem 1.75rem;
+    border-radius: var(--fp-exp-radius-base, 12px);
+    background: var(--fp-exp-color-primary, #8B1E3F);
+    color: #fff;
+    font-weight: 600;
+    border: none;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.fp-exp-button:hover,
+.fp-exp-button:focus {
+    background: var(--fp-exp-color-secondary, #405F3B);
+    transform: translateY(-1px);
+}
+
+.fp-exp-page__nav {
+    display: block;
+    background: var(--fp-exp-color-surface, #f7f4f0);
+    padding: 0.5rem;
+    border-radius: var(--fp-exp-radius-base, 12px);
+    overflow-x: auto;
+}
+
+.fp-exp-page__nav-list {
+    display: flex;
+    gap: 0.5rem;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+.fp-exp-page__nav-button {
+    border: none;
+    background: transparent;
+    color: var(--fp-exp-color-text, #1F1F1F);
+    padding: 0.6rem 1.2rem;
+    border-radius: 999px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.fp-exp-page__nav-button:hover,
+.fp-exp-page__nav-button:focus {
+    background: rgba(0, 0, 0, 0.08);
+}
+
+.fp-exp-section {
+    background: #fff;
+    border-radius: var(--fp-exp-radius-base, 12px);
+    padding: clamp(1.5rem, 4vw, 2.5rem);
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.06);
+}
+
+.fp-exp-section__title {
+    margin: 0 0 1rem;
+    font-size: clamp(1.5rem, 3vw, 2rem);
+    color: var(--fp-exp-color-text, #1F1F1F);
+}
+
+.fp-exp-section__subtitle {
+    margin: 0;
+    color: var(--fp-exp-color-muted, #666666);
+}
+
+.fp-exp-columns {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.fp-exp-columns--stack {
+    gap: clamp(1rem, 3vw, 2rem);
+}
+
+.fp-exp-column__title {
+    margin: 0 0 0.75rem;
+    font-size: 1.125rem;
+    color: var(--fp-exp-color-text, #1F1F1F);
+}
+
+.fp-exp-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.65rem;
+}
+
+.fp-exp-list__item {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    line-height: 1.5;
+}
+
+.fp-exp-icon--check,
+.fp-exp-icon--cross {
+    width: 1rem;
+    height: 1rem;
+    margin-top: 0.25rem;
+}
+
+.fp-exp-icon--check {
+    color: var(--fp-exp-color-success, #1B998B);
+}
+
+.fp-exp-icon--cross {
+    color: var(--fp-exp-color-danger, #C44536);
+}
+
+.fp-exp-paragraph {
+    margin: 0;
+    line-height: 1.6;
+}
+
+.fp-exp-richtext {
+    line-height: 1.6;
+}
+
+.fp-exp-accordion {
+    border-radius: var(--fp-exp-radius-base, 12px);
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    overflow: hidden;
+}
+
+.fp-exp-accordion__item + .fp-exp-accordion__item {
+    border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.fp-exp-accordion__heading {
+    margin: 0;
+}
+
+.fp-exp-accordion__trigger {
+    width: 100%;
+    background: #fff;
+    border: none;
+    padding: 1rem 1.25rem;
+    font-size: 1rem;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    cursor: pointer;
+}
+
+.fp-exp-accordion__trigger:focus {
+    outline: 2px solid var(--fp-exp-color-primary, #8B1E3F);
+    outline-offset: 2px;
+}
+
+.fp-exp-accordion__icon {
+    width: 1.25rem;
+    height: 1.25rem;
+    transition: transform 0.2s ease;
+}
+
+.fp-exp-accordion__trigger[aria-expanded="true"] .fp-exp-accordion__icon {
+    transform: rotate(45deg);
+}
+
+.fp-exp-accordion__panel {
+    padding: 0 1.25rem 1.25rem;
+}
+
+.fp-exp-accordion__content {
+    line-height: 1.6;
+    color: var(--fp-exp-color-text, #1F1F1F);
+}
+
+.fp-exp-reviews {
+    display: grid;
+    gap: 1.5rem;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+.fp-exp-review {
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    border-radius: var(--fp-exp-radius-base, 12px);
+    padding: 1.25rem;
+    background: #fff;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.05);
+}
+
+.fp-exp-review__header {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: baseline;
+    margin-bottom: 0.75rem;
+}
+
+.fp-exp-review__author {
+    font-size: 1rem;
+    color: var(--fp-exp-color-text, #1F1F1F);
+}
+
+.fp-exp-review__rating {
+    font-weight: 600;
+    color: var(--fp-exp-color-accent, #5B8C5A);
+}
+
+.fp-exp-review__date {
+    color: var(--fp-exp-color-muted, #666666);
+    font-size: 0.875rem;
+}
+
+.fp-exp-review__content {
+    margin: 0;
+    line-height: 1.6;
+}
+
+.fp-exp-page__aside {
+    position: relative;
+}
+
+.fp-exp-page__widget {
+    position: relative;
+}
+
+.fp-exp-page__sticky-bar {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 0.75rem clamp(1rem, 5vw, 2rem);
+    background: rgba(255, 255, 255, 0.95);
+    box-shadow: 0 -12px 30px rgba(0, 0, 0, 0.12);
+    display: flex;
+    justify-content: center;
+    z-index: 999;
+    opacity: 1;
+    transform: translateY(0);
+    transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.fp-exp-page__sticky-button {
+    width: min(540px, 100%);
+    border: none;
+    border-radius: var(--fp-exp-radius-base, 12px);
+    background: var(--fp-exp-color-primary, #8B1E3F);
+    color: #fff;
+    font-weight: 600;
+    padding: 0.85rem 1.5rem;
+    cursor: pointer;
+}
+
+.fp-exp-page__sticky-button:hover,
+.fp-exp-page__sticky-button:focus {
+    background: var(--fp-exp-color-secondary, #405F3B);
+}
+
+.fp-exp-page__sticky-bar.is-hidden {
+    opacity: 0;
+    transform: translateY(100%);
+    pointer-events: none;
+}
+
+@media (min-width: 768px) {
+    .fp-exp-gallery {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        grid-auto-rows: 140px;
+    }
+
+    .fp-exp-gallery__item:nth-child(1) {
+        grid-column: span 2;
+        grid-row: span 2;
+    }
+}
+
+@media (min-width: 1024px) {
+    .fp-exp-page__layout {
+        flex-direction: row;
+        align-items: flex-start;
+    }
+
+    .fp-exp-page__main {
+        flex: 1 1 auto;
+    }
+
+    .fp-exp-page__aside {
+        flex: 0 0 360px;
+        position: sticky;
+        top: 2rem;
+        max-height: calc(100vh - 4rem);
+    }
+
+    .fp-exp-page__hero {
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+    }
+
+    .fp-exp-columns {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .fp-exp-columns--stack {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .fp-exp-page__sticky-bar {
+        display: none;
+    }
+}
+
+@media (min-width: 1280px) {
+    .fp-exp-page__hero {
+        grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+    }
+}
+

--- a/readme.txt
+++ b/readme.txt
@@ -34,10 +34,13 @@ FP Experiences brings GetYourGuide-style booking flows to WooCommerce without to
 * `[fp_exp_calendar id="123" months="2"]` – Inline availability calendar for a single experience.
 * `[fp_exp_checkout]` – Isolated checkout that finalises the FP Experiences cart only.
 * `[fp_exp_meeting_points id="123"]` – Outputs the primary meeting point and optional alternatives for an experience, with map links built client-side.
+* `[fp_exp_page id="123" sections="hero,highlights,inclusions,meeting,extras,faq,reviews" sticky_widget="1"]` – Full experience detail page with hero gallery, highlights, inclusions/exclusions, meeting point block, FAQ accordion, reviews, and sticky availability widget. Supports the usual theming overrides (`preset`, `mode`, color variables, `radius`, `shadow`, `font`).
+
+The `sections` attribute accepts a comma-separated list of sections to render (hero, highlights, inclusions, meeting, extras, faq, reviews). Meeting point data automatically reuses the Meeting Points module when enabled; otherwise the section is hidden. Set `sticky_widget="0"` to disable the mobile CTA bar.
 
 == Elementor Widgets ==
 
-Five Elementor widgets mirror the shortcodes: List, Widget, Calendar, Checkout, and Meeting Points. Each exposes theming controls (colors, radius, fonts) plus behavioural toggles (sticky mode, inline calendar, consent defaults).
+Six Elementor widgets mirror the shortcodes: List, Widget, Calendar, Checkout, Meeting Points, and the new Experience Page layout. Each exposes theming controls (colors, radius, fonts) plus behavioural toggles (sticky mode, inline calendar, consent defaults). The Experience Page widget lets editors pick sections to display and toggle the sticky availability bar while reusing the `[fp_exp_page]` shortcode under the hood.
 
 == Settings & Tools ==
 

--- a/src/Elementor/WidgetExperiencePage.php
+++ b/src/Elementor/WidgetExperiencePage.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP_Exp\Elementor;
+
+use Elementor\Controls_Manager;
+use Elementor\Widget_Base;
+
+use function array_filter;
+use function array_map;
+use function do_shortcode;
+use function esc_attr;
+use function esc_html__;
+use function implode;
+use function is_array;
+
+final class WidgetExperiencePage extends Widget_Base
+{
+    public function get_name(): string
+    {
+        return 'fp-exp-page';
+    }
+
+    public function get_title(): string
+    {
+        return esc_html__('FP Experience Page', 'fp-experiences');
+    }
+
+    public function get_icon(): string
+    {
+        return 'eicon-single-post';
+    }
+
+    public function get_categories(): array
+    {
+        return ['fp-exp'];
+    }
+
+    public function get_keywords(): array
+    {
+        return ['experience', 'page', 'detail'];
+    }
+
+    protected function register_controls(): void
+    {
+        $this->start_controls_section(
+            'section_content',
+            [
+                'label' => esc_html__('Content', 'fp-experiences'),
+            ]
+        );
+
+        $this->add_control(
+            'experience_id',
+            [
+                'label' => esc_html__('Experience ID', 'fp-experiences'),
+                'type' => Controls_Manager::NUMBER,
+                'min' => 1,
+                'default' => 0,
+            ]
+        );
+
+        $this->add_control(
+            'sections',
+            [
+                'label' => esc_html__('Sections', 'fp-experiences'),
+                'type' => Controls_Manager::SELECT2,
+                'multiple' => true,
+                'default' => ['hero', 'highlights', 'inclusions', 'meeting', 'extras', 'faq', 'reviews'],
+                'options' => [
+                    'hero' => esc_html__('Hero', 'fp-experiences'),
+                    'highlights' => esc_html__('Highlights', 'fp-experiences'),
+                    'inclusions' => esc_html__('Inclusions/Exclusions', 'fp-experiences'),
+                    'meeting' => esc_html__('Meeting point', 'fp-experiences'),
+                    'extras' => esc_html__('Extras & Policy', 'fp-experiences'),
+                    'faq' => esc_html__('FAQ', 'fp-experiences'),
+                    'reviews' => esc_html__('Reviews', 'fp-experiences'),
+                ],
+            ]
+        );
+
+        $this->add_control(
+            'sticky_widget',
+            [
+                'label' => esc_html__('Sticky availability button', 'fp-experiences'),
+                'type' => Controls_Manager::SWITCHER,
+                'label_on' => esc_html__('Enabled', 'fp-experiences'),
+                'label_off' => esc_html__('Disabled', 'fp-experiences'),
+                'return_value' => 'yes',
+                'default' => 'yes',
+            ]
+        );
+
+        $this->end_controls_section();
+
+        $this->start_controls_section(
+            'section_theme',
+            [
+                'label' => esc_html__('Theme', 'fp-experiences'),
+                'tab' => Controls_Manager::TAB_STYLE,
+            ]
+        );
+
+        $this->add_theme_controls();
+
+        $this->end_controls_section();
+    }
+
+    protected function render(): void
+    {
+        $settings = $this->get_settings_for_display();
+        $sections = $settings['sections'] ?? [];
+        if (is_array($sections)) {
+            $sections = implode(',', array_filter(array_map('strval', $sections)));
+        }
+
+        $atts = [
+            'id' => (string) ($settings['experience_id'] ?? ''),
+            'sections' => $sections ?: 'hero,highlights,inclusions,meeting,extras,faq,reviews',
+            'sticky_widget' => ('yes' === ($settings['sticky_widget'] ?? 'yes')) ? '1' : '0',
+        ];
+
+        $atts = array_merge($atts, $this->collect_theme_atts($settings));
+
+        echo do_shortcode('[fp_exp_page ' . $this->build_shortcode_atts($atts) . ']');
+    }
+
+    private function add_theme_controls(): void
+    {
+        $this->add_control(
+            'preset',
+            [
+                'label' => esc_html__('Preset', 'fp-experiences'),
+                'type' => Controls_Manager::SELECT,
+                'options' => [
+                    '' => esc_html__('Default', 'fp-experiences'),
+                    'light' => esc_html__('Light', 'fp-experiences'),
+                    'dark' => esc_html__('Dark', 'fp-experiences'),
+                    'natural' => esc_html__('Natural (green)', 'fp-experiences'),
+                    'wine' => esc_html__('Wine / Burgundy', 'fp-experiences'),
+                ],
+            ]
+        );
+
+        $this->add_control(
+            'mode',
+            [
+                'label' => esc_html__('Color mode', 'fp-experiences'),
+                'type' => Controls_Manager::SELECT,
+                'options' => [
+                    '' => esc_html__('Inherit', 'fp-experiences'),
+                    'light' => esc_html__('Light', 'fp-experiences'),
+                    'dark' => esc_html__('Dark (.fp-theme-dark)', 'fp-experiences'),
+                    'auto' => esc_html__('Automatic (prefers-color-scheme)', 'fp-experiences'),
+                ],
+            ]
+        );
+
+        $color_labels = [
+            'primary' => esc_html__('Primary', 'fp-experiences'),
+            'secondary' => esc_html__('Secondary', 'fp-experiences'),
+            'accent' => esc_html__('Accent', 'fp-experiences'),
+            'background' => esc_html__('Background', 'fp-experiences'),
+            'surface' => esc_html__('Surface', 'fp-experiences'),
+            'text' => esc_html__('Text', 'fp-experiences'),
+            'muted' => esc_html__('Muted', 'fp-experiences'),
+            'success' => esc_html__('Success', 'fp-experiences'),
+            'warning' => esc_html__('Warning', 'fp-experiences'),
+            'danger' => esc_html__('Danger', 'fp-experiences'),
+        ];
+
+        foreach ($color_labels as $key => $label) {
+            $this->add_control(
+                $key,
+                [
+                    'label' => $label,
+                    'type' => Controls_Manager::COLOR,
+                ]
+            );
+        }
+
+        $this->add_control(
+            'radius',
+            [
+                'label' => esc_html__('Border radius', 'fp-experiences'),
+                'type' => Controls_Manager::TEXT,
+                'placeholder' => '16px',
+            ]
+        );
+
+        $this->add_control(
+            'shadow',
+            [
+                'label' => esc_html__('Shadow', 'fp-experiences'),
+                'type' => Controls_Manager::TEXT,
+                'placeholder' => '0 14px 40px rgba(0,0,0,0.08)',
+            ]
+        );
+
+        $this->add_control(
+            'font',
+            [
+                'label' => esc_html__('Font family', 'fp-experiences'),
+                'type' => Controls_Manager::TEXT,
+                'placeholder' => '"Red Hat Display", sans-serif',
+            ]
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $settings
+     *
+     * @return array<string, string>
+     */
+    private function collect_theme_atts(array $settings): array
+    {
+        $keys = ['preset', 'mode', 'primary', 'secondary', 'accent', 'background', 'surface', 'text', 'muted', 'success', 'warning', 'danger', 'radius', 'shadow', 'font'];
+        $atts = [];
+
+        foreach ($keys as $key) {
+            if (! empty($settings[$key])) {
+                $atts[$key] = (string) $settings[$key];
+            }
+        }
+
+        return $atts;
+    }
+
+    /**
+     * @param array<string, string> $atts
+     */
+    private function build_shortcode_atts(array $atts): string
+    {
+        $parts = [];
+        foreach ($atts as $key => $value) {
+            if ('' === $value) {
+                continue;
+            }
+
+            $parts[] = $key . '="' . esc_attr($value) . '"';
+        }
+
+        return implode(' ', $parts);
+    }
+}

--- a/src/Elementor/WidgetsRegistrar.php
+++ b/src/Elementor/WidgetsRegistrar.php
@@ -35,6 +35,7 @@ final class WidgetsRegistrar
         $widgets_manager->register(new WidgetWidget());
         $widgets_manager->register(new WidgetCalendar());
         $widgets_manager->register(new WidgetCheckout());
+        $widgets_manager->register(new WidgetExperiencePage());
 
         if (Helpers::meeting_points_enabled()) {
             $widgets_manager->register(new WidgetMeetingPoints());

--- a/src/Shortcodes/Registrar.php
+++ b/src/Shortcodes/Registrar.php
@@ -20,6 +20,7 @@ final class Registrar
             new WidgetShortcode(),
             new CalendarShortcode(),
             new CheckoutShortcode(),
+            new ExperienceShortcode(),
         ];
 
         if (Helpers::meeting_points_enabled()) {

--- a/src/Shortcodes/WidgetShortcode.php
+++ b/src/Shortcodes/WidgetShortcode.php
@@ -16,6 +16,7 @@ use WP_Error;
 use WP_Post;
 
 use function absint;
+use function apply_filters;
 use function array_filter;
 use function esc_html__;
 use function get_locale;
@@ -46,6 +47,7 @@ final class WidgetShortcode extends BaseShortcode
         'id' => '',
         'sticky' => '0',
         'show_calendar' => '1',
+        'display_context' => '',
         'preset' => '',
         'mode' => '',
         'primary' => '',
@@ -98,6 +100,8 @@ final class WidgetShortcode extends BaseShortcode
 
         $slots = $this->get_upcoming_slots($experience_id, $tickets, 60);
         $calendar = $this->group_slots_by_day($slots);
+
+        $display_context = apply_filters('fp_exp_widget_display_context', (string) $attributes['display_context'], $experience_id, $attributes);
 
         $theme = Theme::resolve_palette([
             'preset' => (string) $attributes['preset'],
@@ -186,6 +190,7 @@ final class WidgetShortcode extends BaseShortcode
             'schema_json' => $schema,
             'locale' => get_locale(),
             'rtb_settings' => $rtb_settings,
+            'display_context' => $display_context,
         ];
     }
 

--- a/templates/front/experience.php
+++ b/templates/front/experience.php
@@ -1,0 +1,333 @@
+<?php
+/**
+ * Experience detail template.
+ *
+ * @var array<string, mixed> $experience
+ * @var array<int, array<string, string>> $gallery
+ * @var array<int, array<string, string>> $badges
+ * @var array<int, string> $highlights
+ * @var array<int, string> $inclusions
+ * @var array<int, string> $exclusions
+ * @var array<int, string> $what_to_bring
+ * @var array<int, string>|string $notes
+ * @var string $policy
+ * @var array<int, array<string, string>> $faq
+ * @var array<int, array<string, mixed>> $reviews
+ * @var array<string, bool> $sections
+ * @var array<int, array<string, string>> $navigation
+ * @var array{primary: ?array<string, mixed>, alternatives: array<int, array<string, mixed>>} $meeting_points
+ * @var bool $sticky_widget
+ * @var string $widget_html
+ * @var string $schema_json
+ * @var string $data_layer
+ * @var string $scope_class
+ */
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+$scope_class = $scope_class ?? '';
+$container_classes = trim('fp-exp fp-exp-page ' . $scope_class);
+
+$navigation = isset($navigation) && is_array($navigation) ? $navigation : [];
+$has_navigation = ! empty($navigation);
+$has_highlights = ! empty($highlights);
+$has_inclusions = ! empty($inclusions) || ! empty($exclusions);
+$has_meeting = isset($meeting_points['primary']) && is_array($meeting_points['primary']);
+$has_extras = ! empty($what_to_bring) || ! empty($notes) || ! empty($policy);
+$has_faq = ! empty($faq);
+$has_reviews = ! empty($reviews);
+
+$cta_label = esc_html__('Controlla disponibilità', 'fp-experiences');
+
+?>
+<section class="<?php echo esc_attr($container_classes); ?>" data-fp-shortcode="experience">
+    <?php if (! empty($data_layer)) : ?>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            window.dataLayer.push(<?php echo wp_kses_post($data_layer); ?>);
+        </script>
+    <?php endif; ?>
+
+    <div class="fp-exp-page__layout" data-fp-page>
+        <main class="fp-exp-page__main">
+            <?php if (! empty($sections['hero'])) : ?>
+                <header class="fp-exp-page__hero" id="fp-exp-section-hero" data-fp-section="hero">
+                    <div class="fp-exp-page__hero-media" aria-hidden="<?php echo empty($gallery) ? 'true' : 'false'; ?>">
+                        <?php if (! empty($gallery)) : ?>
+                            <div class="fp-exp-gallery" data-fp-gallery>
+                                <?php foreach ($gallery as $index => $image) : ?>
+                                    <figure class="fp-exp-gallery__item" data-index="<?php echo esc_attr((string) $index); ?>">
+                                        <img
+                                            src="<?php echo esc_url($image['url']); ?>"
+                                            <?php if (! empty($image['srcset'])) : ?>srcset="<?php echo esc_attr($image['srcset']); ?>"<?php endif; ?>
+                                            <?php if (! empty($image['width'])) : ?>width="<?php echo esc_attr((string) $image['width']); ?>"<?php endif; ?>
+                                            <?php if (! empty($image['height'])) : ?>height="<?php echo esc_attr((string) $image['height']); ?>"<?php endif; ?>
+                                            alt="<?php echo esc_attr($experience['title']); ?>"
+                                            loading="lazy"
+                                        />
+                                    </figure>
+                                <?php endforeach; ?>
+                            </div>
+                        <?php else : ?>
+                            <div class="fp-exp-gallery fp-exp-gallery--placeholder">
+                                <span aria-hidden="true"></span>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                    <div class="fp-exp-page__hero-body">
+                        <div class="fp-exp-page__eyebrow">
+                            <span class="fp-exp-page__badge">FP Experiences</span>
+                        </div>
+                        <h1 class="fp-exp-page__title"><?php echo esc_html($experience['title']); ?></h1>
+                        <?php if (! empty($badges)) : ?>
+                            <ul class="fp-exp-page__badges" role="list">
+                                <?php foreach ($badges as $badge) : ?>
+                                    <li class="fp-exp-page__badge-item">
+                                        <span class="fp-exp-icon fp-exp-icon--<?php echo esc_attr($badge['icon']); ?>" aria-hidden="true">
+                                            <?php if ('clock' === $badge['icon']) : ?>
+                                                <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm1 10.59 2.12 2.12-1.41 1.41-2.83-2.83V7h2.12Z"/></svg>
+                                            <?php elseif ('language' === $badge['icon']) : ?>
+                                                <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M3 5h18v2H3Zm10 4h8v2h-5.18a7.87 7.87 0 0 1-1.35 3.24l3.14 3.14-1.41 1.41-3.48-3.48A9.85 9.85 0 0 1 10 19.93V22H8v-2.07A9.94 9.94 0 0 1 2 12h2a8 8 0 0 0 4 6.92A7.87 7.87 0 0 0 9.18 11H4V9h6V7h2v2h1Z"/></svg>
+                                            <?php else : ?>
+                                                <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M12 12.88 9.17 10H5a3 3 0 0 0-3 3v7h6v-4h2v4h6v-7a3 3 0 0 0-3-3h-1.17Zm9-2.88a4 4 0 1 0-4-4 4 4 0 0 0 4 4Z"/></svg>
+                                            <?php endif; ?>
+                                        </span>
+                                        <span class="fp-exp-page__badge-label"><?php echo esc_html($badge['label']); ?></span>
+                                    </li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?>
+                        <?php if (! empty($experience['summary'])) : ?>
+                            <p class="fp-exp-page__summary"><?php echo esc_html($experience['summary']); ?></p>
+                        <?php endif; ?>
+                        <div class="fp-exp-page__hero-cta">
+                            <a
+                                href="#fp-exp-widget"
+                                class="fp-exp-button"
+                                data-fp-scroll="widget"
+                                data-fp-cta="hero"
+                            >
+                                <?php echo $cta_label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                            </a>
+                        </div>
+                    </div>
+                </header>
+            <?php endif; ?>
+
+            <?php if ($has_navigation) : ?>
+                <nav class="fp-exp-page__nav" aria-label="<?php esc_attr_e('Experience sections', 'fp-experiences'); ?>">
+                    <ul class="fp-exp-page__nav-list">
+                        <?php foreach ($navigation as $item) : ?>
+                            <li class="fp-exp-page__nav-item">
+                                <button
+                                    type="button"
+                                    class="fp-exp-page__nav-button"
+                                    data-fp-scroll="<?php echo esc_attr($item['id']); ?>"
+                                >
+                                    <?php echo esc_html($item['label']); ?>
+                                </button>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                </nav>
+            <?php endif; ?>
+
+            <?php if (! empty($sections['highlights']) && $has_highlights) : ?>
+                <section class="fp-exp-section" id="fp-exp-section-highlights" data-fp-section="highlights">
+                    <h2 class="fp-exp-section__title"><?php esc_html_e('Highlights', 'fp-experiences'); ?></h2>
+                    <ul class="fp-exp-list" role="list">
+                        <?php foreach ($highlights as $highlight) : ?>
+                            <li class="fp-exp-list__item"><?php echo esc_html($highlight); ?></li>
+                        <?php endforeach; ?>
+                    </ul>
+                </section>
+            <?php endif; ?>
+
+            <?php if (! empty($sections['inclusions']) && $has_inclusions) : ?>
+                <section class="fp-exp-section" id="fp-exp-section-inclusions" data-fp-section="inclusions">
+                    <div class="fp-exp-section__header">
+                        <h2 class="fp-exp-section__title"><?php esc_html_e('What\'s included', 'fp-experiences'); ?></h2>
+                        <?php if (! empty($exclusions)) : ?>
+                            <p class="fp-exp-section__subtitle"><?php esc_html_e('and what\'s not', 'fp-experiences'); ?></p>
+                        <?php endif; ?>
+                    </div>
+                    <div class="fp-exp-columns">
+                        <?php if (! empty($inclusions)) : ?>
+                            <div class="fp-exp-column">
+                                <h3 class="fp-exp-column__title"><?php esc_html_e('Included', 'fp-experiences'); ?></h3>
+                                <ul class="fp-exp-list" role="list">
+                                    <?php foreach ($inclusions as $item) : ?>
+                                        <li class="fp-exp-list__item">
+                                            <span class="fp-exp-icon fp-exp-icon--check" aria-hidden="true">
+                                                <svg viewBox="0 0 24 24"><path fill="currentColor" d="M9.75 18.25 3.5 12l1.41-1.41 4.84 4.84 9.34-9.34L20.5 7.5Z"/></svg>
+                                            </span>
+                                            <span><?php echo esc_html($item); ?></span>
+                                        </li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            </div>
+                        <?php endif; ?>
+                        <?php if (! empty($exclusions)) : ?>
+                            <div class="fp-exp-column">
+                                <h3 class="fp-exp-column__title"><?php esc_html_e('Not included', 'fp-experiences'); ?></h3>
+                                <ul class="fp-exp-list" role="list">
+                                    <?php foreach ($exclusions as $item) : ?>
+                                        <li class="fp-exp-list__item">
+                                            <span class="fp-exp-icon fp-exp-icon--cross" aria-hidden="true">
+                                                <svg viewBox="0 0 24 24"><path fill="currentColor" d="m18.3 5.71 1.42 1.42-5.3 5.29 5.3 5.29-1.42 1.42-5.29-5.3-5.29 5.3-1.42-1.42 5.3-5.29-5.3-5.29 1.42-1.42 5.29 5.3Z"/></svg>
+                                            </span>
+                                            <span><?php echo esc_html($item); ?></span>
+                                        </li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                </section>
+            <?php endif; ?>
+
+            <?php if (! empty($sections['meeting']) && $has_meeting) : ?>
+                <section class="fp-exp-section" id="fp-exp-section-meeting" data-fp-section="meeting">
+                    <h2 class="fp-exp-section__title"><?php esc_html_e('Meeting point', 'fp-experiences'); ?></h2>
+                    <?php
+                    $primary = $meeting_points['primary'];
+                    $alternatives = $meeting_points['alternatives'];
+                    include __DIR__ . '/meeting-points.php';
+                    ?>
+                </section>
+            <?php endif; ?>
+
+            <?php if (! empty($sections['extras']) && $has_extras) : ?>
+                <section class="fp-exp-section" id="fp-exp-section-extras" data-fp-section="extras">
+                    <h2 class="fp-exp-section__title"><?php esc_html_e('Good to know', 'fp-experiences'); ?></h2>
+                    <div class="fp-exp-columns fp-exp-columns--stack">
+                        <?php if (! empty($what_to_bring)) : ?>
+                            <div class="fp-exp-column">
+                                <h3 class="fp-exp-column__title"><?php esc_html_e('What to bring', 'fp-experiences'); ?></h3>
+                                <ul class="fp-exp-list" role="list">
+                                    <?php foreach ($what_to_bring as $item) : ?>
+                                        <li class="fp-exp-list__item"><?php echo esc_html($item); ?></li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            </div>
+                        <?php endif; ?>
+
+                        <?php if (! empty($notes)) : ?>
+                            <div class="fp-exp-column">
+                                <h3 class="fp-exp-column__title"><?php esc_html_e('Notes', 'fp-experiences'); ?></h3>
+                                <?php if (is_array($notes)) : ?>
+                                    <ul class="fp-exp-list" role="list">
+                                        <?php foreach ($notes as $note) : ?>
+                                            <li class="fp-exp-list__item"><?php echo esc_html($note); ?></li>
+                                        <?php endforeach; ?>
+                                    </ul>
+                                <?php else : ?>
+                                    <p class="fp-exp-paragraph"><?php echo esc_html($notes); ?></p>
+                                <?php endif; ?>
+                            </div>
+                        <?php endif; ?>
+
+                        <?php if (! empty($policy)) : ?>
+                            <div class="fp-exp-column">
+                                <h3 class="fp-exp-column__title"><?php esc_html_e('Cancellation policy', 'fp-experiences'); ?></h3>
+                                <div class="fp-exp-richtext"><?php echo wp_kses_post($policy); ?></div>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                </section>
+            <?php endif; ?>
+
+            <?php if (! empty($sections['faq']) && $has_faq) : ?>
+                <section class="fp-exp-section" id="fp-exp-section-faq" data-fp-section="faq">
+                    <h2 class="fp-exp-section__title"><?php esc_html_e('Frequently asked questions', 'fp-experiences'); ?></h2>
+                    <div class="fp-exp-accordion" data-fp-accordion>
+                        <?php foreach ($faq as $index => $item) :
+                            $button_id = $scope_class . '-faq-' . $index;
+                            $panel_id = $scope_class . '-faq-panel-' . $index;
+                            ?>
+                            <div class="fp-exp-accordion__item">
+                                <h3 class="fp-exp-accordion__heading">
+                                    <button
+                                        type="button"
+                                        class="fp-exp-accordion__trigger"
+                                        id="<?php echo esc_attr($button_id); ?>"
+                                        aria-expanded="false"
+                                        aria-controls="<?php echo esc_attr($panel_id); ?>"
+                                        data-fp-accordion-trigger
+                                    >
+                                        <span class="fp-exp-accordion__label"><?php echo esc_html($item['question']); ?></span>
+                                        <span class="fp-exp-accordion__icon" aria-hidden="true">
+                                            <svg viewBox="0 0 24 24"><path fill="currentColor" d="M12 5v14m-7-7h14"/></svg>
+                                        </span>
+                                    </button>
+                                </h3>
+                                <div
+                                    class="fp-exp-accordion__panel"
+                                    id="<?php echo esc_attr($panel_id); ?>"
+                                    role="region"
+                                    aria-labelledby="<?php echo esc_attr($button_id); ?>"
+                                    hidden
+                                >
+                                    <div class="fp-exp-accordion__content"><?php echo wp_kses_post($item['answer']); ?></div>
+                                </div>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                </section>
+            <?php endif; ?>
+
+            <?php if (! empty($sections['reviews']) && $has_reviews) : ?>
+                <section class="fp-exp-section" id="fp-exp-section-reviews" data-fp-section="reviews">
+                    <h2 class="fp-exp-section__title"><?php esc_html_e('Traveler reviews', 'fp-experiences'); ?></h2>
+                    <ul class="fp-exp-reviews" role="list">
+                        <?php foreach ($reviews as $review) : ?>
+                            <li class="fp-exp-review" data-fp-review>
+                                <header class="fp-exp-review__header">
+                                    <strong class="fp-exp-review__author"><?php echo esc_html($review['author'] ?? ''); ?></strong>
+                                    <?php if (! empty($review['rating'])) : ?>
+                                        <span class="fp-exp-review__rating" aria-label="<?php echo esc_attr(sprintf(esc_html__('%s out of 5', 'fp-experiences'), number_format_i18n((float) $review['rating'], 1))); ?>">
+                                            <?php echo esc_html(number_format_i18n((float) $review['rating'], 1)); ?> ★
+                                        </span>
+                                    <?php endif; ?>
+                                    <?php if (! empty($review['date'])) : ?>
+                                        <?php
+                                        $timestamp = strtotime((string) $review['date']);
+                                        if ($timestamp) :
+                                            ?>
+                                            <time class="fp-exp-review__date" datetime="<?php echo esc_attr(gmdate('Y-m-d', $timestamp)); ?>">
+                                                <?php echo esc_html(date_i18n(get_option('date_format', 'F j, Y'), $timestamp)); ?>
+                                            </time>
+                                        <?php endif; ?>
+                                    <?php endif; ?>
+                                </header>
+                                <div class="fp-exp-review__content"><?php echo wp_kses_post($review['content'] ?? ''); ?></div>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                </section>
+            <?php endif; ?>
+
+            <?php if (! empty($schema_json)) : ?>
+                <script type="application/ld+json" class="fp-exp-schema">
+                    <?php echo wp_kses_post($schema_json); ?>
+                </script>
+            <?php endif; ?>
+        </main>
+
+        <aside class="fp-exp-page__aside" data-fp-sticky-container>
+            <div class="fp-exp-page__widget" id="fp-exp-widget">
+                <?php echo $widget_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            </div>
+        </aside>
+    </div>
+
+    <?php if ($sticky_widget) : ?>
+        <div class="fp-exp-page__sticky-bar" data-fp-sticky-bar>
+            <button type="button" class="fp-exp-page__sticky-button" data-fp-scroll="widget" data-fp-cta="sticky">
+                <?php echo $cta_label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            </button>
+        </div>
+    <?php endif; ?>
+</section>

--- a/templates/front/widget.php
+++ b/templates/front/widget.php
@@ -12,6 +12,7 @@
  * @var string $rtb_nonce
  * @var string $scope_class
  * @var string $schema_json
+ * @var string $display_context
  */
 
 if (! defined('ABSPATH')) {
@@ -22,6 +23,8 @@ if (! defined('ABSPATH')) {
 $dialog_id = $scope_class . '-dialog';
 $marketing_id = $scope_class . '-consent-marketing';
 $privacy_id = $scope_class . '-consent-privacy';
+
+$display_context = isset($display_context) ? (string) $display_context : '';
 
 $dataset = [
     'experienceId' => $experience['id'],
@@ -34,6 +37,7 @@ $dataset = [
     'behavior' => $behavior,
     'rtb' => $rtb,
     'nonce' => $rtb_nonce,
+    'displayContext' => $display_context,
 ];
 
 $container_class = 'fp-exp fp-exp-widget ' . esc_attr($scope_class);
@@ -49,6 +53,7 @@ $rtb_submit_label = 'pay_later' === $rtb_mode
     data-fp-shortcode="widget"
     data-config="<?php echo esc_attr(wp_json_encode($dataset)); ?>"
     data-sticky="<?php echo esc_attr($behavior['sticky'] ? '1' : '0'); ?>"
+    data-display-context="<?php echo esc_attr($display_context); ?>"
 >
     <div class="fp-exp-widget__header">
         <h2 class="fp-exp-widget__title"><?php echo esc_html($experience['title']); ?></h2>


### PR DESCRIPTION
## Summary
- implement the `[fp_exp_page]` shortcode with server-side data preparation, section toggles, and data layer payloads for experience detail pages
- add a dedicated template, styles, and scripts to render the GetYourGuide-style layout with sticky availability widget and accessible FAQ accordion
- expose display context hooks to the booking widget, ship an Elementor Experience Page widget, and document the new shortcode usage

## Testing
- php -l src/Shortcodes/ExperienceShortcode.php
- php -l src/Elementor/WidgetExperiencePage.php

------
https://chatgpt.com/codex/tasks/task_e_68da66129248832fa394168715312b62