### PR TITLE
Fix shortcode refresh and cache invalidation issues

### DIFF
--- a/.rebuild-state.json
+++ b/.rebuild-state.json
@@ -49,5 +49,5 @@
     "feature": "admin-ux",
     "step": "complete"
   },
-  "verify_current": "SUMMARY"
+  "verify_current": "FRONT-BINDING"
 }

--- a/docs/VERIFY-FRONT-BINDING.md
+++ b/docs/VERIFY-FRONT-BINDING.md
@@ -1,0 +1,27 @@
+# Verifica front-end shortcode
+
+## Problemi individuati
+- Gli shortcode `[fp_exp_page]` e `[fp_exp_widget]` venivano registrati subito al bootstrap del plugin: in alcuni contesti WordPress la registrazione preventiva impediva ai builder di rilevare i tag dopo un salvataggio.
+- Mancava un fallback sicuro per l'ID esperienza: senza attributo `id` i render restituivano errore senza tentare `get_the_ID()`, e non veniva loggata la condizione.
+- I metadati elenco (highlights, inclusions, ecc.) venivano letti direttamente da `get_post_meta` senza normalizzazione, causando stringhe vuote o valori serialized quando l'editor salvava formati differenti.
+- Il widget serializzava l'intero payload in `data-config` senza versione, quindi HTML già in cache non veniva invalidato.
+- Gli asset front-end usavano una versione statica (`FP_EXP_VERSION`), lasciando CSS/JS in cache dopo un deploy.
+- Il markup del meeting point mostrava sempre il link “Apri in Maps” anche quando mancavano coordinate/indirizzo.
+- Nessun log di diagnostica aiutava a capire quali meta mancassero durante il render.
+- Nessun invalidamento dei transients collegati all’esperienza al salvataggio del CPT.
+
+## Fix applicati
+- **`src/Shortcodes/Registrar.php`** – registrazione su `init` e flush mirato dei transients all’hook `save_post_fp_experience`.
+- **`src/Shortcodes/BaseShortcode.php`** – header `Cache-Control: no-store` per ogni render, evitando cache stale.
+- **`src/Shortcodes/ExperienceShortcode.php`** e **`src/Shortcodes/WidgetShortcode.php`** – fallback ID, normalizzazione meta tramite `Helpers::get_meta_array()`, log diagnostici e passaggio della versione configurazione al template.
+- **`src/Utils/Helpers.php`** – nuovo helper `get_meta_array()`, toggle per il debug logging, invalidamento transients ed utility `log_debug()`.
+- **`src/Shortcodes/Assets.php`** – versionamento dinamico CSS/JS basato su `filemtime`.
+- **`templates/front/widget.php`** – serializzazione JSON con chiave `version` e attributo `data-config-version`.
+- **`templates/front/partials/meeting-point.php`** – generazione sicura del link Maps e soppressione quando mancano dati.
+
+## Da testare manualmente
+1. Inserire `[fp_exp_page]` su una singola esperienza senza parametro `id`: verificare che carichi i dati e che il log non mostri errori.
+2. Aggiornare highlights/inclusions e ricaricare la pagina: i cambiamenti devono comparire subito, senza cache.
+3. Salvare una variazione prezzo biglietti/add-on: ricaricando la pagina il widget deve mostrare i nuovi valori e `data-config-version` deve variare.
+4. Disabilitare/abilitare meeting point o rimuovere l’ID: la sezione deve sparire senza errori e senza link Maps vuoti.
+5. Controllare i log strumenti → Tools: devono esistere voci `shortcodes` con meta mancanti solo quando effettivamente assenti.

--- a/src/Shortcodes/Assets.php
+++ b/src/Shortcodes/Assets.php
@@ -8,9 +8,11 @@ use FP_Exp\Utils\Helpers;
 use FP_Exp\Utils\Theme;
 
 use function admin_url;
+use function filemtime;
 use function function_exists;
 use function get_woocommerce_currency;
 use function get_option;
+use function is_readable;
 use function is_string;
 use function trailingslashit;
 use function wp_add_inline_style;
@@ -78,13 +80,13 @@ final class Assets
         $front_js = trailingslashit(FP_EXP_PLUGIN_URL) . 'assets/js/front.js';
         $checkout_js = trailingslashit(FP_EXP_PLUGIN_URL) . 'assets/js/checkout.js';
 
-        wp_register_style('fp-exp-front', $style_url, [], FP_EXP_VERSION);
+        wp_register_style('fp-exp-front', $style_url, [], $this->asset_version('assets/css/front.css'));
 
         wp_register_script(
             'fp-exp-front',
             $front_js,
             ['wp-i18n'],
-            FP_EXP_VERSION,
+            $this->asset_version('assets/js/front.js'),
             true
         );
 
@@ -92,7 +94,7 @@ final class Assets
             'fp-exp-checkout',
             $checkout_js,
             ['fp-exp-front'],
-            FP_EXP_VERSION,
+            $this->asset_version('assets/js/checkout.js'),
             true
         );
 
@@ -121,5 +123,19 @@ final class Assets
                 'tracking' => Helpers::tracking_config(),
             ]
         );
+    }
+
+    private function asset_version(string $relative): string
+    {
+        $path = trailingslashit(FP_EXP_PLUGIN_DIR) . ltrim($relative, '/');
+
+        if (is_readable($path)) {
+            $mtime = filemtime($path);
+            if (false !== $mtime) {
+                return (string) $mtime;
+            }
+        }
+
+        return FP_EXP_VERSION;
     }
 }

