### PR TITLE
Add experiences listing showcase with filters and Elementor widget

### DIFF
--- a/.rebuild-state.json
+++ b/.rebuild-state.json
@@ -46,8 +46,8 @@
     }
   },
   "rebuild": {
-    "feature": "admin-ux",
-    "step": "complete"
+    "feature": "listing",
+    "step": "DOCS"
   },
   "verify_current": "FRONT-BINDING"
 }

--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -264,6 +264,438 @@
     background: var(--fp-exp-color-secondary, #405F3B);
 }
 
+/* Listing */
+.fp-listing {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    --fp-listing-gap: 1.5rem;
+    --fp-listing-cols-mobile: 1;
+    --fp-listing-cols-tablet: 2;
+    --fp-listing-cols-desktop: 3;
+}
+
+.fp-listing__header {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.fp-listing__intro {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.fp-listing__title {
+    margin: 0;
+    font-size: 1.75rem;
+    color: var(--fp-exp-color-text, #1F1F1F);
+}
+
+.fp-listing__count {
+    margin: 0;
+    color: var(--fp-exp-color-muted, #5c5c5c);
+    font-size: 0.95rem;
+}
+
+.fp-listing__controls {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.fp-listing__filters {
+    display: grid;
+    gap: 1rem 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    padding: 1rem;
+    background: var(--fp-exp-color-surface, #f8f6f2);
+    border-radius: var(--fp-exp-radius-base, 12px);
+}
+
+.fp-listing__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.fp-listing__label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--fp-exp-color-muted, #5c5c5c);
+}
+
+.fp-listing__input,
+.fp-listing__select {
+    appearance: none;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    border-radius: var(--fp-exp-radius-base, 12px);
+    padding: 0.65rem 0.75rem;
+    font: inherit;
+    background: #fff;
+    color: inherit;
+}
+
+.fp-listing__input:focus,
+.fp-listing__select:focus {
+    outline: 2px solid var(--fp-exp-color-primary, #8B1E3F);
+    outline-offset: 2px;
+}
+
+.fp-listing__field--range .fp-listing__range-inputs {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.fp-listing__field--checkbox {
+    justify-content: flex-end;
+}
+
+.fp-listing__checkbox {
+    display: inline-flex;
+    gap: 0.5rem;
+    align-items: center;
+    font-size: 0.95rem;
+}
+
+.fp-listing__checkbox input {
+    width: 1rem;
+    height: 1rem;
+}
+
+.fp-listing__actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.5rem;
+}
+
+.fp-listing__submit {
+    padding: 0.65rem 1.4rem;
+    background: var(--fp-exp-color-primary, #8B1E3F);
+    color: #fff;
+    border: none;
+    border-radius: 999px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.fp-listing__submit:hover,
+.fp-listing__submit:focus {
+    background: var(--fp-exp-color-secondary, #405F3B);
+}
+
+.fp-listing__reset {
+    font-size: 0.9rem;
+    color: var(--fp-exp-color-primary, #8B1E3F);
+    text-decoration: underline;
+}
+
+.fp-listing__view {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.fp-listing__view-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.4rem 0.85rem;
+    border-radius: 999px;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    font-size: 0.85rem;
+}
+
+.fp-listing__view-toggle.is-active {
+    background: var(--fp-exp-color-primary, #8B1E3F);
+    color: #fff;
+    border-color: transparent;
+}
+
+.fp-listing__grid {
+    display: grid;
+    gap: var(--fp-listing-gap, 1.5rem);
+}
+
+.fp-listing__grid--grid {
+    grid-template-columns: repeat(var(--fp-listing-cols-mobile, 1), minmax(0, 1fr));
+}
+
+.fp-listing__grid--list {
+    grid-template-columns: 1fr;
+}
+
+.fp-listing__card {
+    display: flex;
+    flex-direction: column;
+    background: #fff;
+    border-radius: var(--fp-exp-radius-base, 12px);
+    overflow: hidden;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.fp-listing__card:hover,
+.fp-listing__card:focus-within {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.12);
+}
+
+.fp-listing__media {
+    position: relative;
+    display: block;
+    overflow: hidden;
+    aspect-ratio: 16 / 9;
+    background: linear-gradient(120deg, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0.02), rgba(0, 0, 0, 0.08));
+    background-size: 200% 100%;
+    animation: fp-listing-shimmer 1.4s ease-in-out infinite;
+}
+
+.fp-listing__image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.fp-listing__image--placeholder {
+    display: block;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(135deg, var(--fp-exp-color-primary, #8B1E3F), var(--fp-exp-color-accent, #5B8C5A));
+    opacity: 0.25;
+}
+
+.fp-listing__price-tag {
+    position: absolute;
+    bottom: 0.75rem;
+    right: 0.75rem;
+    background: rgba(0, 0, 0, 0.75);
+    color: #fff;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.fp-listing__body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1.25rem 1.25rem 0.75rem;
+}
+
+.fp-listing__name {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.fp-listing__badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.fp-listing__badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
+    background: var(--fp-exp-color-surface, #f2efe8);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.fp-listing__highlights {
+    margin: 0;
+    padding-left: 1rem;
+    color: var(--fp-exp-color-muted, #5c5c5c);
+    font-size: 0.95rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.fp-listing__excerpt {
+    margin: 0;
+    color: var(--fp-exp-color-muted, #5c5c5c);
+    font-size: 0.95rem;
+}
+
+.fp-listing__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem 1.25rem;
+}
+
+.fp-listing__cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.6rem 1.5rem;
+    border-radius: 999px;
+    background: var(--fp-exp-color-primary, #8B1E3F);
+    color: #fff;
+    font-weight: 600;
+}
+
+.fp-listing__cta:hover,
+.fp-listing__cta:focus {
+    background: var(--fp-exp-color-secondary, #405F3B);
+}
+
+.fp-listing__map {
+    font-size: 0.85rem;
+    color: var(--fp-exp-color-primary, #8B1E3F);
+    text-decoration: underline;
+}
+
+.fp-listing__empty {
+    margin: 0;
+    padding: 1.5rem;
+    border-radius: var(--fp-exp-radius-base, 12px);
+    background: rgba(0, 0, 0, 0.04);
+}
+
+.fp-listing__pagination {
+    display: flex;
+    justify-content: center;
+}
+
+.fp-listing__pagination-list {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.fp-listing__pagination-item a,
+.fp-listing__pagination-item span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2rem;
+    padding: 0.4rem 0.6rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+}
+
+.fp-listing__pagination-item a {
+    border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.fp-listing__pagination-item a:hover,
+.fp-listing__pagination-item a:focus {
+    border-color: var(--fp-exp-color-primary, #8B1E3F);
+    color: var(--fp-exp-color-primary, #8B1E3F);
+}
+
+.fp-listing__pagination-item.is-current span {
+    background: var(--fp-exp-color-primary, #8B1E3F);
+    color: #fff;
+}
+
+.fp-listing__pagination-item.is-disabled span {
+    color: var(--fp-exp-color-muted, #9c9c9c);
+}
+
+@media (min-width: 768px) {
+    .fp-listing__controls {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: flex-start;
+    }
+
+    .fp-listing__filters {
+        flex: 1;
+    }
+
+    .fp-listing__grid--grid {
+        grid-template-columns: repeat(var(--fp-listing-cols-tablet, var(--fp-listing-cols-mobile, 1)), minmax(0, 1fr));
+    }
+}
+
+@media (min-width: 1024px) {
+    .fp-listing__grid--grid {
+        grid-template-columns: repeat(var(--fp-listing-cols-desktop, var(--fp-listing-cols-tablet, 1)), minmax(0, 1fr));
+    }
+}
+
+.fp-listing--cols-mobile-1 {
+    --fp-listing-cols-mobile: 1;
+}
+
+.fp-listing--cols-mobile-2 {
+    --fp-listing-cols-mobile: 2;
+}
+
+.fp-listing--cols-mobile-3 {
+    --fp-listing-cols-mobile: 3;
+}
+
+.fp-listing--cols-tablet-1 {
+    --fp-listing-cols-tablet: 1;
+}
+
+.fp-listing--cols-tablet-2 {
+    --fp-listing-cols-tablet: 2;
+}
+
+.fp-listing--cols-tablet-3 {
+    --fp-listing-cols-tablet: 3;
+}
+
+.fp-listing--cols-tablet-4 {
+    --fp-listing-cols-tablet: 4;
+}
+
+.fp-listing--cols-desktop-1 {
+    --fp-listing-cols-desktop: 1;
+}
+
+.fp-listing--cols-desktop-2 {
+    --fp-listing-cols-desktop: 2;
+}
+
+.fp-listing--cols-desktop-3 {
+    --fp-listing-cols-desktop: 3;
+}
+
+.fp-listing--cols-desktop-4 {
+    --fp-listing-cols-desktop: 4;
+}
+
+.fp-listing--gap-compact {
+    --fp-listing-gap: 1rem;
+}
+
+.fp-listing--gap-cozy {
+    --fp-listing-gap: 1.5rem;
+}
+
+.fp-listing--gap-spacious {
+    --fp-listing-gap: 2.5rem;
+}
+
+@keyframes fp-listing-shimmer {
+    0% {
+        background-position: -200% 0;
+    }
+    100% {
+        background-position: 200% 0;
+    }
+}
+
 /* Widget */
 .fp-exp-widget {
     position: relative;

--- a/docs/VERIFY-LISTING.md
+++ b/docs/VERIFY-LISTING.md
@@ -1,0 +1,36 @@
+# VERIFY-LISTING
+
+Manual smoke-test checklist for the experiences showcase.
+
+## Setup
+
+1. Create at least six published `fp_experience` posts with distinct themes, languages, durations, and ticket prices. Assign primary meeting points (with latitude/longitude) to a couple of experiences.
+2. Seed availability so that at least two experiences have open slots on the same calendar date and a couple have none.
+3. Visit **FP Experiences → Settings → Showcase** and confirm defaults (filters enabled, price badge toggle, etc.).
+4. Add the shortcode `[fp_exp_list filters="theme,language,duration,price,family,date" per_page="6" orderby="price" order="ASC" show_price_from="1" show_map="1"]` to a public “Tutte le esperienze” page.
+
+## Behaviour
+
+- ✅ The filter form renders with search, taxonomy selects, price range inputs, family-friendly checkbox, date picker, sort selectors, and view toggles.
+- ✅ Cards display featured imagery (or gradient placeholder), highlights/description, badges (duration, language, family when relevant), “From €X” price tag, and CTA linking to the dedicated experience page (or the CPT fallback). Map link opens a Google Maps search for the meeting point.
+- ✅ The “X experiences found” counter updates after submitting filters. Submissions use `GET` so the page can be bookmarked/shared.
+- ✅ Price badge reflects the lowest ticket price (transient cached) and updates when ticket meta changes.
+- ✅ Pagination retains applied filters/sorting via the query string. Page reset occurs when filters are reapplied.
+- ✅ Date filtering only returns experiences with open slots on the selected day (querying `fp_exp_slots`).
+- ✅ Switching between grid/list views via the toggle updates the layout classes without breaking pagination or filters.
+- ✅ Tracking: with consent granted, `view_item_list` fires once per page load (IDs and titles of visible cards). Clicking a card CTA or hero image fires `select_item` with the corresponding `item_id`/`item_name`.
+- ✅ Asset loading: `assets/css/front.css` and `assets/js/front.js` enqueue only on pages rendering the shortcode.
+
+## Elementor Widget
+
+1. Insert the “FP Experiences List” widget on a test page.
+2. Use the content controls to mirror the shortcode attributes (filters, ordering, map toggle, CTA target).
+3. In the Style tab set different column counts for desktop/tablet/mobile, change the gap, and toggle price/badge visibility.
+4. Confirm the rendered widget honours the configured layout and mirrors shortcode behaviour (filters, pagination, map links, tracking events).
+
+## Settings
+
+- ✅ Changing defaults under **Settings → Showcase** updates the shortcode/widget when attributes are omitted (e.g. turning off the price badge hides it on fresh embeds).
+- ✅ Saving settings clears the price-from transient (`fp_exp_price_from_{id}`) so badge changes appear after editing tickets.
+
+Document test results (pass/fail, notes) in the internal QA tracker.

--- a/readme.txt
+++ b/readme.txt
@@ -29,7 +29,9 @@ FP Experiences brings GetYourGuide-style booking flows to WooCommerce without to
 
 == Shortcodes ==
 
-* `[fp_exp_list]` – Grid of experiences with filters. Attributes: `filters`, `per_page`, `order`.
+* `[fp_exp_list]` – Mobile-first experiences showcase with accessible filter form (themes, languages, duration, price range, family-friendly toggle, date picker, and text search), sorting controls, pagination, price badges, optional map links, and dataLayer tracking (`view_item_list` + `select_item`). Attributes: `filters`, `per_page`, `page`, `search`, `order`, `orderby`, `view`, `show_map`, `cta`, `badge_lang`, `badge_duration`, `badge_family`, `show_price_from`, plus layout helpers (`columns_desktop`, `columns_tablet`, `columns_mobile`, `gap`). Price badges cache the lowest ticket price per experience via transients and respect dedicated experience pages when available. Examples:
+  * `[fp_exp_list filters="theme,language,price,date,family" per_page="9" view="grid" orderby="price" order="ASC" show_price_from="1" show_map="1"]`
+  * `[fp_exp_list filters="search,theme" per_page="12" view="list" cta="widget" gap="compact"]`
 * `[fp_exp_widget id="123"]` – Booking widget for a specific experience. Attributes: `sticky`, `show_calendar`, `primary`, `accent`, `radius`.
 * `[fp_exp_calendar id="123" months="2"]` – Inline availability calendar for a single experience.
 * `[fp_exp_checkout]` – Isolated checkout that finalises the FP Experiences cart only.
@@ -40,12 +42,13 @@ The `sections` attribute accepts a comma-separated list of sections to render (h
 
 == Elementor Widgets ==
 
-Six Elementor widgets mirror the shortcodes: List, Widget, Calendar, Checkout, Meeting Points, and the new Experience Page layout. Each exposes theming controls (colors, radius, fonts) plus behavioural toggles (sticky mode, inline calendar, consent defaults). The Experience Page widget lets editors pick sections to display and toggle the sticky availability bar while reusing the `[fp_exp_page]` shortcode under the hood.
+Six Elementor widgets mirror the shortcodes: List, Widget, Calendar, Checkout, Meeting Points, and the new Experience Page layout. The List widget now bundles the full showcase controls (filters, search, ordering, map toggle, CTA behaviour) plus responsive style controls for columns, card spacing, and badge/price visibility. Each widget exposes theming overrides (colors, radius, fonts) alongside behavioural toggles (sticky mode, inline calendar, consent defaults). The Experience Page widget lets editors pick sections to display and toggle the sticky availability bar while reusing the `[fp_exp_page]` shortcode under the hood.
 
 == Settings & Tools ==
 
 * **General** – Structure and webmaster emails, locale preferences, VAT class filters, meeting points toggle.
 * **Branding** – Color palette, button radius, shadows, presets, contrast checker, optional Google Font.
+* **Showcase** – Default filters, ordering, and price badge toggle for the experiences listing/Elementor widget.
 * **Tracking** – Enable/disable GA4, Google Ads, Meta Pixel, Clarity, enhanced conversions, and consent defaults.
 * **Brevo** – API key, list ID, attribute mappings, transactional template IDs, webhook diagnostics.
 * **Calendar** – Google OAuth client credentials, redirect URI, connect/disconnect, target calendar.

--- a/src/Elementor/WidgetList.php
+++ b/src/Elementor/WidgetList.php
@@ -6,7 +6,9 @@ namespace FP_Exp\Elementor;
 
 use Elementor\Controls_Manager;
 use Elementor\Widget_Base;
+use FP_Exp\Utils\Helpers;
 
+use function absint;
 use function array_filter;
 use function do_shortcode;
 use function esc_attr;
@@ -50,6 +52,8 @@ final class WidgetList extends Widget_Base
             ]
         );
 
+        $defaults = Helpers::listing_settings();
+
         $this->add_control(
             'filters',
             [
@@ -57,12 +61,15 @@ final class WidgetList extends Widget_Base
                 'type' => Controls_Manager::SELECT2,
                 'multiple' => true,
                 'options' => [
+                    'search' => esc_html__('Search', 'fp-experiences'),
                     'theme' => esc_html__('Theme', 'fp-experiences'),
+                    'language' => esc_html__('Language', 'fp-experiences'),
                     'duration' => esc_html__('Duration', 'fp-experiences'),
                     'price' => esc_html__('Price', 'fp-experiences'),
-                    'language' => esc_html__('Language', 'fp-experiences'),
+                    'family' => esc_html__('Family-friendly', 'fp-experiences'),
+                    'date' => esc_html__('Date', 'fp-experiences'),
                 ],
-                'default' => ['theme', 'duration', 'price'],
+                'default' => $defaults['filters'],
             ]
         );
 
@@ -73,27 +80,27 @@ final class WidgetList extends Widget_Base
                 'type' => Controls_Manager::NUMBER,
                 'min' => 1,
                 'max' => 24,
-                'default' => 9,
+                'default' => $defaults['per_page'],
+            ]
+        );
+
+        $this->add_control(
+            'orderby',
+            [
+                'label' => esc_html__('Order by', 'fp-experiences'),
+                'type' => Controls_Manager::SELECT,
+                'options' => [
+                    'menu_order' => esc_html__('Manual order', 'fp-experiences'),
+                    'date' => esc_html__('Publish date', 'fp-experiences'),
+                    'title' => esc_html__('Title', 'fp-experiences'),
+                    'price' => esc_html__('Price (lowest first)', 'fp-experiences'),
+                ],
+                'default' => $defaults['orderby'],
             ]
         );
 
         $this->add_control(
             'order',
-            [
-                'label' => esc_html__('Order by', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    'menu_order' => esc_html__('Menu order', 'fp-experiences'),
-                    'date' => esc_html__('Publish date', 'fp-experiences'),
-                    'title' => esc_html__('Title', 'fp-experiences'),
-                    'modified' => esc_html__('Last modified', 'fp-experiences'),
-                ],
-                'default' => 'menu_order',
-            ]
-        );
-
-        $this->add_control(
-            'order_direction',
             [
                 'label' => esc_html__('Order direction', 'fp-experiences'),
                 'type' => Controls_Manager::SELECT,
@@ -101,7 +108,116 @@ final class WidgetList extends Widget_Base
                     'ASC' => esc_html__('Ascending', 'fp-experiences'),
                     'DESC' => esc_html__('Descending', 'fp-experiences'),
                 ],
-                'default' => 'ASC',
+                'default' => $defaults['order'],
+            ]
+        );
+
+        $this->add_control(
+            'view',
+            [
+                'label' => esc_html__('Initial view', 'fp-experiences'),
+                'type' => Controls_Manager::SELECT,
+                'options' => [
+                    'grid' => esc_html__('Grid', 'fp-experiences'),
+                    'list' => esc_html__('List', 'fp-experiences'),
+                ],
+                'default' => 'grid',
+            ]
+        );
+
+        $this->add_control(
+            'show_map',
+            [
+                'label' => esc_html__('Show map link', 'fp-experiences'),
+                'type' => Controls_Manager::SWITCHER,
+                'default' => 'no',
+            ]
+        );
+
+        $this->add_control(
+            'cta',
+            [
+                'label' => esc_html__('CTA behaviour', 'fp-experiences'),
+                'type' => Controls_Manager::SELECT,
+                'options' => [
+                    'page' => esc_html__('Open experience page', 'fp-experiences'),
+                    'widget' => esc_html__('Scroll to booking widget', 'fp-experiences'),
+                ],
+                'default' => 'page',
+            ]
+        );
+
+        $this->end_controls_section();
+
+        $this->start_controls_section(
+            'section_layout',
+            [
+                'label' => esc_html__('Layout', 'fp-experiences'),
+                'tab' => Controls_Manager::TAB_STYLE,
+            ]
+        );
+
+        $this->add_responsive_control(
+            'columns',
+            [
+                'label' => esc_html__('Columns', 'fp-experiences'),
+                'type' => Controls_Manager::NUMBER,
+                'min' => 1,
+                'max' => 4,
+                'step' => 1,
+                'default' => 3,
+                'tablet_default' => 2,
+                'mobile_default' => 1,
+            ]
+        );
+
+        $this->add_control(
+            'gap',
+            [
+                'label' => esc_html__('Card spacing', 'fp-experiences'),
+                'type' => Controls_Manager::SELECT,
+                'options' => [
+                    'compact' => esc_html__('Compact', 'fp-experiences'),
+                    'cozy' => esc_html__('Cozy', 'fp-experiences'),
+                    'spacious' => esc_html__('Spacious', 'fp-experiences'),
+                ],
+                'default' => 'cozy',
+            ]
+        );
+
+        $this->add_control(
+            'show_price_from',
+            [
+                'label' => esc_html__('Show “price from” badge', 'fp-experiences'),
+                'type' => Controls_Manager::SWITCHER,
+                'default' => $defaults['show_price_from'] ? 'yes' : 'no',
+            ]
+        );
+
+        $this->add_control(
+            'show_language_badge',
+            [
+                'label' => esc_html__('Show language badge', 'fp-experiences'),
+                'type' => Controls_Manager::SWITCHER,
+                'default' => 'yes',
+            ]
+        );
+
+        $this->add_control(
+            'show_duration_badge',
+            [
+                'label' => esc_html__('Show duration badge', 'fp-experiences'),
+                'type' => Controls_Manager::SWITCHER,
+                'default' => 'yes',
+            ]
+        );
+
+        $this->add_control(
+            'show_family_badge',
+            [
+                'label' => esc_html__('Show family badge', 'fp-experiences'),
+                'type' => Controls_Manager::SWITCHER,
+                'default' => 'yes',
             ]
         );
 
@@ -129,11 +245,34 @@ final class WidgetList extends Widget_Base
         }
 
         $atts = [
-            'filters' => $filters ?: 'theme,duration,price',
+            'filters' => $filters ?: implode(',', $defaults['filters']),
             'per_page' => (string) ($settings['per_page'] ?? '9'),
-            'order' => (string) ($settings['order'] ?? 'menu_order'),
-            'order_direction' => (string) ($settings['order_direction'] ?? 'ASC'),
+            'orderby' => (string) ($settings['orderby'] ?? 'menu_order'),
+            'order' => (string) ($settings['order'] ?? 'ASC'),
+            'view' => (string) ($settings['view'] ?? 'grid'),
+            'show_map' => ('yes' === ($settings['show_map'] ?? 'no')) ? '1' : '0',
+            'cta' => (string) ($settings['cta'] ?? 'page'),
+            'show_price_from' => ('yes' === ($settings['show_price_from'] ?? 'yes')) ? '1' : '0',
+            'badge_lang' => ('yes' === ($settings['show_language_badge'] ?? 'yes')) ? '1' : '0',
+            'badge_duration' => ('yes' === ($settings['show_duration_badge'] ?? 'yes')) ? '1' : '0',
+            'badge_family' => ('yes' === ($settings['show_family_badge'] ?? 'yes')) ? '1' : '0',
         ];
+
+        if (! empty($settings['columns'])) {
+            $atts['columns_desktop'] = (string) absint($settings['columns']);
+        }
+
+        if (! empty($settings['columns_tablet'])) {
+            $atts['columns_tablet'] = (string) absint($settings['columns_tablet']);
+        }
+
+        if (! empty($settings['columns_mobile'])) {
+            $atts['columns_mobile'] = (string) absint($settings['columns_mobile']);
+        }
+
+        if (! empty($settings['gap'])) {
+            $atts['gap'] = (string) $settings['gap'];
+        }
 
         $atts = array_merge($atts, $this->collect_theme_atts($settings));
 

--- a/src/Shortcodes/ListShortcode.php
+++ b/src/Shortcodes/ListShortcode.php
@@ -4,39 +4,64 @@ declare(strict_types=1);
 
 namespace FP_Exp\Shortcodes;
 
+use DateInterval;
 use DateTimeImmutable;
-use DateTimeInterface;
 use DateTimeZone;
 use Exception;
 use FP_Exp\Booking\Slots;
+use FP_Exp\MeetingPoints\Repository as MeetingPointRepository;
+use FP_Exp\Utils\Helpers;
 use FP_Exp\Utils\Theme;
-use WP_Error;
 use WP_Post;
 use WP_Query;
 
+use function __;
+use function _n;
 use function absint;
+use function add_query_arg;
 use function array_filter;
 use function array_map;
-use function explode;
-use function get_option;
+use function array_slice;
+use function array_values;
+use function ceil;
+use function count;
 use function get_permalink;
+use function get_post_field;
 use function get_post_meta;
+use function get_posts;
+use function get_terms;
 use function get_the_post_thumbnail_url;
+use function get_the_terms;
 use function get_the_title;
+use function get_transient;
+use function home_url;
+use function implode;
+use function in_array;
 use function is_array;
+use function is_bool;
 use function is_numeric;
+use function is_string;
+use function is_wp_error;
 use function max;
+use function min;
+use function number_format_i18n;
+use function preg_match;
+use function rawurlencode;
+use function remove_query_arg;
 use function sanitize_key;
 use function sanitize_text_field;
-use function strtoupper;
-use function __;
-use function gmdate;
-use function in_array;
+use function set_transient;
+use function sprintf;
+use function strpos;
+use function strtolower;
+use function trim;
 use function wp_get_post_terms;
-use function wp_json_encode;
-use function wp_timezone;
 use function wp_list_pluck;
-use const ARRAY_A;
+use function wp_timezone;
+use function wp_unslash;
+use function wp_json_encode;
+
+use const DAY_IN_SECONDS;
 
 final class ListShortcode extends BaseShortcode
 {
@@ -45,10 +70,23 @@ final class ListShortcode extends BaseShortcode
     protected string $template = 'front/list.php';
 
     protected array $defaults = [
-        'filters' => 'theme,duration,price',
-        'per_page' => '9',
-        'order' => 'menu_order',
-        'order_direction' => 'ASC',
+        'filters' => '',
+        'per_page' => '',
+        'page' => '1',
+        'order' => '',
+        'orderby' => '',
+        'search' => '',
+        'view' => '',
+        'show_map' => '0',
+        'cta' => 'page',
+        'badge_lang' => '1',
+        'badge_duration' => '1',
+        'badge_family' => '1',
+        'show_price_from' => '',
+        'columns_desktop' => '',
+        'columns_tablet' => '',
+        'columns_mobile' => '',
+        'gap' => '',
         'preset' => '',
         'mode' => '',
         'primary' => '',
@@ -66,55 +104,83 @@ final class ListShortcode extends BaseShortcode
         'font' => '',
     ];
 
+    private const ALLOWED_FILTERS = ['theme', 'language', 'duration', 'price', 'family', 'date', 'search'];
+
+    private const ALLOWED_ORDERBY = ['menu_order', 'date', 'title', 'price'];
+
+    private const ALLOWED_ORDER = ['ASC', 'DESC'];
+
+    private const LISTING_PARAM_PREFIX = 'fp_exp_';
+
+    private const PRICE_TRANSIENT_PREFIX = 'fp_exp_price_from_';
+
     /**
      * @param array<string, mixed> $attributes
      *
-     * @return array<string, mixed>|WP_Error
+     * @return array<string, mixed>|\WP_Error
      */
     protected function get_context(array $attributes, ?string $content = null)
     {
-        $order = strtoupper(sanitize_key((string) $attributes['order_direction']));
-        if (! in_array($order, ['ASC', 'DESC'], true)) {
-            $order = 'ASC';
+        unset($content);
+
+        $settings = Helpers::listing_settings();
+
+        $active_filters = $this->normalize_filters((string) $attributes['filters'], $settings['filters']);
+        $per_page = $this->normalize_positive_int($attributes['per_page'] ?: $settings['per_page'], $settings['per_page']);
+        $view = $this->normalize_view((string) $attributes['view']);
+        $order = $this->normalize_order($attributes['order'] ?: $settings['order']);
+        $orderby = $this->normalize_orderby($attributes['orderby'] ?: $settings['orderby']);
+        $show_price_from = $this->normalize_bool($attributes['show_price_from'], $settings['show_price_from']);
+        $show_map = $this->normalize_bool($attributes['show_map'] ?? '0', false);
+        $cta_mode = $this->normalize_cta((string) $attributes['cta']);
+        $badge_flags = [
+            'language' => $this->normalize_bool($attributes['badge_lang'] ?? '1', true),
+            'duration' => $this->normalize_bool($attributes['badge_duration'] ?? '1', true),
+            'family' => $this->normalize_bool($attributes['badge_family'] ?? '1', true),
+        ];
+
+        $layout = [
+            'desktop' => $this->normalize_column_setting($attributes['columns_desktop'] ?? ''),
+            'tablet' => $this->normalize_column_setting($attributes['columns_tablet'] ?? ''),
+            'mobile' => $this->normalize_column_setting($attributes['columns_mobile'] ?? ''),
+            'gap' => $this->normalize_gap_setting($attributes['gap'] ?? ''),
+        ];
+
+        $state = $this->read_filter_state($active_filters, $attributes, $order, $orderby, $view);
+        $order = $state['order'] ?? $order;
+        $orderby = $state['orderby'] ?? $orderby;
+        $view = $state['view'] ?? $view;
+
+        $query_args = $this->build_query_args($state, $order, $orderby);
+        $query = new WP_Query($query_args);
+
+        $experience_ids = array_map('absint', $query->posts);
+
+        if (! empty($state['date'])) {
+            $experience_ids = $this->filter_by_date($experience_ids, $state['date']);
         }
 
-        $order_by = sanitize_key((string) $attributes['order']);
-        if (! in_array($order_by, ['menu_order', 'date', 'title', 'modified'], true)) {
-            $order_by = 'menu_order';
+        $prices = $this->load_prices($experience_ids);
+
+        $price_range = $this->determine_price_range($prices);
+
+        if (isset($state['price_min'], $state['price_max'])) {
+            $experience_ids = $this->filter_by_price($experience_ids, $prices, $state['price_min'], $state['price_max']);
         }
 
-        $per_page = max(1, absint($attributes['per_page']));
-
-        $query = new WP_Query([
-            'post_type' => 'fp_experience',
-            'post_status' => 'publish',
-            'posts_per_page' => $per_page,
-            'orderby' => $order_by,
-            'order' => $order,
-            'no_found_rows' => true,
-        ]);
-
-        $experiences = [];
-        $schema = [];
-
-        foreach ($query->posts as $post) {
-            if (! $post instanceof WP_Post) {
-                continue;
-            }
-
-            $experience = $this->map_experience($post);
-
-            if (empty($experience)) {
-                continue;
-            }
-
-            $experiences[] = $experience;
-            if (! empty($experience['schema'])) {
-                $schema[] = $experience['schema'];
-            }
+        if ('price' === $orderby) {
+            $experience_ids = $this->sort_by_price($experience_ids, $prices, $order);
         }
 
-        $filters = $this->prepare_filters((string) $attributes['filters'], $experiences);
+        $total = count($experience_ids);
+        $total_pages = max(1, (int) ceil($total / $per_page));
+        $current_page = min($total_pages, max(1, (int) $state['page']));
+
+        $page_ids = array_slice($experience_ids, ($current_page - 1) * $per_page, $per_page);
+        $experiences = $this->map_experiences($page_ids, $prices, $show_price_from, $badge_flags, $show_map, $cta_mode);
+
+        $filters = $this->build_filters($active_filters, $state, $price_range);
+        $tracking_items = $this->build_tracking_items($page_ids, $prices);
 
         $theme = Theme::resolve_palette([
             'preset' => (string) $attributes['preset'],
@@ -135,268 +201,856 @@ final class ListShortcode extends BaseShortcode
         ]);
 
         return [
+            'theme' => $theme,
             'experiences' => $experiences,
             'filters' => $filters,
-            'theme' => $theme,
-            'schema_json' => $schema ? wp_json_encode(['@context' => 'https://schema.org', '@graph' => $schema]) : '',
+            'state' => $state,
+            'view' => $view,
+            'per_page' => $per_page,
+            'order' => $order,
+            'orderby' => $orderby,
+            'show_price_from' => $show_price_from,
+            'show_map' => $show_map,
+            'cta_mode' => $cta_mode,
+            'badge_flags' => $badge_flags,
+            'layout' => $layout,
+            'total' => $total,
+            'current_page' => $current_page,
+            'total_pages' => $total_pages,
+            'pagination_links' => $this->build_pagination_links($current_page, $total_pages, $state),
+            'tracking_items' => $tracking_items,
+            'schema_json' => $this->build_schema($experiences),
         ];
+    }
+
+    /**
+     * @param array<int> $experience_ids
+     *
+     * @return array<int>
+     */
+    private function filter_by_date(array $experience_ids, string $date): array
+    {
+        if (empty($experience_ids)) {
+            return [];
+        }
+
+        $date = sanitize_text_field($date);
+        if (! preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
+            return $experience_ids;
+        }
+
+        $timezone = wp_timezone();
+
+        try {
+            $start = new DateTimeImmutable($date, $timezone);
+            $end = $start->add(new DateInterval('P1D'));
+        } catch (Exception $exception) {
+            unset($exception);
+
+            return $experience_ids;
+        }
+
+        $start_utc = $start->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s');
+        $end_utc = $end->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s');
+
+        global $wpdb;
+
+        $table = $wpdb->prefix . 'fp_exp_slots';
+        $placeholders = implode(',', array_fill(0, count($experience_ids), '%d'));
+        $sql = $wpdb->prepare(
+            "SELECT DISTINCT experience_id FROM {$table} WHERE experience_id IN ({$placeholders}) AND status = %s AND start_datetime >= %s AND start_datetime < %s",
+            ...array_merge($experience_ids, [Slots::STATUS_OPEN, $start_utc, $end_utc])
+        );
+
+        $results = $wpdb->get_col($sql);
+        if (empty($results)) {
+            return [];
+        }
+
+        $allowed = array_map('absint', $results);
+
+        return array_values(array_filter(
+            $experience_ids,
+            static fn (int $id): bool => in_array($id, $allowed, true)
+        ));
+    }
+
+    /**
+     * @param array<string, mixed> $state
+     */
+    private function build_query_args(array $state, string $order, string $orderby): array
+    {
+        $args = [
+            'post_type' => 'fp_experience',
+            'post_status' => 'publish',
+            'fields' => 'ids',
+            'posts_per_page' => -1,
+            'orderby' => in_array($orderby, ['menu_order', 'date', 'title'], true) ? $orderby : 'menu_order',
+            'order' => $order,
+            'no_found_rows' => true,
+        ];
+
+        if (! empty($state['search'])) {
+            $args['s'] = $state['search'];
+        }
+
+        $tax_query = [];
+
+        if (! empty($state['theme'])) {
+            $tax_query[] = [
+                'taxonomy' => 'fp_exp_theme',
+                'field' => 'slug',
+                'terms' => $state['theme'],
+                'operator' => 'IN',
+            ];
+        }
+
+        if (! empty($state['language'])) {
+            $tax_query[] = [
+                'taxonomy' => 'fp_exp_language',
+                'field' => 'slug',
+                'terms' => $state['language'],
+                'operator' => 'IN',
+            ];
+        }
+
+        if (! empty($state['duration'])) {
+            $tax_query[] = [
+                'taxonomy' => 'fp_exp_duration',
+                'field' => 'slug',
+                'terms' => $state['duration'],
+                'operator' => 'IN',
+            ];
+        }
+
+        if (! empty($state['family'])) {
+            $tax_query[] = [
+                'taxonomy' => 'fp_exp_family_friendly',
+                'operator' => 'EXISTS',
+            ];
+        }
+
+        if (! empty($tax_query)) {
+            $args['tax_query'] = $tax_query;
+        }
+
+        return $args;
+    }
+
+    /**
+     * @param array<int> $ids
+     *
+     * @return array<int, float>
+     */
+    private function load_prices(array $ids): array
+    {
+        $prices = [];
+
+        foreach ($ids as $id) {
+            $prices[$id] = $this->get_price_from_cache($id);
+        }
+
+        return $prices;
+    }
+
+    /**
+     * @return array{min: float|null, max: float|null}
+     */
+    private function determine_price_range(array $prices): array
+    {
+        $values = array_filter($prices, static fn ($value): bool => null !== $value && $value >= 0);
+
+        if (empty($values)) {
+            return ['min' => null, 'max' => null];
+        }
+
+        return [
+            'min' => (float) min($values),
+            'max' => (float) max($values),
+        ];
+    }
+
+    /**
+     * @param array<int> $ids
+     * @param array<int, float|null> $prices
+     *
+     * @return array<int>
+     */
+    private function filter_by_price(array $ids, array $prices, float $min, float $max): array
+    {
+        return array_values(array_filter(
+            $ids,
+            static function (int $id) use ($prices, $min, $max): bool {
+                $price = $prices[$id] ?? null;
+                if (null === $price) {
+                    return false;
+                }
+
+                return $price >= $min && $price <= $max;
+            }
+        ));
+    }
+
+    /**
+     * @param array<int> $ids
+     * @param array<int, float|null> $prices
+     *
+     * @return array<int>
+     */
+    private function sort_by_price(array $ids, array $prices, string $order): array
+    {
+        $sorted = $ids;
+
+        usort($sorted, static function (int $a, int $b) use ($prices, $order): int {
+            $price_a = $prices[$a] ?? null;
+            $price_b = $prices[$b] ?? null;
+
+            if (null === $price_a && null === $price_b) {
+                return 0;
+            }
+
+            if (null === $price_a) {
+                return 'ASC' === $order ? 1 : -1;
+            }
+
+            if (null === $price_b) {
+                return 'ASC' === $order ? -1 : 1;
+            }
+
+            if ($price_a === $price_b) {
+                return 0;
+            }
+
+            return ('ASC' === $order ? 1 : -1) * (($price_a < $price_b) ? -1 : 1);
+        });
+
+        return $sorted;
+    }
+
+    /**
+     * @param array<int> $ids
+     * @param array<int, float|null> $prices
+     * @param array<string, bool> $badge_flags
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function map_experiences(array $ids, array $prices, bool $show_price_from, array $badge_flags, bool $show_map, string $cta_mode): array
+    {
+        if (empty($ids)) {
+            return [];
+        }
+
+        $posts = get_posts([
+            'post_type' => 'fp_experience',
+            'post__in' => $ids,
+            'orderby' => 'post__in',
+            'numberposts' => count($ids),
+        ]);
+
+        $experiences = [];
+
+        foreach ($posts as $post) {
+            if (! $post instanceof WP_Post) {
+                continue;
+            }
+
+            $experience = $this->map_experience($post, $prices[$post->ID] ?? null, $show_price_from, $badge_flags, $show_map, $cta_mode);
+
+            if (! empty($experience)) {
+                $experiences[] = $experience;
+            }
+        }
+
+        return $experiences;
     }
 
     /**
      * @return array<string, mixed>
      */
-    private function map_experience(WP_Post $post): array
+    private function map_experience(WP_Post $post, ?float $price_from, bool $show_price_from, array $badge_flags, bool $show_map, string $cta_mode): array
     {
         $id = $post->ID;
-        $gallery_ids = get_post_meta($id, '_fp_gallery_ids', true);
-        $highlights = get_post_meta($id, '_fp_highlights', true);
-        $duration = absint((string) get_post_meta($id, '_fp_duration_minutes', true));
-        $ticket_types = get_post_meta($id, '_fp_ticket_types', true);
-        $languages = get_post_meta($id, '_fp_languages', true);
+        $title = get_the_title($post);
+        $permalink = $this->resolve_permalink($id, $cta_mode);
+        $thumbnail = get_the_post_thumbnail_url($id, 'large') ?: '';
+        $highlights = array_slice(Helpers::get_meta_array($id, '_fp_highlights'), 0, 3);
+        $short_description = sanitize_text_field((string) get_post_meta($id, '_fp_short_desc', true));
+        $duration_minutes = absint((string) get_post_meta($id, '_fp_duration_minutes', true));
+        $languages = Helpers::get_meta_array($id, '_fp_languages');
+        $family_terms = get_the_terms($id, 'fp_exp_family_friendly');
+        $family_friendly = is_array($family_terms) && ! empty($family_terms);
+        $duration_label = $this->format_duration($duration_minutes);
+        $badges = [];
 
-        $price_from = null;
-        if (is_array($ticket_types)) {
-            foreach ($ticket_types as $ticket) {
-                if (! isset($ticket['price'])) {
-                    continue;
-                }
-                $price = (float) $ticket['price'];
-                if ($price <= 0) {
-                    continue;
-                }
-                if (null === $price_from || $price < $price_from) {
-                    $price_from = $price;
-                }
-            }
-        }
-
-        $thumbnail = get_the_post_thumbnail_url($id, 'large');
-        if (! $thumbnail && is_array($gallery_ids) && $gallery_ids) {
-            $thumbnail = get_the_post_thumbnail_url((int) $gallery_ids[0], 'large');
-        }
-
-        $terms = [
-            'theme' => wp_list_pluck(wp_get_post_terms($id, 'theme'), 'name'),
-            'language' => wp_list_pluck(wp_get_post_terms($id, 'language'), 'name'),
-            'duration' => wp_list_pluck(wp_get_post_terms($id, 'duration'), 'name'),
-        ];
-
-        $slots = $this->get_upcoming_slots($id, 6);
-
-        $schema_offers = [];
-        foreach ($slots as $slot) {
-            $schema_offers[] = [
-                '@type' => 'Offer',
-                'availability' => $slot['availability'],
-                'price' => $price_from ?? 0,
-                'priceCurrency' => get_option('woocommerce_currency', 'EUR'),
-                'validFrom' => $slot['start_iso'],
-                'validThrough' => $slot['end_iso'],
+        if ($badge_flags['duration'] && $duration_label) {
+            $badges[] = [
+                'label' => $duration_label,
+                'context' => 'duration',
             ];
         }
 
-        $schema = [
-            '@type' => 'TouristTrip',
-            '@id' => get_permalink($id) . '#tour',
-            'name' => get_the_title($post),
-            'description' => sanitize_text_field((string) get_post_meta($id, '_fp_short_desc', true)),
-            'image' => $thumbnail,
-            'offers' => $schema_offers,
-        ];
+        if ($badge_flags['language'] && ! empty($languages)) {
+            $badges[] = [
+                'label' => implode(', ', $languages),
+                'context' => 'language',
+            ];
+        }
 
-        $duration_label = $this->determine_duration_bucket($duration);
+        if ($badge_flags['family'] && $family_friendly) {
+            $badges[] = [
+                'label' => __('Family friendly', 'fp-experiences'),
+                'context' => 'family',
+            ];
+        }
+
+        $map_url = '';
+        if ($show_map) {
+            $map_url = $this->resolve_map_url($id);
+        }
+
+        $terms = [
+            'theme' => wp_list_pluck(wp_get_post_terms($id, 'fp_exp_theme'), 'name'),
+            'language' => wp_list_pluck(wp_get_post_terms($id, 'fp_exp_language'), 'name'),
+            'duration' => wp_list_pluck(wp_get_post_terms($id, 'fp_exp_duration'), 'name'),
+        ];
 
         return [
             'id' => $id,
-            'title' => get_the_title($post),
-            'permalink' => get_permalink($id),
-            'short_description' => (string) get_post_meta($id, '_fp_short_desc', true),
-            'highlights' => is_array($highlights) ? array_filter($highlights) : [],
-            'duration' => $duration,
-            'duration_label' => $duration_label,
+            'title' => $title,
+            'permalink' => $permalink,
             'thumbnail' => $thumbnail,
-            'price_from' => $price_from,
-            'languages' => is_array($languages) ? array_filter($languages) : [],
+            'highlights' => $highlights,
+            'short_description' => $short_description,
+            'badges' => $badges,
+            'price_from' => $show_price_from ? $price_from : null,
+            'price_from_display' => $show_price_from && null !== $price_from ? number_format_i18n($price_from, 0) : '',
+            'map_url' => $map_url,
+            'family_friendly' => $family_friendly,
+            'languages' => $languages,
+            'duration_minutes' => $duration_minutes,
             'terms' => $terms,
-            'slots' => $slots,
-            'schema' => $schema,
         ];
+    }
+
+    private function resolve_permalink(int $experience_id, string $cta_mode): string
+    {
+        $page_id = absint((string) get_post_meta($experience_id, '_fp_exp_page_id', true));
+
+        if ($page_id > 0) {
+            $url = get_permalink($page_id);
+            if ($url && 'widget' === $cta_mode && $this->page_has_widget_anchor($page_id)) {
+                return $url . '#fp-widget';
+            }
+
+            return $url ?: get_permalink($experience_id);
+        }
+
+        $fallback = get_permalink($experience_id);
+        if (! $fallback) {
+            return '';
+        }
+
+        if ('widget' === $cta_mode) {
+            return $fallback . '#fp-widget';
+        }
+
+        return $fallback;
+    }
+
+    private function page_has_widget_anchor(int $page_id): bool
+    {
+        $content = get_post_field('post_content', $page_id);
+        if (! is_string($content) || '' === $content) {
+            return false;
+        }
+
+        return false !== strpos($content, '[fp_exp_page');
+    }
+
+    private function resolve_map_url(int $experience_id): string
+    {
+        $points = MeetingPointRepository::get_meeting_points_for_experience($experience_id);
+        $primary = $points['primary'];
+        if (! is_array($primary)) {
+            return '';
+        }
+
+        $lat = $primary['lat'] ?? null;
+        $lng = $primary['lng'] ?? null;
+
+        if (is_numeric($lat) && is_numeric($lng)) {
+            return sprintf('https://www.google.com/maps/search/?api=1&query=%s,%s', rawurlencode((string) $lat), rawurlencode((string) $lng));
+        }
+
+        $address = trim((string) ($primary['address'] ?? ''));
+        if ($address) {
+            return sprintf('https://www.google.com/maps/search/?api=1&query=%s', rawurlencode($address));
+        }
+
+        return '';
+    }
+
+    private function format_duration(int $minutes): string
+    {
+        if ($minutes <= 0) {
+            return '';
+        }
+
+        $hours = intdiv($minutes, 60);
+        $remaining = $minutes % 60;
+
+        if ($hours > 0 && $remaining > 0) {
+            return sprintf(__('%1$dh %2$dmin', 'fp-experiences'), $hours, $remaining);
+        }
+
+        if ($hours > 0) {
+            return sprintf(_n('%dh', '%dh', $hours, 'fp-experiences'), $hours);
+        }
+
+        return sprintf(_n('%d minute', '%d minutes', $minutes, 'fp-experiences'), $minutes);
+    }
+
+    /**
+     * @param array<string> $active_filters
+     * @param array<string, mixed> $state
+     *
+     * @return array<string, mixed>
+     */
+    private function build_filters(array $active_filters, array $state, array $price_range): array
+    {
+        $filters = [];
+
+        if (in_array('search', $active_filters, true)) {
+            $filters['search'] = [
+                'value' => $state['search'] ?? '',
+            ];
+        }
+
+        if (in_array('theme', $active_filters, true)) {
+            $filters['theme'] = [
+                'label' => __('Theme', 'fp-experiences'),
+                'choices' => $this->get_term_choices('fp_exp_theme'),
+                'value' => $state['theme'] ?? [],
+            ];
+        }
+
+        if (in_array('language', $active_filters, true)) {
+            $filters['language'] = [
+                'label' => __('Language', 'fp-experiences'),
+                'choices' => $this->get_term_choices('fp_exp_language'),
+                'value' => $state['language'] ?? [],
+            ];
+        }
+
+        if (in_array('duration', $active_filters, true)) {
+            $filters['duration'] = [
+                'label' => __('Duration', 'fp-experiences'),
+                'choices' => $this->get_term_choices('fp_exp_duration'),
+                'value' => $state['duration'] ?? [],
+            ];
+        }
+
+        if (in_array('price', $active_filters, true) && null !== $price_range['min'] && null !== $price_range['max']) {
+            $filters['price'] = [
+                'label' => __('Price range', 'fp-experiences'),
+                'min' => $price_range['min'],
+                'max' => $price_range['max'],
+                'value' => [
+                    'min' => $state['price_min'] ?? $price_range['min'],
+                    'max' => $state['price_max'] ?? $price_range['max'],
+                ],
+            ];
+        }
+
+        if (in_array('family', $active_filters, true)) {
+            $filters['family'] = [
+                'label' => __('Family friendly', 'fp-experiences'),
+                'value' => ! empty($state['family']),
+            ];
+        }
+
+        if (in_array('date', $active_filters, true)) {
+            $filters['date'] = [
+                'label' => __('Date', 'fp-experiences'),
+                'value' => $state['date'] ?? '',
+            ];
+        }
+
+        return $filters;
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    private function get_term_choices(string $taxonomy): array
+    {
+        $terms = get_terms([
+            'taxonomy' => $taxonomy,
+            'hide_empty' => true,
+        ]);
+
+        if (is_wp_error($terms) || empty($terms)) {
+            return [];
+        }
+
+        $choices = [];
+        foreach ($terms as $term) {
+            $choices[] = [
+                'slug' => $term->slug,
+                'name' => $term->name,
+            ];
+        }
+
+        return $choices;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function read_filter_state(array $active_filters, array $attributes, string $order, string $orderby, string $view_default): array
+    {
+        $state = [];
+        $query = isset($_GET) && is_array($_GET) ? wp_unslash($_GET) : [];
+
+        $state['page'] = $this->normalize_positive_int($query[self::LISTING_PARAM_PREFIX . 'page'] ?? $attributes['page'] ?? '1', 1);
+        $state['view'] = $this->normalize_view($query[self::LISTING_PARAM_PREFIX . 'view'] ?? $attributes['view'] ?? $view_default);
+        $state['order'] = $this->normalize_order($query[self::LISTING_PARAM_PREFIX . 'order'] ?? $order);
+        $state['orderby'] = $this->normalize_orderby($query[self::LISTING_PARAM_PREFIX . 'orderby'] ?? $orderby);
+
+        if (in_array('search', $active_filters, true)) {
+            $state['search'] = sanitize_text_field((string) ($query[self::LISTING_PARAM_PREFIX . 'search'] ?? $attributes['search'] ?? ''));
+        }
+
+        foreach (['theme', 'language', 'duration'] as $filter) {
+            if (! in_array($filter, $active_filters, true)) {
+                continue;
+            }
+
+            $key = self::LISTING_PARAM_PREFIX . $filter;
+            $value = $query[$key] ?? [];
+            if (! is_array($value)) {
+                $value = '' !== $value ? [$value] : [];
+            }
+
+            $state[$filter] = array_values(array_filter(array_map(static function ($item): string {
+                $item = is_string($item) ? $item : '';
+                $item = sanitize_key($item);
+
+                return $item;
+            }, $value)));
+        }
+
+        if (in_array('price', $active_filters, true)) {
+            $min = isset($query[self::LISTING_PARAM_PREFIX . 'price_min']) ? (float) $query[self::LISTING_PARAM_PREFIX . 'price_min'] : null;
+            $max = isset($query[self::LISTING_PARAM_PREFIX . 'price_max']) ? (float) $query[self::LISTING_PARAM_PREFIX . 'price_max'] : null;
+            if (null !== $min && null !== $max && $max >= $min) {
+                $state['price_min'] = max(0.0, $min);
+                $state['price_max'] = max(0.0, $max);
+            }
+        }
+
+        if (in_array('family', $active_filters, true)) {
+            $state['family'] = ! empty($query[self::LISTING_PARAM_PREFIX . 'family']);
+        }
+
+        if (in_array('date', $active_filters, true)) {
+            $date_value = (string) ($query[self::LISTING_PARAM_PREFIX . 'date'] ?? '');
+            if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $date_value)) {
+                $state['date'] = $date_value;
+            }
+        }
+
+        return $state;
+    }
+
+    private function normalize_positive_int($value, int $fallback): int
+    {
+        $value = absint((string) $value);
+
+        return $value > 0 ? $value : $fallback;
+    }
+
+    private function normalize_filters(string $attribute, array $default): array
+    {
+        if ('' === $attribute) {
+            return $default;
+        }
+
+        $parts = array_map('trim', explode(',', $attribute));
+        $filters = [];
+
+        foreach ($parts as $part) {
+            $part = sanitize_key($part);
+            if ($part && in_array($part, self::ALLOWED_FILTERS, true)) {
+                $filters[] = $part;
+            }
+        }
+
+        return $filters ?: $default;
+    }
+
+    private function normalize_view(string $view): string
+    {
+        $view = strtolower($view);
+        if (! in_array($view, ['grid', 'list'], true)) {
+            return 'grid';
+        }
+
+        return $view;
+    }
+
+    private function normalize_order($order): string
+    {
+        $order = strtoupper(sanitize_key((string) $order));
+
+        if (! in_array($order, self::ALLOWED_ORDER, true)) {
+            return 'ASC';
+        }
+
+        return $order;
+    }
+
+    private function normalize_orderby($orderby): string
+    {
+        $orderby = sanitize_key((string) $orderby);
+
+        if (! in_array($orderby, self::ALLOWED_ORDERBY, true)) {
+            return 'menu_order';
+        }
+
+        return $orderby;
+    }
+
+    private function normalize_bool($value, bool $fallback): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_numeric($value)) {
+            return (int) $value > 0;
+        }
+
+        if (is_string($value)) {
+            $value = strtolower(trim($value));
+            if ('' === $value) {
+                return $fallback;
+            }
+
+            return in_array($value, ['1', 'yes', 'true', 'on'], true);
+        }
+
+        return $fallback;
+    }
+
+    private function normalize_cta(string $cta): string
+    {
+        $cta = strtolower(sanitize_key($cta));
+
+        return in_array($cta, ['page', 'widget'], true) ? $cta : 'page';
+    }
+
+    private function normalize_column_setting($value): int
+    {
+        $value = absint((string) $value);
+
+        if ($value < 1 || $value > 4) {
+            return 0;
+        }
+
+        return $value;
+    }
+
+    private function normalize_gap_setting($value): string
+    {
+        $value = sanitize_key((string) $value);
+
+        $allowed = ['compact', 'cozy', 'spacious'];
+
+        return in_array($value, $allowed, true) ? $value : '';
     }
 
     /**
      * @return array<int, array<string, mixed>>
      */
-    private function get_upcoming_slots(int $experience_id, int $limit = 6): array
+    private function build_tracking_items(array $ids, array $prices): array
     {
-        global $wpdb;
-
-        $table = Slots::table_name();
-        $now = gmdate('Y-m-d H:i:s');
-
-        $sql = $wpdb->prepare(
-            "SELECT id, start_datetime, end_datetime, capacity_total FROM {$table} " .
-            "WHERE experience_id = %d AND status = %s AND start_datetime >= %s ORDER BY start_datetime ASC LIMIT %d",
-            $experience_id,
-            Slots::STATUS_OPEN,
-            $now,
-            $limit
-        );
-
-        $rows = $wpdb->get_results($sql, ARRAY_A);
-        if (! $rows) {
-            return [];
-        }
-
-        $timezone = wp_timezone();
-        $slots = [];
-
-        foreach ($rows as $row) {
-            try {
-                $start = new DateTimeImmutable((string) $row['start_datetime'], new DateTimeZone('UTC'));
-                $end = new DateTimeImmutable((string) $row['end_datetime'], new DateTimeZone('UTC'));
-            } catch (Exception $exception) {
-                continue;
-            }
-
-            $snapshot = Slots::get_capacity_snapshot((int) $row['id']);
-            $remaining = max(0, (int) $row['capacity_total'] - $snapshot['total']);
-
-            $slots[] = [
-                'id' => (int) $row['id'],
-                'start' => $start->setTimezone($timezone)->format('Y-m-d H:i'),
-                'start_iso' => $start->setTimezone($timezone)->format(DateTimeInterface::ATOM),
-                'end_iso' => $end->setTimezone($timezone)->format(DateTimeInterface::ATOM),
-                'remaining' => $remaining,
-                'availability' => $remaining > 0 ? 'https://schema.org/InStock' : 'https://schema.org/SoldOut',
+        $items = [];
+        foreach ($ids as $position => $id) {
+            $items[] = [
+                'item_id' => (string) $id,
+                'item_name' => get_the_title($id),
+                'index' => $position + 1,
+                'price' => isset($prices[$id]) && null !== $prices[$id] ? $prices[$id] : null,
             ];
         }
 
-        return $slots;
+        return $items;
     }
 
     /**
      * @param array<int, array<string, mixed>> $experiences
-     *
-     * @return array<string, mixed>
      */
-    private function prepare_filters(string $filter_string, array $experiences): array
+    private function build_schema(array $experiences): string
     {
-        $available = array_map('trim', explode(',', $filter_string));
-
-        $filters = [];
-
-        foreach ($available as $filter) {
-            $key = sanitize_key($filter);
-            if (! $key) {
-                continue;
-            }
-
-            switch ($key) {
-                case 'theme':
-                    $filters['theme'] = $this->collect_terms($experiences, 'theme');
-                    break;
-                case 'duration':
-                    $filters['duration'] = $this->collect_durations($experiences);
-                    break;
-                case 'price':
-                    $filters['price'] = $this->collect_price_range($experiences);
-                    break;
-            }
-        }
-
-        return array_filter($filters);
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $experiences
-     *
-     * @return array<int, string>
-     */
-    private function collect_terms(array $experiences, string $taxonomy): array
-    {
-        $values = [];
-        foreach ($experiences as $experience) {
-            $terms = $experience['terms'][$taxonomy] ?? [];
-            foreach ($terms as $term) {
-                $values[$term] = $term;
-            }
-        }
-
-        return array_values($values);
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $experiences
-     *
-     * @return array<int, string>
-     */
-    private function collect_durations(array $experiences): array
-    {
-        $buckets = [];
-        foreach ($experiences as $experience) {
-            $duration = (int) ($experience['duration'] ?? 0);
-            if ($duration <= 0) {
-                continue;
-            }
-
-            $label = $this->determine_duration_bucket($duration);
-
-            if ($label) {
-                $buckets[$label] = $label;
-            }
-        }
-
-        return array_values($buckets);
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $experiences
-     *
-     * @return array{min:float|null,max:float|null}
-     */
-    private function collect_price_range(array $experiences): array
-    {
-        $min = null;
-        $max = null;
-
-        foreach ($experiences as $experience) {
-            $price = $experience['price_from'] ?? null;
-
-            if (! is_numeric($price)) {
-                continue;
-            }
-
-            $price = (float) $price;
-
-            if (null === $min || $price < $min) {
-                $min = $price;
-            }
-
-            if (null === $max || $price > $max) {
-                $max = $price;
-            }
-        }
-
-        return [
-            'min' => $min,
-            'max' => $max,
-        ];
-    }
-
-    private function determine_duration_bucket(int $duration): string
-    {
-        if ($duration <= 0) {
+        if (empty($experiences)) {
             return '';
         }
 
-        if ($duration <= 90) {
-            return __('Up to 1.5h', 'fp-experiences');
+        $offers = [];
+        foreach ($experiences as $experience) {
+            if (! isset($experience['price_from']) || null === $experience['price_from']) {
+                continue;
+            }
+
+            $offers[] = [
+                '@type' => 'Offer',
+                'price' => $experience['price_from'],
+                'priceCurrency' => Helpers::currency_code(),
+                'availability' => 'https://schema.org/InStock',
+                'itemOffered' => [
+                    '@type' => 'Product',
+                    'name' => $experience['title'],
+                    'url' => $experience['permalink'],
+                ],
+            ];
         }
 
-        if ($duration <= 180) {
-            return __('Up to 3h', 'fp-experiences');
+        if (empty($offers)) {
+            return '';
         }
 
-        return __('Full day', 'fp-experiences');
+        return wp_json_encode([
+            '@context' => 'https://schema.org',
+            '@type' => 'ItemList',
+            'itemListElement' => array_map(
+                static fn (array $offer, int $index): array => [
+                    '@type' => 'ListItem',
+                    'position' => $index + 1,
+                    'item' => $offer['itemOffered'],
+                ],
+                $offers,
+                array_keys($offers)
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function build_pagination_links(int $current_page, int $total_pages, array $state): array
+    {
+        if ($total_pages <= 1) {
+            return [];
+        }
+
+        $links = [];
+        $base_url = $this->current_url();
+        $base_url = remove_query_arg(self::LISTING_PARAM_PREFIX . 'page', $base_url);
+
+        for ($page = 1; $page <= $total_pages; ++$page) {
+            $query_args = $this->build_query_from_state($state, $page);
+            $url = add_query_arg($query_args, $base_url);
+            $links[] = [
+                'page' => $page,
+                'url' => $url,
+                'is_current' => $page === $current_page,
+            ];
+        }
+
+        return $links;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function build_query_from_state(array $state, int $page): array
+    {
+        $args = [];
+
+        $args[self::LISTING_PARAM_PREFIX . 'page'] = $page;
+        $args[self::LISTING_PARAM_PREFIX . 'view'] = $state['view'] ?? 'grid';
+        $args[self::LISTING_PARAM_PREFIX . 'order'] = $state['order'] ?? 'ASC';
+        $args[self::LISTING_PARAM_PREFIX . 'orderby'] = $state['orderby'] ?? 'menu_order';
+
+        if (! empty($state['search'])) {
+            $args[self::LISTING_PARAM_PREFIX . 'search'] = $state['search'];
+        }
+
+        foreach (['theme', 'language', 'duration'] as $filter) {
+            if (! empty($state[$filter]) && is_array($state[$filter])) {
+                $args[self::LISTING_PARAM_PREFIX . $filter] = $state[$filter];
+            }
+        }
+
+        if (isset($state['price_min'], $state['price_max'])) {
+            $args[self::LISTING_PARAM_PREFIX . 'price_min'] = $state['price_min'];
+            $args[self::LISTING_PARAM_PREFIX . 'price_max'] = $state['price_max'];
+        }
+
+        if (! empty($state['family'])) {
+            $args[self::LISTING_PARAM_PREFIX . 'family'] = '1';
+        }
+
+        if (! empty($state['date'])) {
+            $args[self::LISTING_PARAM_PREFIX . 'date'] = $state['date'];
+        }
+
+        return $args;
+    }
+
+    private function current_url(): string
+    {
+        $request_uri = isset($_SERVER['REQUEST_URI']) ? sanitize_text_field(wp_unslash($_SERVER['REQUEST_URI'])) : '/';
+
+        return home_url($request_uri);
+    }
+
+    private function get_price_from_cache(int $experience_id): ?float
+    {
+        $key = self::PRICE_TRANSIENT_PREFIX . $experience_id;
+        $cached = get_transient($key);
+        if (false !== $cached) {
+            if ('none' === $cached) {
+                return null;
+            }
+
+            return is_numeric($cached) ? (float) $cached : null;
+        }
+
+        $price = $this->calculate_price_from_meta($experience_id);
+        if (null !== $price) {
+            set_transient($key, $price, DAY_IN_SECONDS);
+        } else {
+            set_transient($key, 'none', DAY_IN_SECONDS);
+        }
+
+        return $price;
+    }
+
+    private function calculate_price_from_meta(int $experience_id): ?float
+    {
+        $tickets = get_post_meta($experience_id, '_fp_ticket_types', true);
+        if (! is_array($tickets) || empty($tickets)) {
+            return null;
+        }
+
+        $min_price = null;
+        foreach ($tickets as $ticket) {
+            if (! is_array($ticket) || ! isset($ticket['price'])) {
+                continue;
+            }
+
+            $price = (float) $ticket['price'];
+            if ($price <= 0) {
+                continue;
+            }
+
+            if (null === $min_price || $price < $min_price) {
+                $min_price = $price;
+            }
+        }
+
+        return $min_price;
     }
 }

--- a/templates/front/list.php
+++ b/templates/front/list.php
@@ -1,9 +1,14 @@
 <?php
 /**
- * Experiences list template.
+ * Experiences listing template.
  *
  * @var array<int, array<string, mixed>> $experiences
  * @var array<string, mixed>             $filters
+ * @var array<string, mixed>             $state
+ * @var string                           $view
+ * @var int                              $total
+ * @var array<int, array<string, mixed>> $pagination_links
+ * @var array<int, array<string, mixed>> $tracking_items
  * @var string                           $scope_class
  * @var string                           $schema_json
  */
@@ -12,109 +17,300 @@ if (! defined('ABSPATH')) {
     exit;
 }
 
+use function add_query_arg;
+use function esc_attr;
+use function esc_html;
+use function esc_html_e;
+use function esc_url;
+use function number_format_i18n;
+use function remove_query_arg;
+use function wp_json_encode;
+use function _n;
 
-$container_classes = 'fp-exp fp-exp-list ' . esc_attr($scope_class);
+$layout = isset($layout) && is_array($layout) ? $layout : [];
+$layout_classes = [];
+
+if (! empty($layout['desktop'])) {
+    $layout_classes[] = 'fp-listing--cols-desktop-' . (int) $layout['desktop'];
+}
+
+if (! empty($layout['tablet'])) {
+    $layout_classes[] = 'fp-listing--cols-tablet-' . (int) $layout['tablet'];
+}
+
+if (! empty($layout['mobile'])) {
+    $layout_classes[] = 'fp-listing--cols-mobile-' . (int) $layout['mobile'];
+}
+
+if (! empty($layout['gap'])) {
+    $layout_classes[] = 'fp-listing--gap-' . preg_replace('/[^a-z0-9_-]/i', '', $layout['gap']);
+}
+
+$container_classes = 'fp-exp ' . esc_attr($scope_class) . ' fp-listing fp-listing--' . esc_attr($view);
+if ($layout_classes) {
+    $container_classes .= ' ' . esc_attr(implode(' ', $layout_classes));
+}
+$tracking_json = ! empty($tracking_items) ? wp_json_encode($tracking_items) : '';
+$base_view_url = remove_query_arg(['fp_exp_view', 'fp_exp_page']);
+$grid_url = add_query_arg(['fp_exp_view' => 'grid', 'fp_exp_page' => 1], $base_view_url);
+$list_url = add_query_arg(['fp_exp_view' => 'list', 'fp_exp_page' => 1], $base_view_url);
+$current_order = isset($state['order']) ? (string) $state['order'] : 'ASC';
+$current_orderby = isset($state['orderby']) ? (string) $state['orderby'] : 'menu_order';
+$current_view = isset($state['view']) ? (string) $state['view'] : $view;
+$current_page = isset($state['page']) ? (int) $state['page'] : 1;
+$results_label = sprintf(
+    _n('%d experience found', '%d experiences found', (int) $total, 'fp-experiences'),
+    (int) $total
+);
 ?>
-<section class="<?php echo $container_classes; ?>" data-fp-shortcode="list">
-    <header class="fp-exp-list__header">
-        <h2 class="fp-exp-list__title"><?php echo esc_html__('Experiences', 'fp-experiences'); ?></h2>
-        <?php if (! empty($filters)) : ?>
-            <div class="fp-exp-list__filters" role="region" aria-label="<?php echo esc_attr__('Filters', 'fp-experiences'); ?>">
-                <?php if (! empty($filters['theme'])) : ?>
-                    <div class="fp-exp-filter fp-exp-filter--theme">
-                        <span class="fp-exp-filter__label"><?php echo esc_html__('Theme', 'fp-experiences'); ?></span>
-                        <ul class="fp-exp-filter__choices">
-                            <?php foreach ($filters['theme'] as $theme) : ?>
-                                <li class="fp-exp-filter__choice" data-filter-type="theme" data-filter-value="<?php echo esc_attr($theme); ?>"><?php echo esc_html($theme); ?></li>
-                            <?php endforeach; ?>
-                        </ul>
+<section
+    class="<?php echo $container_classes; ?>"
+    data-fp-shortcode="list"
+    data-fp-list-view="<?php echo esc_attr($current_view); ?>"
+    <?php if ($tracking_json) : ?>data-fp-items='<?php echo esc_attr($tracking_json); ?>'<?php endif; ?>
+>
+    <header class="fp-listing__header">
+        <div class="fp-listing__intro">
+            <h2 class="fp-listing__title"><?php esc_html_e('Experiences', 'fp-experiences'); ?></h2>
+            <p class="fp-listing__count" aria-live="polite"><?php echo esc_html($results_label); ?></p>
+        </div>
+        <div class="fp-listing__controls">
+            <form class="fp-listing__filters" method="get">
+                <input type="hidden" name="fp_exp_page" value="1" />
+                <input type="hidden" name="fp_exp_view" value="<?php echo esc_attr($current_view); ?>" />
+                <?php if (isset($filters['search'])) : ?>
+                    <div class="fp-listing__field fp-listing__field--search">
+                        <label class="fp-listing__label" for="fp-exp-search"><?php esc_html_e('Search', 'fp-experiences'); ?></label>
+                        <input
+                            type="search"
+                            id="fp-exp-search"
+                            name="fp_exp_search"
+                            class="fp-listing__input"
+                            value="<?php echo esc_attr((string) ($filters['search']['value'] ?? '')); ?>"
+                            placeholder="<?php esc_attr_e('Search experiences…', 'fp-experiences'); ?>"
+                        />
                     </div>
                 <?php endif; ?>
-                <?php if (! empty($filters['duration'])) : ?>
-                    <div class="fp-exp-filter fp-exp-filter--duration">
-                        <span class="fp-exp-filter__label"><?php echo esc_html__('Duration', 'fp-experiences'); ?></span>
-                        <ul class="fp-exp-filter__choices">
-                            <?php foreach ($filters['duration'] as $duration_label) : ?>
-                                <li class="fp-exp-filter__choice" data-filter-type="duration" data-filter-value="<?php echo esc_attr($duration_label); ?>"><?php echo esc_html($duration_label); ?></li>
+
+                <?php if (isset($filters['theme'])) : ?>
+                    <div class="fp-listing__field">
+                        <label class="fp-listing__label" for="fp-exp-theme"><?php esc_html_e('Theme', 'fp-experiences'); ?></label>
+                        <select id="fp-exp-theme" name="fp_exp_theme[]" class="fp-listing__select" multiple>
+                            <?php foreach ($filters['theme']['choices'] as $choice) : ?>
+                                <option value="<?php echo esc_attr($choice['slug']); ?>" <?php selected(in_array($choice['slug'], (array) ($filters['theme']['value'] ?? []), true)); ?>>
+                                    <?php echo esc_html($choice['name']); ?>
+                                </option>
                             <?php endforeach; ?>
-                        </ul>
+                        </select>
                     </div>
                 <?php endif; ?>
-                <?php if (! empty($filters['price']['min']) && ! empty($filters['price']['max'])) : ?>
-                    <div class="fp-exp-filter fp-exp-filter--price" data-price-min="<?php echo esc_attr((string) $filters['price']['min']); ?>" data-price-max="<?php echo esc_attr((string) $filters['price']['max']); ?>">
-                        <span class="fp-exp-filter__label"><?php echo esc_html__('Price range', 'fp-experiences'); ?></span>
-                        <div class="fp-exp-filter__range">
-                            <span class="fp-exp-filter__range-value" data-role="min">€<?php echo esc_html(number_format_i18n((float) $filters['price']['min'], 2)); ?></span>
-                            <span class="fp-exp-filter__range-separator" aria-hidden="true">—</span>
-                            <span class="fp-exp-filter__range-value" data-role="max">€<?php echo esc_html(number_format_i18n((float) $filters['price']['max'], 2)); ?></span>
+
+                <?php if (isset($filters['language'])) : ?>
+                    <div class="fp-listing__field">
+                        <label class="fp-listing__label" for="fp-exp-language"><?php esc_html_e('Language', 'fp-experiences'); ?></label>
+                        <select id="fp-exp-language" name="fp_exp_language[]" class="fp-listing__select" multiple>
+                            <?php foreach ($filters['language']['choices'] as $choice) : ?>
+                                <option value="<?php echo esc_attr($choice['slug']); ?>" <?php selected(in_array($choice['slug'], (array) ($filters['language']['value'] ?? []), true)); ?>>
+                                    <?php echo esc_html($choice['name']); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                <?php endif; ?>
+
+                <?php if (isset($filters['duration'])) : ?>
+                    <div class="fp-listing__field">
+                        <label class="fp-listing__label" for="fp-exp-duration"><?php esc_html_e('Duration', 'fp-experiences'); ?></label>
+                        <select id="fp-exp-duration" name="fp_exp_duration[]" class="fp-listing__select" multiple>
+                            <?php foreach ($filters['duration']['choices'] as $choice) : ?>
+                                <option value="<?php echo esc_attr($choice['slug']); ?>" <?php selected(in_array($choice['slug'], (array) ($filters['duration']['value'] ?? []), true)); ?>>
+                                    <?php echo esc_html($choice['name']); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                <?php endif; ?>
+
+                <?php if (isset($filters['price'])) :
+                    $price_min = max(0.0, (float) ($filters['price']['min'] ?? 0));
+                    $price_max = max($price_min, (float) ($filters['price']['max'] ?? 0));
+                    $current_min_price = max($price_min, (float) ($filters['price']['value']['min'] ?? $price_min));
+                    $current_max_price = max($current_min_price, (float) ($filters['price']['value']['max'] ?? $price_max));
+                    ?>
+                    <div class="fp-listing__field fp-listing__field--range">
+                        <span class="fp-listing__label"><?php esc_html_e('Price range (€)', 'fp-experiences'); ?></span>
+                        <div class="fp-listing__range-inputs">
+                            <label>
+                                <span class="screen-reader-text"><?php esc_html_e('Minimum price', 'fp-experiences'); ?></span>
+                                <input
+                                    type="number"
+                                    name="fp_exp_price_min"
+                                    class="fp-listing__input"
+                                    min="<?php echo esc_attr((string) $price_min); ?>"
+                                    max="<?php echo esc_attr((string) $price_max); ?>"
+                                    value="<?php echo esc_attr((string) $current_min_price); ?>"
+                                />
+                            </label>
+                            <label>
+                                <span class="screen-reader-text"><?php esc_html_e('Maximum price', 'fp-experiences'); ?></span>
+                                <input
+                                    type="number"
+                                    name="fp_exp_price_max"
+                                    class="fp-listing__input"
+                                    min="<?php echo esc_attr((string) $price_min); ?>"
+                                    max="<?php echo esc_attr((string) $price_max); ?>"
+                                    value="<?php echo esc_attr((string) $current_max_price); ?>"
+                                />
+                            </label>
                         </div>
                     </div>
                 <?php endif; ?>
-            </div>
-        <?php endif; ?>
-    </header>
-    <div class="fp-exp-list__grid" role="list">
-        <?php foreach ($experiences as $experience) : ?>
-            <article
-                class="fp-exp-card"
-                role="listitem"
-                data-experience-id="<?php echo esc_attr((string) $experience['id']); ?>"
-                data-price-from="<?php echo esc_attr((string) ($experience['price_from'] ?? 0)); ?>"
-                data-themes="<?php echo esc_attr(implode('|', $experience['terms']['theme'] ?? [])); ?>"
-                data-duration-label="<?php echo esc_attr($experience['duration_label'] ?? ''); ?>"
-            >
-                <a class="fp-exp-card__link" href="<?php echo esc_url($experience['permalink']); ?>">
-                    <div class="fp-exp-card__media" aria-hidden="true">
-                        <?php if (! empty($experience['thumbnail'])) : ?>
-                            <span class="fp-exp-card__thumbnail" style="background-image:url('<?php echo esc_url($experience['thumbnail']); ?>');"></span>
-                        <?php else : ?>
-                            <span class="fp-exp-card__thumbnail fp-exp-card__thumbnail--placeholder"></span>
-                        <?php endif; ?>
-                        <?php if (! empty($experience['price_from'])) : ?>
-                            <span class="fp-exp-card__price-tag"><?php echo esc_html__('From', 'fp-experiences'); ?> €<?php echo esc_html(number_format_i18n((float) $experience['price_from'], 2)); ?></span>
-                        <?php endif; ?>
+
+                <?php if (isset($filters['family'])) : ?>
+                    <div class="fp-listing__field fp-listing__field--checkbox">
+                        <label class="fp-listing__checkbox">
+                            <input type="checkbox" name="fp_exp_family" value="1" <?php checked(! empty($filters['family']['value'])); ?> />
+                            <span><?php esc_html_e('Family-friendly only', 'fp-experiences'); ?></span>
+                        </label>
                     </div>
-                    <div class="fp-exp-card__body">
-                        <h3 class="fp-exp-card__title"><?php echo esc_html($experience['title']); ?></h3>
-                        <?php if (! empty($experience['short_description'])) : ?>
-                            <p class="fp-exp-card__excerpt"><?php echo esc_html($experience['short_description']); ?></p>
+                <?php endif; ?>
+
+                <?php if (isset($filters['date'])) : ?>
+                    <div class="fp-listing__field">
+                        <label class="fp-listing__label" for="fp-exp-date"><?php esc_html_e('Date', 'fp-experiences'); ?></label>
+                        <input
+                            type="date"
+                            id="fp-exp-date"
+                            name="fp_exp_date"
+                            class="fp-listing__input"
+                            value="<?php echo esc_attr((string) ($filters['date']['value'] ?? '')); ?>"
+                        />
+                    </div>
+                <?php endif; ?>
+
+                <div class="fp-listing__field fp-listing__field--sort">
+                    <label class="fp-listing__label" for="fp-exp-orderby"><?php esc_html_e('Sort by', 'fp-experiences'); ?></label>
+                    <select id="fp-exp-orderby" name="fp_exp_orderby" class="fp-listing__select">
+                        <option value="menu_order" <?php selected('menu_order' === $current_orderby); ?>><?php esc_html_e('Featured', 'fp-experiences'); ?></option>
+                        <option value="date" <?php selected('date' === $current_orderby); ?>><?php esc_html_e('Publish date', 'fp-experiences'); ?></option>
+                        <option value="title" <?php selected('title' === $current_orderby); ?>><?php esc_html_e('Title', 'fp-experiences'); ?></option>
+                        <option value="price" <?php selected('price' === $current_orderby); ?>><?php esc_html_e('Price', 'fp-experiences'); ?></option>
+                    </select>
+                </div>
+
+                <div class="fp-listing__field fp-listing__field--order">
+                    <label class="fp-listing__label" for="fp-exp-order"><?php esc_html_e('Order', 'fp-experiences'); ?></label>
+                    <select id="fp-exp-order" name="fp_exp_order" class="fp-listing__select">
+                        <option value="ASC" <?php selected('ASC' === $current_order); ?>><?php esc_html_e('Ascending', 'fp-experiences'); ?></option>
+                        <option value="DESC" <?php selected('DESC' === $current_order); ?>><?php esc_html_e('Descending', 'fp-experiences'); ?></option>
+                    </select>
+                </div>
+
+                <div class="fp-listing__actions">
+                    <button type="submit" class="fp-listing__submit"><?php esc_html_e('Apply filters', 'fp-experiences'); ?></button>
+                    <a class="fp-listing__reset" href="<?php echo esc_url(remove_query_arg(['fp_exp_theme', 'fp_exp_language', 'fp_exp_duration', 'fp_exp_price_min', 'fp_exp_price_max', 'fp_exp_family', 'fp_exp_date', 'fp_exp_search', 'fp_exp_page'], $base_view_url)); ?>"><?php esc_html_e('Reset', 'fp-experiences'); ?></a>
+                </div>
+            </form>
+            <div class="fp-listing__view" role="group" aria-label="<?php esc_attr_e('Change layout', 'fp-experiences'); ?>">
+                <a class="fp-listing__view-toggle<?php echo 'grid' === $current_view ? ' is-active' : ''; ?>" href="<?php echo esc_url($grid_url); ?>"><?php esc_html_e('Grid', 'fp-experiences'); ?></a>
+                <a class="fp-listing__view-toggle<?php echo 'list' === $current_view ? ' is-active' : ''; ?>" href="<?php echo esc_url($list_url); ?>"><?php esc_html_e('List', 'fp-experiences'); ?></a>
+            </div>
+        </div>
+    </header>
+
+    <?php if (empty($experiences)) : ?>
+        <p class="fp-listing__empty"><?php esc_html_e('No experiences match your filters. Try adjusting your search.', 'fp-experiences'); ?></p>
+    <?php else : ?>
+        <div class="fp-listing__grid fp-listing__grid--<?php echo esc_attr($current_view); ?>">
+            <?php foreach ($experiences as $experience) : ?>
+                <article
+                    class="fp-listing__card"
+                    data-experience-id="<?php echo esc_attr((string) $experience['id']); ?>"
+                    data-experience-name="<?php echo esc_attr($experience['title']); ?>"
+                    data-experience-price="<?php echo esc_attr((string) ($experience['price_from'] ?? '')); ?>"
+                >
+                    <a class="fp-listing__media" href="<?php echo esc_url($experience['permalink']); ?>">
+                        <?php if (! empty($experience['thumbnail'])) : ?>
+                            <img
+                                src="<?php echo esc_url($experience['thumbnail']); ?>"
+                                alt=""
+                                loading="lazy"
+                                class="fp-listing__image"
+                            />
+                        <?php else : ?>
+                            <span class="fp-listing__image fp-listing__image--placeholder" aria-hidden="true"></span>
+                        <?php endif; ?>
+                        <?php if (! empty($experience['price_from_display'])) : ?>
+                            <span class="fp-listing__price-tag"><?php printf(esc_html__('From €%s', 'fp-experiences'), esc_html($experience['price_from_display'])); ?></span>
+                        <?php endif; ?>
+                    </a>
+                    <div class="fp-listing__body">
+                        <h3 class="fp-listing__name">
+                            <a href="<?php echo esc_url($experience['permalink']); ?>"><?php echo esc_html($experience['title']); ?></a>
+                        </h3>
+                        <?php if (! empty($experience['badges'])) : ?>
+                            <ul class="fp-listing__badges">
+                                <?php foreach ($experience['badges'] as $badge) : ?>
+                                    <li class="fp-listing__badge fp-listing__badge--<?php echo esc_attr($badge['context']); ?>"><?php echo esc_html($badge['label']); ?></li>
+                                <?php endforeach; ?>
+                            </ul>
                         <?php endif; ?>
                         <?php if (! empty($experience['highlights'])) : ?>
-                            <ul class="fp-exp-card__highlights">
+                            <ul class="fp-listing__highlights">
                                 <?php foreach ($experience['highlights'] as $highlight) : ?>
                                     <li><?php echo esc_html($highlight); ?></li>
                                 <?php endforeach; ?>
                             </ul>
+                        <?php elseif (! empty($experience['short_description'])) : ?>
+                            <p class="fp-listing__excerpt"><?php echo esc_html($experience['short_description']); ?></p>
                         <?php endif; ?>
-                        <dl class="fp-exp-card__meta">
-                            <?php if (! empty($experience['duration'])) : ?>
-                                <div>
-                                    <dt><?php echo esc_html__('Duration', 'fp-experiences'); ?></dt>
-                                    <dd><?php echo esc_html(sprintf(__('About %d minutes', 'fp-experiences'), (int) $experience['duration'])); ?></dd>
-                                </div>
-                            <?php endif; ?>
-                            <?php if (! empty($experience['languages'])) : ?>
-                                <div>
-                                    <dt><?php echo esc_html__('Languages', 'fp-experiences'); ?></dt>
-                                    <dd>
-                                        <?php echo esc_html(implode(', ', $experience['languages'])); ?>
-                                    </dd>
-                                </div>
-                            <?php endif; ?>
-                        </dl>
                     </div>
-                </a>
-                <footer class="fp-exp-card__footer">
-                    <a class="fp-exp-card__cta" href="<?php echo esc_url($experience['permalink']); ?>">
-                        <?php echo esc_html__('View availability', 'fp-experiences'); ?>
-                    </a>
-                </footer>
-            </article>
-        <?php endforeach; ?>
-    </div>
+                    <footer class="fp-listing__footer">
+                        <a class="fp-listing__cta" href="<?php echo esc_url($experience['permalink']); ?>"><?php esc_html_e('Details', 'fp-experiences'); ?></a>
+                        <?php if (! empty($experience['map_url'])) : ?>
+                            <a class="fp-listing__map" href="<?php echo esc_url($experience['map_url']); ?>" target="_blank" rel="noreferrer noopener"><?php esc_html_e('View on map', 'fp-experiences'); ?></a>
+                        <?php endif; ?>
+                    </footer>
+                </article>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <?php if (! empty($pagination_links)) : ?>
+        <nav class="fp-listing__pagination" role="navigation" aria-label="<?php esc_attr_e('Experiences navigation', 'fp-experiences'); ?>">
+            <ul class="fp-listing__pagination-list">
+                <?php
+                $prev = $current_page > 1 ? $pagination_links[$current_page - 2] ?? null : null;
+                $next = $current_page < count($pagination_links) ? $pagination_links[$current_page] ?? null : null;
+                ?>
+                <li class="fp-listing__pagination-item fp-listing__pagination-item--prev<?php echo $prev ? '' : ' is-disabled'; ?>">
+                    <?php if ($prev) : ?>
+                        <a href="<?php echo esc_url($prev['url']); ?>"><?php esc_html_e('Previous', 'fp-experiences'); ?></a>
+                    <?php else : ?>
+                        <span><?php esc_html_e('Previous', 'fp-experiences'); ?></span>
+                    <?php endif; ?>
+                </li>
+                <?php foreach ($pagination_links as $page) : ?>
+                    <li class="fp-listing__pagination-item<?php echo ! empty($page['is_current']) ? ' is-current' : ''; ?>">
+                        <?php if (! empty($page['is_current'])) : ?>
+                            <span aria-current="page"><?php echo esc_html((string) $page['page']); ?></span>
+                        <?php else : ?>
+                            <a href="<?php echo esc_url($page['url']); ?>"><?php echo esc_html((string) $page['page']); ?></a>
+                        <?php endif; ?>
+                    </li>
+                <?php endforeach; ?>
+                <li class="fp-listing__pagination-item fp-listing__pagination-item--next<?php echo $next ? '' : ' is-disabled'; ?>">
+                    <?php if ($next) : ?>
+                        <a href="<?php echo esc_url($next['url']); ?>"><?php esc_html_e('Next', 'fp-experiences'); ?></a>
+                    <?php else : ?>
+                        <span><?php esc_html_e('Next', 'fp-experiences'); ?></span>
+                    <?php endif; ?>
+                </li>
+            </ul>
+        </nav>
+    <?php endif; ?>
+
     <?php if (! empty($schema_json)) : ?>
-        <script type="application/ld+json" class="fp-exp-schema">
-            <?php echo wp_kses_post($schema_json); ?>
-        </script>
+        <script type="application/ld+json" class="fp-exp-schema"><?php echo wp_kses_post($schema_json); ?></script>
     <?php endif; ?>
 </section>


### PR DESCRIPTION
## Summary
- rebuild the `[fp_exp_list]` shortcode to support filters, price caching, pagination, tracking payloads, and layout metadata for the front-end template
- overhaul the listing template, styles, and script hooks to render the new accessible filter form, responsive cards, pagination, and dataLayer events while loading assets only when needed
- extend settings, helpers, Elementor controls, and documentation with showcase defaults, layout toggles, QA steps, and rebuild state updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da8fc3774c832fa51e20fdc75155a7