--- a/src/Shortcodes/Registrar.php
+++ b/src/Shortcodes/Registrar.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace FP_Exp\Shortcodes;
 
 use FP_Exp\Utils\Helpers;
+use WP_Post;
+
+use function add_action;
 
 final class Registrar
 {
@@ -30,8 +33,31 @@ final class Registrar
 
     public function register(): void
     {
+        add_action('init', [$this, 'register_shortcodes']);
+        add_action('save_post_fp_experience', [$this, 'flush_experience_cache'], 20, 3);
+    }
+
+    public function register_shortcodes(): void
+    {
         foreach ($this->shortcodes as $shortcode) {
             $shortcode->register();
         }
+    }
+
+    public function flush_experience_cache(int $post_id, WP_Post $post, bool $update): void
+    {
+        if ($post_id <= 0) {
+            return;
+        }
+
+        if ('fp_experience' !== $post->post_type) {
+            return;
+        }
+
+        if ('auto-draft' === $post->post_status) {
+            return;
+        }
+
+        Helpers::clear_experience_transients($post_id);
     }
 }

--- a/templates/front/partials/meeting-point.php
+++ b/templates/front/partials/meeting-point.php
@@ -11,15 +11,26 @@ $email = $meeting_point['email'] ?? '';
 $opening_hours = $meeting_point['opening_hours'] ?? '';
 $lat = isset($meeting_point['lat']) && '' !== $meeting_point['lat'] ? $meeting_point['lat'] : null;
 $lng = isset($meeting_point['lng']) && '' !== $meeting_point['lng'] ? $meeting_point['lng'] : null;
+$map_url = '';
+
+if (null !== $lat && null !== $lng) {
+    $map_url = 'https://www.google.com/maps/search/?api=1&query=' . rawurlencode((string) $lat . ',' . (string) $lng);
+} elseif ($address) {
+    $map_url = 'https://www.google.com/maps/search/?api=1&query=' . rawurlencode((string) $address);
+}
 ?>
 <div class="fp-exp-meeting-point" data-fp-meeting-point data-address="<?php echo esc_attr((string) $address); ?>" data-lat="<?php echo esc_attr(null === $lat ? '' : (string) $lat); ?>" data-lng="<?php echo esc_attr(null === $lng ? '' : (string) $lng); ?>">
     <h3 class="fp-exp-meeting-point__title"><?php echo esc_html((string) ($meeting_point['title'] ?? '')); ?></h3>
-    <?php if ($address) : ?>
+    <?php if ($address || $map_url) : ?>
         <p class="fp-exp-meeting-point__address">
-            <span><?php echo esc_html((string) $address); ?></span>
-            <a href="#" class="fp-exp-meeting-point__map-link" data-fp-map-link target="_blank" rel="noopener">
-                <?php esc_html_e('Apri in Maps', 'fp-experiences'); ?>
-            </a>
+            <?php if ($address) : ?>
+                <span><?php echo esc_html((string) $address); ?></span>
+            <?php endif; ?>
+            <?php if ($map_url) : ?>
+                <a href="<?php echo esc_url($map_url); ?>" class="fp-exp-meeting-point__map-link" data-fp-map-link target="_blank" rel="noopener">
+                    <?php esc_html_e('Apri in Maps', 'fp-experiences'); ?>
+                </a>
+            <?php endif; ?>
         </p>
     <?php endif; ?>
 

--- a/templates/front/widget.php
+++ b/templates/front/widget.php
@@ -25,6 +25,7 @@ $marketing_id = $scope_class . '-consent-marketing';
 $privacy_id = $scope_class . '-consent-privacy';
 
 $display_context = isset($display_context) ? (string) $display_context : '';
+$config_version = isset($config_version) ? (string) $config_version : '';
 
 $dataset = [
     'experienceId' => $experience['id'],
@@ -38,6 +39,7 @@ $dataset = [
     'rtb' => $rtb,
     'nonce' => $rtb_nonce,
     'displayContext' => $display_context,
+    'version' => $config_version,
 ];
 
 $container_class = 'fp-exp fp-exp-widget ' . esc_attr($scope_class);
@@ -54,6 +56,7 @@ $rtb_submit_label = 'pay_later' === $rtb_mode
     data-config="<?php echo esc_attr(wp_json_encode($dataset)); ?>"
     data-sticky="<?php echo esc_attr($behavior['sticky'] ? '1' : '0'); ?>"
     data-display-context="<?php echo esc_attr($display_context); ?>"
+    data-config-version="<?php echo esc_attr($config_version); ?>"
 >
     <div class="fp-exp-widget__header">
         <h2 class="fp-exp-widget__title"><?php echo esc_html($experience['title']); ?></h2>


### PR DESCRIPTION
## Summary
- register shortcode handlers during init and clear plugin transients when an experience is saved
- normalise meta payloads, add shortcode debug logging, and prevent cached HTML via no-store headers and versioned widget data
- version front-end assets and guard the meeting point map link so it only renders when usable coordinates or addresses exist

## Testing
- php -l src/Shortcodes/Assets.php
- php -l src/Shortcodes/BaseShortcode.php
- php -l src/Shortcodes/ExperienceShortcode.php
- php -l src/Shortcodes/Registrar.php
- php -l src/Shortcodes/WidgetShortcode.php
- php -l src/Utils/Helpers.php
- php -l templates/front/partials/meeting-point.php
- php -l templates/front/widget.php

------
https://chatgpt.com/codex/tasks/task_e_68da83871d3c832fb22303cedcb2c908