### PR TITLE
Create unified FP Experiences admin menu

### DIFF
--- a/.rebuild-state.json
+++ b/.rebuild-state.json
@@ -46,8 +46,8 @@
     }
   },
   "rebuild": {
-    "feature": "listing",
-    "step": "DOCS"
+    "feature": "admin-menu",
+    "step": "POLISH"
   },
   "verify_current": "FRONT-BINDING"
 }

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -197,3 +197,128 @@
 .fp-exp-tab-panel textarea {
     width: 100%;
 }
+
+.fp-exp-dashboard {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.fp-exp-dashboard__breadcrumb {
+    font-size: 13px;
+    color: var(--fp-exp-color-muted, #666);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.fp-exp-dashboard__grid {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.fp-exp-dashboard__card {
+    background: #fff;
+    border-radius: 12px;
+    padding: 18px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+}
+
+.fp-exp-dashboard__card-label {
+    margin: 0;
+    font-size: 13px;
+    color: var(--fp-exp-color-muted, #666);
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+}
+
+.fp-exp-dashboard__card-value {
+    margin: 8px 0 0;
+    font-size: 28px;
+    font-weight: 700;
+    color: var(--fp-exp-color-text, #1f1f1f);
+}
+
+.fp-exp-dashboard__card-hint {
+    margin: 6px 0 0;
+    font-size: 13px;
+    color: var(--fp-exp-color-muted, #666);
+}
+
+.fp-exp-dashboard__columns {
+    display: grid;
+    gap: 24px;
+}
+
+.fp-exp-dashboard__section {
+    background: #fff;
+    border-radius: 12px;
+    padding: 20px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+}
+
+.fp-exp-dashboard__section h2 {
+    margin-top: 0;
+}
+
+.fp-exp-dashboard__table th,
+.fp-exp-dashboard__table td {
+    vertical-align: middle;
+}
+
+.fp-exp-dashboard__shortcuts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+.fp-exp-checkin__table td {
+    vertical-align: middle;
+}
+
+.fp-exp-checkin__badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: var(--fp-exp-color-primary, #8b1e3f);
+    color: #fff;
+    font-size: 12px;
+}
+
+.fp-exp-settings__panel {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+    margin-top: 16px;
+}
+
+.fp-exp-settings__list {
+    margin: 0 0 16px;
+    padding-left: 18px;
+}
+
+.fp-exp-settings__links {
+    display: flex;
+    gap: 12px;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.fp-exp-help__section {
+    background: #fff;
+    padding: 20px;
+    border-radius: 12px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+    margin-top: 16px;
+}
+
+.fp-exp-help__section h2 {
+    margin-top: 0;
+}

--- a/docs/ADMIN-MENU.md
+++ b/docs/ADMIN-MENU.md
@@ -1,0 +1,45 @@
+# FP Experiences admin menu
+
+_Updated: unify plugin links under a single top-level menu._
+
+## Struttura
+
+- **FP Experiences → Dashboard** (`fp_exp_manage`)
+  - KPI prenotazioni, riepilogo ordini, azioni rapide.
+- **Esperienze / Nuova esperienza** (`edit_fp_experiences`)
+  - CPT `fp_experience` gestito interamente sotto il nuovo menu.
+- **Meeting point** (`fp_exp_manage`)
+  - Visibile solo quando l'opzione “Enable Meeting Points” è attiva.
+- **Calendario** (`fp_exp_operate`)
+  - Vista calendario/manual booking.
+- **Richieste** (`fp_exp_operate`)
+  - Appare solo con RTB attivo.
+- **Check-in** (`fp_exp_operate`)
+  - Console per confermare arrivi nelle prossime 48h.
+- **Ordini** (`fp_exp_manage` + `manage_woocommerce`)
+  - Reindirizza alla lista ordini Woo filtrata sugli item `fp_experience_item`.
+- **Impostazioni / Tools / Logs** (`fp_exp_manage`)
+  - Tabs aggiornati: Generale, Branding, Booking Rules, Brevo, Calendar, Tracking, RTB, Vetrina, Tools, Logs.
+- **Guida & Shortcode** (`fp_exp_guide`)
+  - Documentazione interna e scorciatoie.
+- **Crea pagina esperienza** (`fp_exp_manage`)
+  - Genera una pagina WordPress con `[fp_exp_page id="{ID}"]`.
+
+La toolbar di WordPress aggiunge il nodo “FP Experiences” con link rapidi a Nuova esperienza, Calendario, Richieste (se abilitate) e Impostazioni.
+
+## Flussi rapidi
+
+1. **Operatore** accede, apre **FP Experiences → Calendario** e gestisce slot o richieste senza vedere le impostazioni avanzate.
+2. **Manager** consulta la **Dashboard** per KPI giornalieri, poi passa a **Impostazioni** per modificare branding/integrazioni.
+3. **Marketing/Guide** trovano in **Guida & Shortcode** gli snippet pronti da copiare nelle pagine.
+
+## Asset
+
+- Gli asset `assets/css/admin.css` e `assets/js/admin.js` vengono caricati solo quando `get_current_screen()->id` contiene `fp-exp_page_` o `toplevel_page_fp_exp_dashboard`.
+- Le pagine Tools usano le stesse chiamate REST della scheda Tools.
+
+## Screenshot
+
+```
+[Screenshot placeholder – Admin → FP Experiences]
+```

--- a/docs/INTEGRATIONS-AUDIT.md
+++ b/docs/INTEGRATIONS-AUDIT.md
@@ -11,6 +11,6 @@
 - ICS attachments continue to ship regardless of calendar connectivity.
 
 ## Diagnostics
-- `fp-exp/v1/ping` GET endpoint is available to capability holders (`fp_exp_manage_tools`) for quick REST health checks.
+- `fp-exp/v1/ping` GET endpoint is available to capability holders (`fp_exp_manage`) for quick REST health checks.
 
 Next phase: A8 — Functional flows (smoke tests).

--- a/docs/SECURITY-AUDIT.md
+++ b/docs/SECURITY-AUDIT.md
@@ -7,7 +7,7 @@ The audit revisited REST endpoints, admin flows, Request-to-Book lifecycle, logg
 | ID | Area | Severity | Status | Notes |
 | -- | ---- | -------- | ------ | ----- |
 | SEC-01 | Google Calendar connect/disconnect actions | Low | Fixed | Sanitised `_wpnonce` handling in `SettingsPage::maybe_handle_calendar_actions()` to unslash the nonce before verification, preventing failures with slashed query vars. |
-| SEC-02 | REST capability checks | Info | Pass | All management routes use dedicated capabilities (`fp_exp_manage_calendar`, `fp_exp_manage_tools`, `fp_exp_manage_requests`). |
+| SEC-02 | REST capability checks | Info | Pass | All management routes use dedicated capabilities (`fp_exp_operate`, `fp_exp_manage`). |
 | SEC-03 | Front-end submission nonces | Info | Pass | Checkout (`fp-exp-checkout`) and RTB (`fp-exp-rtb`) endpoints require signed nonces and sanitise payloads (`sanitize_text_field`, `sanitize_textarea_field`, `sanitize_email`). |
 | SEC-04 | Logging of sensitive data | Info | Pass | `Logger::scrub_context()` masks email, phone, and credential fields before persisting to options. |
 | SEC-05 | SQL access | Info | Pass | Custom table queries rely on `$wpdb->prepare()` and sanitised inputs across `Reservations`, `Slots`, and `Resources` models; no unprepared SQL detected in audit spot checks. |

--- a/readme.txt
+++ b/readme.txt
@@ -44,6 +44,19 @@ The `sections` attribute accepts a comma-separated list of sections to render (h
 
 Six Elementor widgets mirror the shortcodes: List, Widget, Calendar, Checkout, Meeting Points, and the new Experience Page layout. The List widget now bundles the full showcase controls (filters, search, ordering, map toggle, CTA behaviour) plus responsive style controls for columns, card spacing, and badge/price visibility. Each widget exposes theming overrides (colors, radius, fonts) alongside behavioural toggles (sticky mode, inline calendar, consent defaults). The Experience Page widget lets editors pick sections to display and toggle the sticky availability bar while reusing the `[fp_exp_page]` shortcode under the hood.
 
+== Admin menu ==
+
+* **Dashboard** — visione rapida di KPI e ordini (solo ruoli con `fp_exp_manage`).
+* **Esperienze** / **Nuova esperienza** — gestiscono il CPT `fp_experience` (`edit_fp_experiences`).
+* **Meeting point** — appare quando l'opzione è attiva; richiede `fp_exp_manage`.
+* **Calendario**, **Richieste**, **Check-in** — strumenti operativi per chi possiede `fp_exp_operate`.
+* **Ordini** — scorciatoia agli ordini WooCommerce filtrati (necessita sia `fp_exp_manage` che `manage_woocommerce`).
+* **Impostazioni**, **Tools**, **Logs** — pannelli amministrativi riservati ai manager (`fp_exp_manage`).
+* **Guida & Shortcode** — documentazione interna accessibile a tutti i ruoli FP (`fp_exp_guide`).
+* **Crea pagina esperienza** — azione rapida per generare una pagina con shortcode (`fp_exp_manage`).
+
+La voce di menu viene replicata anche nella toolbar con collegamenti rapidi (Nuova esperienza, Calendario, Richieste, Impostazioni).
+
 == Settings & Tools ==
 
 * **General** – Structure and webmaster emails, locale preferences, VAT class filters, meeting points toggle.

--- a/src/Activation.php
+++ b/src/Activation.php
@@ -41,17 +41,33 @@ final class Activation
 
     private static function register_roles(): void
     {
-        $manager_caps = [
-            'read' => true,
-            'fp_exp_manage_settings' => true,
-            'fp_exp_manage_bookings' => true,
-            'fp_exp_manage_calendar' => true,
-            'fp_exp_manual_bookings' => true,
-            'fp_exp_manage_tools' => true,
-            'fp_exp_manage_requests' => true,
-            'fp_exp_view_assignments' => true,
-            'fp_exp_handle_checkins' => true,
+        $experience_caps = [
+            'edit_fp_experience' => true,
+            'read_fp_experience' => true,
+            'delete_fp_experience' => true,
+            'edit_fp_experiences' => true,
+            'edit_others_fp_experiences' => true,
+            'publish_fp_experiences' => true,
+            'read_private_fp_experiences' => true,
+            'delete_fp_experiences' => true,
+            'delete_others_fp_experiences' => true,
+            'delete_private_fp_experiences' => true,
+            'delete_published_fp_experiences' => true,
+            'edit_private_fp_experiences' => true,
+            'edit_published_fp_experiences' => true,
         ];
+
+        $manager_caps = array_merge(
+            [
+                'read' => true,
+                'edit_posts' => true,
+                'upload_files' => true,
+                'fp_exp_manage' => true,
+                'fp_exp_operate' => true,
+                'fp_exp_guide' => true,
+            ],
+            $experience_caps
+        );
 
         add_role(
             'fp_exp_manager',
@@ -59,14 +75,15 @@ final class Activation
             $manager_caps
         );
 
-        $operator_caps = [
-            'read' => true,
-            'fp_exp_manage_bookings' => true,
-            'fp_exp_manage_calendar' => true,
-            'fp_exp_manual_bookings' => true,
-            'fp_exp_manage_requests' => true,
-            'fp_exp_handle_checkins' => true,
-        ];
+        $operator_caps = array_merge(
+            [
+                'read' => true,
+                'edit_posts' => true,
+                'fp_exp_operate' => true,
+                'fp_exp_guide' => true,
+            ],
+            $experience_caps
+        );
 
         add_role(
             'fp_exp_operator',
@@ -76,7 +93,7 @@ final class Activation
 
         $guide_caps = [
             'read' => true,
-            'fp_exp_view_assignments' => true,
+            'fp_exp_guide' => true,
         ];
 
         add_role(

--- a/src/Admin/AdminMenu.php
+++ b/src/Admin/AdminMenu.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP_Exp\Admin;
+
+use FP_Exp\Utils\Helpers;
+use WP_Admin_Bar;
+
+use function add_action;
+use function add_menu_page;
+use function add_submenu_page;
+use function admin_url;
+use function current_user_can;
+use function esc_html__;
+use function get_current_screen;
+use function remove_menu_page;
+use function strpos;
+use function wp_enqueue_script;
+use function wp_enqueue_style;
+use function wp_localize_script;
+
+final class AdminMenu
+{
+    private SettingsPage $settings_page;
+
+    private CalendarAdmin $calendar_admin;
+
+    private LogsPage $logs_page;
+
+    private RequestsPage $requests_page;
+
+    private ToolsPage $tools_page;
+
+    private CheckinPage $checkin_page;
+
+    private OrdersPage $orders_page;
+
+    private HelpPage $help_page;
+
+    private ?ExperiencePageCreator $page_creator;
+
+    public function __construct(
+        SettingsPage $settings_page,
+        CalendarAdmin $calendar_admin,
+        LogsPage $logs_page,
+        RequestsPage $requests_page,
+        ToolsPage $tools_page,
+        CheckinPage $checkin_page,
+        OrdersPage $orders_page,
+        HelpPage $help_page,
+        ?ExperiencePageCreator $page_creator = null
+    ) {
+        $this->settings_page = $settings_page;
+        $this->calendar_admin = $calendar_admin;
+        $this->logs_page = $logs_page;
+        $this->requests_page = $requests_page;
+        $this->tools_page = $tools_page;
+        $this->checkin_page = $checkin_page;
+        $this->orders_page = $orders_page;
+        $this->help_page = $help_page;
+        $this->page_creator = $page_creator;
+    }
+
+    public function register_hooks(): void
+    {
+        add_action('admin_menu', [$this, 'register_menu']);
+        add_action('admin_menu', [$this, 'remove_duplicate_cpt_menus'], 99);
+        add_action('admin_bar_menu', [$this, 'register_admin_bar_links'], 80);
+        add_action('admin_enqueue_scripts', [$this, 'enqueue_shared_assets']);
+    }
+
+    public function register_menu(): void
+    {
+        add_menu_page(
+            esc_html__('FP Experiences', 'fp-experiences'),
+            esc_html__('FP Experiences', 'fp-experiences'),
+            'fp_exp_manage',
+            'fp_exp_dashboard',
+            [Dashboard::class, 'render'],
+            'dashicons-location',
+            58
+        );
+
+        add_submenu_page(
+            'fp_exp_dashboard',
+            esc_html__('Dashboard', 'fp-experiences'),
+            esc_html__('Dashboard', 'fp-experiences'),
+            'fp_exp_manage',
+            'fp_exp_dashboard',
+            [Dashboard::class, 'render']
+        );
+
+        add_submenu_page(
+            'fp_exp_dashboard',
+            esc_html__('Experiences', 'fp-experiences'),
+            esc_html__('Esperienze', 'fp-experiences'),
+            'edit_fp_experiences',
+            'edit.php?post_type=fp_experience'
+        );
+
+        add_submenu_page(
+            'fp_exp_dashboard',
+            esc_html__('Add New Experience', 'fp-experiences'),
+            esc_html__('Nuova esperienza', 'fp-experiences'),
+            'edit_fp_experiences',
+            'post-new.php?post_type=fp_experience'
+        );
+
+        if (Helpers::meeting_points_enabled()) {
+            add_submenu_page(
+                'fp_exp_dashboard',
+                esc_html__('Meeting Points', 'fp-experiences'),
+                esc_html__('Meeting point', 'fp-experiences'),
+                'fp_exp_manage',
+                'edit.php?post_type=fp_meeting_point'
+            );
+        }
+
+        add_submenu_page(
+            'fp_exp_dashboard',
+            esc_html__('Calendar', 'fp-experiences'),
+            esc_html__('Calendario', 'fp-experiences'),
+            'fp_exp_operate',
+            'fp_exp_calendar',
+            [$this->calendar_admin, 'render_page']
+        );
+
+        if (Helpers::rtb_mode() !== 'off') {
+            add_submenu_page(
+                'fp_exp_dashboard',
+                esc_html__('Requests', 'fp-experiences'),
+                esc_html__('Richieste', 'fp-experiences'),
+                'fp_exp_operate',
+                'fp_exp_requests',
+                [$this->requests_page, 'render_page']
+            );
+        }
+
+        add_submenu_page(
+            'fp_exp_dashboard',
+            esc_html__('Check-in', 'fp-experiences'),
+            esc_html__('Check-in', 'fp-experiences'),
+            'fp_exp_operate',
+            'fp_exp_checkin',
+            [$this->checkin_page, 'render_page']
+        );
+
+        if (current_user_can('manage_woocommerce') && current_user_can('fp_exp_manage')) {
+            add_submenu_page(
+                'fp_exp_dashboard',
+                esc_html__('Orders', 'fp-experiences'),
+                esc_html__('Ordini', 'fp-experiences'),
+                'manage_woocommerce',
+                'fp_exp_orders',
+                [$this->orders_page, 'render_page']
+            );
+        }
+
+        add_submenu_page(
+            'fp_exp_dashboard',
+            esc_html__('Settings', 'fp-experiences'),
+            esc_html__('Impostazioni', 'fp-experiences'),
+            'fp_exp_manage',
+            'fp_exp_settings',
+            [$this->settings_page, 'render_page']
+        );
+
+        add_submenu_page(
+            'fp_exp_dashboard',
+            esc_html__('Tools', 'fp-experiences'),
+            esc_html__('Tools', 'fp-experiences'),
+            'fp_exp_manage',
+            'fp_exp_tools',
+            [$this->tools_page, 'render_page']
+        );
+
+        add_submenu_page(
+            'fp_exp_dashboard',
+            esc_html__('Logs', 'fp-experiences'),
+            esc_html__('Logs', 'fp-experiences'),
+            'fp_exp_manage',
+            'fp_exp_logs',
+            [$this->logs_page, 'render_page']
+        );
+
+        add_submenu_page(
+            'fp_exp_dashboard',
+            esc_html__('Guide & Shortcodes', 'fp-experiences'),
+            esc_html__('Guida & Shortcode', 'fp-experiences'),
+            'fp_exp_guide',
+            'fp_exp_help',
+            [$this->help_page, 'render_page']
+        );
+
+        if ($this->page_creator instanceof ExperiencePageCreator) {
+            add_submenu_page(
+                'fp_exp_dashboard',
+                esc_html__('Create Experience Page', 'fp-experiences'),
+                esc_html__('Crea pagina esperienza', 'fp-experiences'),
+                'fp_exp_manage',
+                'fp_exp_create_page',
+                [$this->page_creator, 'render_page']
+            );
+        }
+    }
+
+    public function remove_duplicate_cpt_menus(): void
+    {
+        remove_menu_page('edit.php?post_type=fp_experience');
+        remove_menu_page('edit.php?post_type=fp_meeting_point');
+    }
+
+    public function register_admin_bar_links(WP_Admin_Bar $admin_bar): void
+    {
+        if (! current_user_can('fp_exp_guide')) {
+            return;
+        }
+
+        $admin_bar->add_node([
+            'id' => 'fp-exp',
+            'title' => esc_html__('FP Experiences', 'fp-experiences'),
+            'href' => current_user_can('fp_exp_manage')
+                ? admin_url('admin.php?page=fp_exp_dashboard')
+                : admin_url('post-new.php?post_type=fp_experience'),
+        ]);
+
+        if (current_user_can('edit_fp_experiences')) {
+            $admin_bar->add_node([
+                'id' => 'fp-exp-new',
+                'parent' => 'fp-exp',
+                'title' => esc_html__('Nuova esperienza', 'fp-experiences'),
+                'href' => admin_url('post-new.php?post_type=fp_experience'),
+            ]);
+        }
+
+        if (current_user_can('fp_exp_operate')) {
+            $admin_bar->add_node([
+                'id' => 'fp-exp-calendar',
+                'parent' => 'fp-exp',
+                'title' => esc_html__('Calendario', 'fp-experiences'),
+                'href' => admin_url('admin.php?page=fp_exp_calendar'),
+            ]);
+
+            if (Helpers::rtb_mode() !== 'off') {
+                $admin_bar->add_node([
+                    'id' => 'fp-exp-requests',
+                    'parent' => 'fp-exp',
+                    'title' => esc_html__('Richieste', 'fp-experiences'),
+                    'href' => admin_url('admin.php?page=fp_exp_requests'),
+                ]);
+            }
+        }
+
+        if (current_user_can('fp_exp_manage')) {
+            $admin_bar->add_node([
+                'id' => 'fp-exp-settings',
+                'parent' => 'fp-exp',
+                'title' => esc_html__('Impostazioni', 'fp-experiences'),
+                'href' => admin_url('admin.php?page=fp_exp_settings'),
+            ]);
+        }
+    }
+
+    public function enqueue_shared_assets(): void
+    {
+        $screen = get_current_screen();
+        if (! $screen) {
+            return;
+        }
+
+        $screen_id = $screen->id ?? '';
+        if ('toplevel_page_fp_exp_dashboard' !== $screen_id && 0 !== strpos($screen_id, 'fp-exp-dashboard_page_fp_exp_')) {
+            return;
+        }
+
+        wp_enqueue_style('fp-exp-admin', FP_EXP_PLUGIN_URL . 'assets/css/admin.css', [], FP_EXP_VERSION);
+        wp_enqueue_script('fp-exp-admin', FP_EXP_PLUGIN_URL . 'assets/js/admin.js', ['wp-api-fetch', 'wp-i18n'], FP_EXP_VERSION, true);
+
+        wp_localize_script('fp-exp-admin', 'fpExpAdmin', [
+            'strings' => [
+                'ticketWarning' => esc_html__('Aggiungi almeno un tipo di biglietto con un prezzo valido.', 'fp-experiences'),
+            ],
+        ]);
+    }
+}

--- a/src/Admin/CalendarAdmin.php
+++ b/src/Admin/CalendarAdmin.php
@@ -14,7 +14,6 @@ use WP_Error;
 use function absint;
 use function add_action;
 use function add_query_arg;
-use function add_submenu_page;
 use function admin_url;
 use function array_filter;
 use function check_admin_referer;
@@ -24,6 +23,7 @@ use function esc_attr;
 use function esc_html;
 use function esc_html__;
 use function esc_url;
+use function get_current_screen;
 use function get_option;
 use function get_posts;
 use function get_the_title;
@@ -56,25 +56,13 @@ final class CalendarAdmin
 
     public function register_hooks(): void
     {
-        add_action('admin_menu', [$this, 'register_menu']);
         add_action('admin_enqueue_scripts', [$this, 'enqueue_assets']);
-    }
-
-    public function register_menu(): void
-    {
-        add_submenu_page(
-            'fp-exp-settings',
-            esc_html__('Calendar & Manual Booking', 'fp-experiences'),
-            esc_html__('Calendar', 'fp-experiences'),
-            'fp_exp_manage_calendar',
-            'fp-exp-calendar',
-            [$this, 'render_page']
-        );
     }
 
     public function enqueue_assets(string $hook): void
     {
-        if ('fp-exp-settings_page_fp-exp-calendar' !== $hook) {
+        $screen = get_current_screen();
+        if (! $screen || 'fp-exp-dashboard_page_fp_exp_calendar' !== $screen->id) {
             return;
         }
 
@@ -120,7 +108,7 @@ final class CalendarAdmin
 
     public function render_page(): void
     {
-        if (! current_user_can('fp_exp_manage_calendar')) {
+        if (! current_user_can('fp_exp_operate')) {
             wp_die(esc_html__('You do not have permission to manage FP Experiences bookings.', 'fp-experiences'));
         }
 
@@ -413,7 +401,7 @@ final class CalendarAdmin
     {
         check_admin_referer('fp_exp_manual_booking', 'fp_exp_manual_booking_nonce');
 
-        if (! current_user_can('fp_exp_manual_bookings')) {
+        if (! current_user_can('fp_exp_operate')) {
             return new WP_Error('fp_exp_manual_permission', esc_html__('You do not have permission to create manual bookings.', 'fp-experiences'));
         }
 

--- a/src/Admin/CheckinPage.php
+++ b/src/Admin/CheckinPage.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP_Exp\Admin;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use FP_Exp\Booking\Reservations;
+use FP_Exp\Booking\Slots;
+use function absint;
+use function add_action;
+use function add_query_arg;
+use function admin_url;
+use function check_admin_referer;
+use function current_user_can;
+use function esc_attr;
+use function esc_html;
+use function esc_html__;
+use function get_option;
+use function get_transient;
+use function is_array;
+use function is_numeric;
+use function maybe_unserialize;
+use function number_format_i18n;
+use function sanitize_key;
+use function set_transient;
+use function delete_transient;
+use function wp_date;
+use function wp_nonce_field;
+use function wp_safe_redirect;
+use function wp_unslash;
+use function wp_die;
+use function wp_timezone;
+use function strtotime;
+
+final class CheckinPage
+{
+    private const NOTICE_KEY = 'fp_exp_checkin_notice';
+
+    public function register_hooks(): void
+    {
+        add_action('admin_init', [$this, 'maybe_handle_action']);
+    }
+
+    public function maybe_handle_action(): void
+    {
+        if (! current_user_can('fp_exp_operate')) {
+            return;
+        }
+
+        if ('POST' !== ($_SERVER['REQUEST_METHOD'] ?? '')) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            return;
+        }
+
+        if (! isset($_POST['fp_exp_checkin_action'])) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            return;
+        }
+
+        $action = sanitize_key((string) wp_unslash($_POST['fp_exp_checkin_action']));
+        if ('mark_checked_in' !== $action) {
+            return;
+        }
+
+        $reservation_id = isset($_POST['reservation_id']) ? absint($_POST['reservation_id']) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+        if ($reservation_id <= 0) {
+            return;
+        }
+
+        check_admin_referer('fp_exp_checkin_' . $reservation_id, 'fp_exp_checkin_nonce');
+
+        $result = Reservations::update_status($reservation_id, Reservations::STATUS_CHECKED_IN);
+        if (! $result) {
+            set_transient(self::NOTICE_KEY, [
+                'message' => esc_html__('Impossibile registrare il check-in, riprova più tardi.', 'fp-experiences'),
+                'type' => 'error',
+            ], 30);
+        } else {
+            set_transient(self::NOTICE_KEY, [
+                'message' => esc_html__('Check-in confermato.', 'fp-experiences'),
+                'type' => 'success',
+            ], 30);
+        }
+
+        wp_safe_redirect(add_query_arg('page', 'fp_exp_checkin', admin_url('admin.php')));
+        exit;
+    }
+
+    public function render_page(): void
+    {
+        if (! current_user_can('fp_exp_operate')) {
+            wp_die(esc_html__('You do not have permission to access the check-in console.', 'fp-experiences'));
+        }
+
+        $notice = get_transient(self::NOTICE_KEY);
+        if (is_array($notice) && ! empty($notice['message'])) {
+            $class = 'notice notice-' . sanitize_key($notice['type'] ?? 'success');
+            echo '<div class="' . esc_attr($class) . '"><p>' . esc_html((string) $notice['message']) . '</p></div>';
+            delete_transient(self::NOTICE_KEY);
+        }
+
+        $rows = $this->get_upcoming_reservations();
+
+        echo '<div class="wrap fp-exp-checkin">';
+        echo '<h1>' . esc_html__('Console check-in', 'fp-experiences') . '</h1>';
+        echo '<p>' . esc_html__('Segna gli ospiti al loro arrivo e controlla le prenotazioni imminenti.', 'fp-experiences') . '</p>';
+
+        if (! $rows) {
+            echo '<p>' . esc_html__('Nessuna prenotazione in arrivo nelle prossime 48 ore.', 'fp-experiences') . '</p>';
+            echo '</div>';
+
+            return;
+        }
+
+        echo '<table class="widefat striped fp-exp-checkin__table">';
+        echo '<thead><tr>';
+        echo '<th>' . esc_html__('Esperienza', 'fp-experiences') . '</th>';
+        echo '<th>' . esc_html__('Orario', 'fp-experiences') . '</th>';
+        echo '<th>' . esc_html__('Ospiti', 'fp-experiences') . '</th>';
+        echo '<th>' . esc_html__('Stato', 'fp-experiences') . '</th>';
+        echo '<th>' . esc_html__('Azione', 'fp-experiences') . '</th>';
+        echo '</tr></thead><tbody>';
+
+        foreach ($rows as $row) {
+            $time_label = wp_date(get_option('date_format', 'Y-m-d') . ' ' . get_option('time_format', 'H:i'), $row['timestamp']);
+            $status_label = $this->format_status((string) $row['status']);
+            echo '<tr>';
+            echo '<td>' . esc_html($row['experience']) . '</td>';
+            echo '<td>' . esc_html($time_label) . '</td>';
+            echo '<td>' . esc_html(number_format_i18n($row['guests'])) . '</td>';
+            echo '<td>' . esc_html($status_label) . '</td>';
+            echo '<td>';
+            if (Reservations::STATUS_CHECKED_IN === $row['status']) {
+                echo '<span class="fp-exp-checkin__badge">' . esc_html__('Completato', 'fp-experiences') . '</span>';
+            } else {
+                echo '<form method="post" action="" class="fp-exp-checkin__form">';
+                wp_nonce_field('fp_exp_checkin_' . $row['id'], 'fp_exp_checkin_nonce');
+                echo '<input type="hidden" name="fp_exp_checkin_action" value="mark_checked_in" />';
+                echo '<input type="hidden" name="reservation_id" value="' . esc_attr((string) $row['id']) . '" />';
+                echo '<button type="submit" class="button button-primary">' . esc_html__('Segna check-in', 'fp-experiences') . '</button>';
+                echo '</form>';
+            }
+            echo '</td>';
+            echo '</tr>';
+        }
+
+        echo '</tbody></table>';
+        echo '</div>';
+    }
+
+    /**
+     * @return array<int, array{id: int, experience: string, timestamp: int, guests: int, status: string}>
+     */
+    private function get_upcoming_reservations(): array
+    {
+        global $wpdb;
+
+        $reservations_table = Reservations::table_name();
+        $slots_table = Slots::table_name();
+        $posts_table = $wpdb->posts;
+
+        $timezone = wp_timezone();
+        $now = new DateTimeImmutable('now', $timezone);
+        $window_start = $now->sub(new DateInterval('PT6H'));
+        $window_end = $now->add(new DateInterval('P2D'));
+
+        $start_utc = $window_start->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s');
+        $end_utc = $window_end->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s');
+
+        $sql = $wpdb->prepare(
+            "SELECT r.id, r.pax, r.status, s.start_datetime, p.post_title FROM {$reservations_table} r " .
+            "INNER JOIN {$slots_table} s ON r.slot_id = s.id " .
+            "INNER JOIN {$posts_table} p ON p.ID = r.experience_id " .
+            "WHERE s.start_datetime BETWEEN %s AND %s AND r.status NOT IN (%s, %s) " .
+            "ORDER BY s.start_datetime ASC LIMIT 30",
+            $start_utc,
+            $end_utc,
+            Reservations::STATUS_CANCELLED,
+            Reservations::STATUS_DECLINED
+        );
+
+        $results = $wpdb->get_results($sql, ARRAY_A);
+        if (! $results) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($results as $row) {
+            $guests = 0;
+            $pax = maybe_unserialize($row['pax']);
+            if (is_array($pax)) {
+                foreach ($pax as $quantity) {
+                    if (is_numeric($quantity)) {
+                        $guests += (int) $quantity;
+                    }
+                }
+            }
+
+            $start = strtotime((string) $row['start_datetime']);
+            if (! $start) {
+                continue;
+            }
+
+            $rows[] = [
+                'id' => (int) $row['id'],
+                'experience' => (string) $row['post_title'],
+                'timestamp' => $start,
+                'guests' => max(0, $guests),
+                'status' => (string) $row['status'],
+            ];
+        }
+
+        return $rows;
+    }
+
+    private function format_status(string $status): string
+    {
+        switch ($status) {
+            case Reservations::STATUS_PAID:
+            case Reservations::STATUS_APPROVED_CONFIRMED:
+                return esc_html__('Confermato', 'fp-experiences');
+            case Reservations::STATUS_APPROVED_PENDING_PAYMENT:
+                return esc_html__('In attesa pagamento', 'fp-experiences');
+            case Reservations::STATUS_PENDING:
+            case Reservations::STATUS_PENDING_REQUEST:
+                return esc_html__('In attesa', 'fp-experiences');
+            case Reservations::STATUS_CHECKED_IN:
+                return esc_html__('Check-in effettuato', 'fp-experiences');
+            case Reservations::STATUS_CANCELLED:
+                return esc_html__('Cancellato', 'fp-experiences');
+            default:
+                return esc_html__('Aggiornamento', 'fp-experiences');
+        }
+    }
+}

--- a/src/Admin/Dashboard.php
+++ b/src/Admin/Dashboard.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP_Exp\Admin;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use FP_Exp\Booking\Reservations;
+use FP_Exp\Booking\Slots;
+use FP_Exp\Utils\Helpers;
+use WC_Order;
+
+use function admin_url;
+use function current_user_can;
+use function esc_attr__;
+use function esc_html;
+use function esc_html__;
+use function esc_url;
+use function get_option;
+use function maybe_unserialize;
+use function number_format_i18n;
+use function wp_die;
+use function wp_strip_all_tags;
+use function wp_timezone;
+use function wc_get_order;
+use function wc_get_order_status_name;
+use function wc_get_order_statuses;
+
+final class Dashboard
+{
+    public static function render(): void
+    {
+        if (! current_user_can('fp_exp_manage')) {
+            wp_die(esc_html__('You do not have permission to access the FP Experiences dashboard.', 'fp-experiences'));
+        }
+
+        $metrics = self::collect_metrics();
+
+        echo '<div class="wrap fp-exp-dashboard">';
+        echo '<nav class="fp-exp-dashboard__breadcrumb" aria-label="' . esc_attr__('Percorso di navigazione', 'fp-experiences') . '">';
+        echo '<a href="' . esc_url(admin_url('admin.php?page=fp_exp_dashboard')) . '">' . esc_html__('FP Experiences', 'fp-experiences') . '</a>';
+        echo ' <span aria-hidden="true">›</span> ';
+        echo '<span>' . esc_html__('Dashboard', 'fp-experiences') . '</span>';
+        echo '</nav>';
+
+        echo '<h1>' . esc_html__('FP Experiences — Dashboard', 'fp-experiences') . '</h1>';
+
+        echo '<div class="fp-exp-dashboard__grid">';
+        self::render_metric_card(
+            esc_html__('Prenotazioni oggi', 'fp-experiences'),
+            number_format_i18n($metrics['bookings_today'])
+        );
+
+        $fill_rate = $metrics['fill_rate'];
+        self::render_metric_card(
+            esc_html__('Riempimento settimana', 'fp-experiences'),
+            $fill_rate['label'],
+            $fill_rate['description']
+        );
+
+        if (null !== $metrics['pending_requests']) {
+            self::render_metric_card(
+                esc_html__('Richieste in attesa', 'fp-experiences'),
+                number_format_i18n($metrics['pending_requests'])
+            );
+        }
+        echo '</div>';
+
+        echo '<div class="fp-exp-dashboard__columns">';
+
+        echo '<section class="fp-exp-dashboard__section" aria-labelledby="fp-exp-dashboard-orders">';
+        echo '<h2 id="fp-exp-dashboard-orders">' . esc_html__('Ultimi ordini esperienza', 'fp-experiences') . '</h2>';
+        if ($metrics['orders']) {
+            echo '<table class="widefat striped fp-exp-dashboard__table">';
+            echo '<thead><tr>';
+            echo '<th>' . esc_html__('# Ordine', 'fp-experiences') . '</th>';
+            echo '<th>' . esc_html__('Data', 'fp-experiences') . '</th>';
+            echo '<th>' . esc_html__('Stato', 'fp-experiences') . '</th>';
+            echo '<th>' . esc_html__('Totale', 'fp-experiences') . '</th>';
+            echo '</tr></thead><tbody>';
+            foreach ($metrics['orders'] as $order) {
+                echo '<tr>';
+                echo '<td><a href="' . esc_url($order['url']) . '">#' . esc_html($order['number']) . '</a></td>';
+                echo '<td>' . esc_html($order['date']) . '</td>';
+                echo '<td>' . esc_html($order['status']) . '</td>';
+                echo '<td>' . esc_html($order['total']) . '</td>';
+                echo '</tr>';
+            }
+            echo '</tbody></table>';
+        } else {
+            echo '<p>' . esc_html__('Ancora nessun ordine registrato per le esperienze.', 'fp-experiences') . '</p>';
+        }
+        echo '</section>';
+
+        echo '<section class="fp-exp-dashboard__section" aria-labelledby="fp-exp-dashboard-shortcuts">';
+        echo '<h2 id="fp-exp-dashboard-shortcuts">' . esc_html__('Azioni rapide', 'fp-experiences') . '</h2>';
+        echo '<ul class="fp-exp-dashboard__shortcuts">';
+        if (current_user_can('edit_fp_experiences')) {
+            echo '<li><a class="button button-primary" href="' . esc_url(admin_url('post-new.php?post_type=fp_experience')) . '">' . esc_html__('Crea nuova esperienza', 'fp-experiences') . '</a></li>';
+        }
+        echo '<li><a class="button" href="' . esc_url(admin_url('edit.php?post_type=fp_experience')) . '">' . esc_html__('Gestisci vetrina', 'fp-experiences') . '</a></li>';
+        if (current_user_can('fp_exp_manage')) {
+            echo '<li><a class="button" href="' . esc_url(admin_url('admin.php?page=fp_exp_settings')) . '">' . esc_html__('Apri impostazioni', 'fp-experiences') . '</a></li>';
+        }
+        echo '</ul>';
+        echo '</section>';
+
+        echo '</div>';
+        echo '</div>';
+    }
+
+    /**
+     * @return array{
+     *     bookings_today: int,
+     *     fill_rate: array{label: string, description: string},
+     *     pending_requests: ?int,
+     *     orders: array<int, array{number: string, date: string, status: string, total: string, url: string}>
+     * }
+     */
+    private static function collect_metrics(): array
+    {
+        global $wpdb;
+
+        $reservations_table = Reservations::table_name();
+        $slots_table = Slots::table_name();
+
+        $timezone = wp_timezone();
+        $today = new DateTimeImmutable('now', $timezone);
+        $start_of_day = $today->setTime(0, 0, 0);
+        $end_of_day = $start_of_day->setTime(23, 59, 59);
+        $end_of_week = $start_of_day->add(new DateInterval('P6D'))->setTime(23, 59, 59);
+
+        $start_utc = $start_of_day->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s');
+        $end_day_utc = $end_of_day->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s');
+        $end_week_utc = $end_of_week->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s');
+
+        $bookings_today = (int) $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT COUNT(r.id) FROM {$reservations_table} r " .
+                "INNER JOIN {$slots_table} s ON r.slot_id = s.id " .
+                "WHERE s.start_datetime BETWEEN %s AND %s AND r.status NOT IN (%s, %s)",
+                $start_utc,
+                $end_day_utc,
+                Reservations::STATUS_CANCELLED,
+                Reservations::STATUS_DECLINED
+            )
+        );
+
+        $reservations = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT r.pax FROM {$reservations_table} r " .
+                "INNER JOIN {$slots_table} s ON r.slot_id = s.id " .
+                "WHERE s.start_datetime BETWEEN %s AND %s AND r.status NOT IN (%s, %s)",
+                $start_utc,
+                $end_week_utc,
+                Reservations::STATUS_CANCELLED,
+                Reservations::STATUS_DECLINED
+            ),
+            ARRAY_A
+        );
+
+        $guests_week = 0;
+        foreach ($reservations as $row) {
+            $pax = maybe_unserialize($row['pax']);
+            if (is_array($pax)) {
+                foreach ($pax as $quantity) {
+                    if (is_numeric($quantity)) {
+                        $guests_week += (int) $quantity;
+                    }
+                }
+            } elseif (is_numeric($row['pax'])) {
+                $guests_week += (int) $row['pax'];
+            }
+        }
+
+        $capacity_total = (int) $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT SUM(capacity_total) FROM {$slots_table} WHERE start_datetime BETWEEN %s AND %s AND status <> %s",
+                $start_utc,
+                $end_week_utc,
+                Slots::STATUS_CANCELLED
+            )
+        );
+
+        $fill_percentage = 0.0;
+        if ($capacity_total > 0) {
+            $fill_percentage = min(100.0, ($guests_week / $capacity_total) * 100.0);
+        }
+
+        $fill_rate = [
+            'label' => $capacity_total > 0
+                ? sprintf('%s%%', number_format_i18n($fill_percentage, 1))
+                : esc_html__('n/d', 'fp-experiences'),
+            'description' => $capacity_total > 0
+                ? sprintf(
+                    /* translators: 1: booked guests, 2: available seats. */
+                    esc_html__('%1$s ospiti su %2$s posti disponibili nei prossimi 7 giorni.', 'fp-experiences'),
+                    number_format_i18n($guests_week),
+                    number_format_i18n($capacity_total)
+                )
+                : esc_html__('Nessun slot programmato per la settimana corrente.', 'fp-experiences'),
+        ];
+
+        $pending_requests = null;
+        if (Helpers::rtb_mode() !== 'off') {
+            $pending_requests = (int) $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT COUNT(id) FROM {$reservations_table} WHERE status = %s",
+                    Reservations::STATUS_PENDING_REQUEST
+                )
+            );
+        }
+
+        $orders = self::load_recent_orders();
+
+        return [
+            'bookings_today' => $bookings_today,
+            'fill_rate' => $fill_rate,
+            'pending_requests' => $pending_requests,
+            'orders' => $orders,
+        ];
+    }
+
+    /**
+     * @return array<int, array{number: string, date: string, status: string, total: string, url: string}>
+     */
+    private static function load_recent_orders(): array
+    {
+        if (! function_exists('wc_get_order')) {
+            return [];
+        }
+
+        global $wpdb;
+
+        $order_items_table = $wpdb->prefix . 'woocommerce_order_items';
+        $posts_table = $wpdb->posts;
+        $statuses = array_keys(wc_get_order_statuses());
+
+        if (! $statuses) {
+            return [];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($statuses), '%s'));
+
+        $sql = $wpdb->prepare(
+            "SELECT DISTINCT p.ID FROM {$order_items_table} i " .
+            "INNER JOIN {$posts_table} p ON i.order_id = p.ID " .
+            "WHERE i.order_item_type = %s AND p.post_type = 'shop_order' " .
+            "AND p.post_status IN ({$placeholders}) ORDER BY p.post_date DESC LIMIT 5",
+            array_merge(['fp_experience_item'], $statuses)
+        );
+
+        $order_ids = $wpdb->get_col($sql);
+
+        if (! $order_ids) {
+            return [];
+        }
+
+        $orders = [];
+        foreach ($order_ids as $order_id) {
+            $order = wc_get_order((int) $order_id);
+            if (! $order instanceof WC_Order) {
+                continue;
+            }
+
+            $date = $order->get_date_created();
+            $orders[] = [
+                'number' => $order->get_order_number(),
+                'date' => $date ? $date->date_i18n(get_option('date_format', 'Y-m-d H:i')) : esc_html__('n/d', 'fp-experiences'),
+                'status' => wc_get_order_status_name($order->get_status()),
+                'total' => wp_strip_all_tags($order->get_formatted_order_total()),
+                'url' => $order->get_edit_order_url(),
+            ];
+        }
+
+        return $orders;
+    }
+
+    private static function render_metric_card(string $label, string $value, ?string $description = null): void
+    {
+        echo '<div class="fp-exp-dashboard__card">';
+        echo '<p class="fp-exp-dashboard__card-label">' . esc_html($label) . '</p>';
+        echo '<p class="fp-exp-dashboard__card-value">' . esc_html($value) . '</p>';
+        if ($description) {
+            echo '<p class="fp-exp-dashboard__card-hint">' . esc_html($description) . '</p>';
+        }
+        echo '</div>';
+    }
+}

--- a/src/Admin/ExperiencePageCreator.php
+++ b/src/Admin/ExperiencePageCreator.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP_Exp\Admin;
+
+use function absint;
+use function add_action;
+use function add_query_arg;
+use function admin_url;
+use function check_admin_referer;
+use function current_user_can;
+use function esc_attr;
+use function esc_html;
+use function esc_html__;
+use function delete_transient;
+use function get_posts;
+use function get_transient;
+use function is_array;
+use function is_wp_error;
+use function sanitize_text_field;
+use function set_transient;
+use function submit_button;
+use function wp_insert_post;
+use function wp_nonce_field;
+use function wp_safe_redirect;
+use function wp_unslash;
+use function wp_die;
+
+final class ExperiencePageCreator
+{
+    private const NOTICE_KEY = 'fp_exp_page_creator_notice';
+
+    public function register_hooks(): void
+    {
+        add_action('admin_init', [$this, 'maybe_handle_submit']);
+    }
+
+    public function maybe_handle_submit(): void
+    {
+        if (! current_user_can('fp_exp_manage')) {
+            return;
+        }
+
+        if ('POST' !== ($_SERVER['REQUEST_METHOD'] ?? '')) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            return;
+        }
+
+        if (! isset($_POST['fp_exp_page_creator'])) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            return;
+        }
+
+        check_admin_referer('fp_exp_create_page', 'fp_exp_create_page_nonce');
+
+        $experience_id = isset($_POST['fp_exp_experience']) ? absint($_POST['fp_exp_experience']) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+        $title = isset($_POST['fp_exp_page_title']) ? sanitize_text_field((string) wp_unslash($_POST['fp_exp_page_title'])) : '';
+
+        if ($experience_id <= 0 || '' === $title) {
+            set_transient(self::NOTICE_KEY, [
+                'message' => esc_html__('Seleziona un\'esperienza e inserisci un titolo valido.', 'fp-experiences'),
+                'type' => 'error',
+            ], 30);
+            wp_safe_redirect(add_query_arg('page', 'fp_exp_create_page', admin_url('admin.php')));
+            exit;
+        }
+
+        $content = sprintf('[fp_exp_page id="%d"]', $experience_id);
+        $result = wp_insert_post([
+            'post_title' => $title,
+            'post_content' => $content,
+            'post_status' => 'publish',
+            'post_type' => 'page',
+        ]);
+
+        if ($result && ! is_wp_error($result)) {
+            set_transient(self::NOTICE_KEY, [
+                'message' => esc_html__('Pagina esperienza creata con successo.', 'fp-experiences'),
+                'type' => 'success',
+            ], 30);
+        } else {
+            set_transient(self::NOTICE_KEY, [
+                'message' => esc_html__('Impossibile creare la pagina, riprova più tardi.', 'fp-experiences'),
+                'type' => 'error',
+            ], 30);
+        }
+
+        wp_safe_redirect(add_query_arg('page', 'fp_exp_create_page', admin_url('admin.php')));
+        exit;
+    }
+
+    public function render_page(): void
+    {
+        if (! current_user_can('fp_exp_manage')) {
+            wp_die(esc_html__('You do not have permission to generate experience pages.', 'fp-experiences'));
+        }
+
+        $notice = get_transient(self::NOTICE_KEY);
+        if (is_array($notice) && ! empty($notice['message'])) {
+            $class = 'notice notice-' . esc_attr($notice['type'] ?? 'success');
+            echo '<div class="' . $class . '"><p>' . esc_html((string) $notice['message']) . '</p></div>';
+            delete_transient(self::NOTICE_KEY);
+        }
+
+        $experiences = get_posts([
+            'post_type' => 'fp_experience',
+            'posts_per_page' => 200,
+            'post_status' => ['publish', 'draft'],
+            'orderby' => 'title',
+            'order' => 'ASC',
+        ]);
+
+        echo '<div class="wrap fp-exp-page-creator">';
+        echo '<h1>' . esc_html__('Crea pagina esperienza', 'fp-experiences') . '</h1>';
+        echo '<p>' . esc_html__('Genera una pagina WordPress con shortcode preconfigurato per un\'esperienza.', 'fp-experiences') . '</p>';
+
+        echo '<form method="post">';
+        wp_nonce_field('fp_exp_create_page', 'fp_exp_create_page_nonce');
+        echo '<input type="hidden" name="fp_exp_page_creator" value="1" />';
+
+        echo '<p>';
+        echo '<label for="fp-exp-page-title">' . esc_html__('Titolo pagina', 'fp-experiences') . '</label><br />';
+        echo '<input type="text" id="fp-exp-page-title" name="fp_exp_page_title" class="regular-text" required />';
+        echo '</p>';
+
+        echo '<p>';
+        echo '<label for="fp-exp-experience-select">' . esc_html__('Esperienza da collegare', 'fp-experiences') . '</label><br />';
+        echo '<select id="fp-exp-experience-select" name="fp_exp_experience" class="regular-text" required>';
+        echo '<option value="">' . esc_html__('Seleziona un\'esperienza', 'fp-experiences') . '</option>';
+        foreach ($experiences as $experience) {
+            echo '<option value="' . esc_attr((string) $experience->ID) . '">' . esc_html($experience->post_title) . '</option>';
+        }
+        echo '</select>';
+        echo '</p>';
+
+        submit_button(esc_html__('Crea pagina', 'fp-experiences'));
+        echo '</form>';
+        echo '</div>';
+    }
+}

--- a/src/Admin/HelpPage.php
+++ b/src/Admin/HelpPage.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP_Exp\Admin;
+
+use function current_user_can;
+use function esc_html;
+use function esc_html__;
+use function wp_die;
+
+final class HelpPage
+{
+    public function render_page(): void
+    {
+        if (! current_user_can('fp_exp_guide')) {
+            wp_die(esc_html__('You do not have permission to access the FP Experiences guide.', 'fp-experiences'));
+        }
+
+        echo '<div class="wrap fp-exp-help">';
+        echo '<h1>' . esc_html__('Guida & Shortcode', 'fp-experiences') . '</h1>';
+        echo '<p>' . esc_html__('Consulta i componenti disponibili e copia rapidamente gli shortcode nelle pagine del sito.', 'fp-experiences') . '</p>';
+
+        echo '<section class="fp-exp-help__section">';
+        echo '<h2>' . esc_html__('Shortcode disponibili', 'fp-experiences') . '</h2>';
+        echo '<ul>';
+        echo '<li><code>[fp_exp_page id="123"]</code> — ' . esc_html__('Pagina esperienza completa con calendario e CTA.', 'fp-experiences') . '</li>';
+        echo '<li><code>[fp_exp_widget id="123"]</code> — ' . esc_html__('Widget prenotazione compatto per pagine di vendita.', 'fp-experiences') . '</li>';
+        echo '<li><code>[fp_exp_list theme="" columns="3"]</code> — ' . esc_html__('Vetrina delle esperienze con filtri e ricerca.', 'fp-experiences') . '</li>';
+        echo '<li><code>[fp_exp_meeting_points id="123"]</code> — ' . esc_html__('Mappa dei meeting point collegati a una esperienza.', 'fp-experiences') . '</li>';
+        echo '</ul>';
+        echo '</section>';
+
+        echo '<section class="fp-exp-help__section">';
+        echo '<h2>' . esc_html__('Risorse utili', 'fp-experiences') . '</h2>';
+        echo '<p>' . esc_html__('Tutte le pagine dell'amministrazione FP Experiences rispettano i ruoli guida, operatore e manager. Per supporto aggiuntivo consulta la documentazione interna.', 'fp-experiences') . '</p>';
+        echo '</section>';
+
+        echo '</div>';
+    }
+}

--- a/src/Admin/LogsPage.php
+++ b/src/Admin/LogsPage.php
@@ -7,9 +7,8 @@ namespace FP_Exp\Admin;
 use FP_Exp\Utils\Logger;
 
 use function add_action;
-use function admin_url;
 use function add_query_arg;
-use function add_submenu_page;
+use function admin_url;
 use function check_admin_referer;
 use function class_exists;
 use function esc_attr;
@@ -30,24 +29,12 @@ final class LogsPage
 {
     public function register_hooks(): void
     {
-        add_action('admin_menu', [$this, 'register_menu']);
-    }
-
-    public function register_menu(): void
-    {
-        add_submenu_page(
-            'fp-exp-settings',
-            esc_html__('Logs & Diagnostics', 'fp-experiences'),
-            esc_html__('Logs', 'fp-experiences'),
-            'fp_exp_manage_settings',
-            'fp-exp-logs',
-            [$this, 'render_page']
-        );
+        // Intentionally left blank; menu registered via AdminMenu.
     }
 
     public function render_page(): void
     {
-        if (! current_user_can('fp_exp_manage_settings')) {
+        if (! current_user_can('fp_exp_manage')) {
             wp_die(esc_html__('You do not have permission to view FP Experiences logs.', 'fp-experiences'));
         }
 
@@ -129,10 +116,10 @@ final class LogsPage
     private function render_filters(string $channel, string $search): void
     {
         $channels = Logger::channels();
-        $base_url = add_query_arg('page', 'fp-exp-logs', admin_url('admin.php'));
+        $base_url = add_query_arg('page', 'fp_exp_logs', admin_url('admin.php'));
         $export_url = add_query_arg(
             [
-                'page' => 'fp-exp-logs',
+                'page' => 'fp_exp_logs',
                 'channel' => $channel,
                 's' => $search,
                 'export' => '1',
@@ -141,7 +128,7 @@ final class LogsPage
         );
 
         echo '<form method="get" action="' . esc_url($base_url) . '" class="fp-exp-log-filter">';
-        echo '<input type="hidden" name="page" value="fp-exp-logs" />';
+        echo '<input type="hidden" name="page" value="fp_exp_logs" />';
 
         echo '<label for="fp-exp-log-channel" class="screen-reader-text">' . esc_html__('Filter by channel', 'fp-experiences') . '</label>';
         echo '<select id="fp-exp-log-channel" name="channel">';

--- a/src/Admin/OrdersPage.php
+++ b/src/Admin/OrdersPage.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP_Exp\Admin;
+
+use WP_Query;
+
+use function add_action;
+use function add_filter;
+use function add_query_arg;
+use function admin_url;
+use function current_user_can;
+use function esc_html__;
+use function is_admin;
+use function sanitize_key;
+use function strpos;
+use function wp_die;
+use function wp_safe_redirect;
+use function wp_unslash;
+
+final class OrdersPage
+{
+    private const ORDER_ITEM_TYPE = 'fp_experience_item';
+
+    public function register_hooks(): void
+    {
+        add_action('pre_get_posts', [$this, 'maybe_filter_orders']);
+    }
+
+    public function render_page(): void
+    {
+        if (! current_user_can('fp_exp_manage') || ! current_user_can('manage_woocommerce')) {
+            wp_die(esc_html__('You do not have permission to view experience orders.', 'fp-experiences'));
+        }
+
+        $url = add_query_arg(
+            [
+                'post_type' => 'shop_order',
+                'fp_exp_order_item_type' => self::ORDER_ITEM_TYPE,
+            ],
+            admin_url('edit.php')
+        );
+
+        wp_safe_redirect($url);
+        exit;
+    }
+
+    public function maybe_filter_orders($query): void
+    {
+        if (! $query instanceof WP_Query || ! is_admin() || ! $query->is_main_query()) {
+            return;
+        }
+
+        if ('shop_order' !== $query->get('post_type')) {
+            return;
+        }
+
+        $requested = isset($_GET['fp_exp_order_item_type']) ? sanitize_key((string) wp_unslash($_GET['fp_exp_order_item_type'])) : '';
+
+        if (self::ORDER_ITEM_TYPE !== $requested) {
+            return;
+        }
+
+        $query->set('fp_exp_order_item_type', self::ORDER_ITEM_TYPE);
+
+        add_filter('posts_join', [$this, 'filter_orders_join'], 10, 2);
+        add_filter('posts_where', [$this, 'filter_orders_where'], 10, 2);
+        add_filter('posts_distinct', [$this, 'filter_orders_distinct'], 10, 2);
+    }
+
+    public function filter_orders_join(string $join, WP_Query $query): string
+    {
+        if (self::ORDER_ITEM_TYPE !== $query->get('fp_exp_order_item_type')) {
+            return $join;
+        }
+
+        global $wpdb;
+
+        if (false === strpos($join, 'fp_exp_items')) {
+            $join .= " INNER JOIN {$wpdb->prefix}woocommerce_order_items fp_exp_items ON fp_exp_items.order_id = {$wpdb->posts}.ID";
+        }
+
+        return $join;
+    }
+
+    public function filter_orders_where(string $where, WP_Query $query): string
+    {
+        if (self::ORDER_ITEM_TYPE !== $query->get('fp_exp_order_item_type')) {
+            return $where;
+        }
+
+        global $wpdb;
+
+        return $where . $wpdb->prepare(' AND fp_exp_items.order_item_type = %s', self::ORDER_ITEM_TYPE);
+    }
+
+    public function filter_orders_distinct(string $distinct, WP_Query $query): string
+    {
+        if (self::ORDER_ITEM_TYPE !== $query->get('fp_exp_order_item_type')) {
+            return $distinct;
+        }
+
+        return 'DISTINCT';
+    }
+}

--- a/src/Admin/RequestsPage.php
+++ b/src/Admin/RequestsPage.php
@@ -12,7 +12,6 @@ use function absint;
 use function add_action;
 use function add_query_arg;
 use function add_settings_error;
-use function add_submenu_page;
 use function admin_url;
 use function check_admin_referer;
 use function current_time;
@@ -50,25 +49,12 @@ final class RequestsPage
 
     public function register_hooks(): void
     {
-        add_action('admin_menu', [$this, 'register_menu']);
         add_action('admin_init', [$this, 'maybe_handle_action']);
-    }
-
-    public function register_menu(): void
-    {
-        add_submenu_page(
-            'fp-exp-settings',
-            esc_html__('Requests', 'fp-experiences'),
-            esc_html__('Requests', 'fp-experiences'),
-            'fp_exp_manage_requests',
-            'fp-exp-requests',
-            [$this, 'render_page']
-        );
     }
 
     public function maybe_handle_action(): void
     {
-        if (! current_user_can('fp_exp_manage_requests')) {
+        if (! current_user_can('fp_exp_operate')) {
             return;
         }
 
@@ -120,12 +106,9 @@ final class RequestsPage
         $stored = get_settings_errors('fp_exp_rtb_requests');
         set_transient('fp_exp_rtb_requests_notices', $stored, 30);
 
-        $redirect = add_query_arg(
-            [
-                'page' => 'fp-exp-requests',
-            ],
-            admin_url('admin.php')
-        );
+        $redirect = add_query_arg([
+            'page' => 'fp_exp_requests',
+        ], admin_url('admin.php'));
 
         wp_safe_redirect($redirect);
         exit;
@@ -133,7 +116,7 @@ final class RequestsPage
 
     public function render_page(): void
     {
-        if (! current_user_can('fp_exp_manage_requests')) {
+        if (! current_user_can('fp_exp_operate')) {
             return;
         }
 
@@ -176,7 +159,7 @@ final class RequestsPage
         echo '<h1>' . esc_html__('Request-to-Book', 'fp-experiences') . '</h1>';
 
         echo '<form method="get" class="fp-exp-requests__filters">';
-        echo '<input type="hidden" name="page" value="fp-exp-requests" />';
+        echo '<input type="hidden" name="page" value="fp_exp_requests" />';
         echo '<label for="fp-exp-requests-status">' . esc_html__('Filter by status', 'fp-experiences') . '</label> ';
         echo '<select id="fp-exp-requests-status" name="status">';
         $options = ['all' => esc_html__('All statuses', 'fp-experiences')] + $statuses;

--- a/src/Admin/ToolsPage.php
+++ b/src/Admin/ToolsPage.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP_Exp\Admin;
+
+use function add_action;
+use function current_user_can;
+use function esc_html__;
+use function get_current_screen;
+use function settings_errors;
+use function wp_die;
+
+final class ToolsPage
+{
+    private SettingsPage $settings_page;
+
+    public function __construct(SettingsPage $settings_page)
+    {
+        $this->settings_page = $settings_page;
+    }
+
+    public function register_hooks(): void
+    {
+        add_action('admin_enqueue_scripts', [$this, 'enqueue_assets']);
+    }
+
+    public function enqueue_assets(): void
+    {
+        $screen = get_current_screen();
+        if (! $screen || 'fp-exp-dashboard_page_fp_exp_tools' !== $screen->id) {
+            return;
+        }
+
+        $this->settings_page->enqueue_tools_assets();
+    }
+
+    public function render_page(): void
+    {
+        if (! current_user_can('fp_exp_manage')) {
+            wp_die(esc_html__('You do not have permission to run FP Experiences tools.', 'fp-experiences'));
+        }
+
+        echo '<div class="wrap fp-exp-tools-page">';
+        echo '<h1>' . esc_html__('Strumenti operativi', 'fp-experiences') . '</h1>';
+        echo '<p>' . esc_html__('Esegui azioni di manutenzione: sincronizzazioni Brevo, ripubblicazione eventi, pulizia cache e diagnostica.', 'fp-experiences') . '</p>';
+
+        settings_errors('fp_exp_settings');
+        $this->settings_page->render_tools_panel();
+        echo '</div>';
+    }
+}

--- a/src/Api/RestRoutes.php
+++ b/src/Api/RestRoutes.php
@@ -45,7 +45,7 @@ final class RestRoutes
             [
                 'methods' => 'GET',
                 'permission_callback' => static function (): bool {
-                    return current_user_can('fp_exp_manage_calendar');
+                    return current_user_can('fp_exp_operate');
                 },
                 'callback' => [$this, 'get_calendar_slots'],
                 'args' => [
@@ -75,7 +75,7 @@ final class RestRoutes
             [
                 'methods' => 'POST',
                 'permission_callback' => static function (): bool {
-                    return current_user_can('fp_exp_manage_calendar');
+                    return current_user_can('fp_exp_operate');
                 },
                 'callback' => [$this, 'move_calendar_slot'],
                 'args' => [
@@ -97,7 +97,7 @@ final class RestRoutes
             [
                 'methods' => 'POST',
                 'permission_callback' => static function (): bool {
-                    return current_user_can('fp_exp_manage_calendar');
+                    return current_user_can('fp_exp_operate');
                 },
                 'callback' => [$this, 'update_slot_capacity'],
             ]
@@ -109,7 +109,7 @@ final class RestRoutes
             [
                 'methods' => 'POST',
                 'permission_callback' => static function (): bool {
-                    return current_user_can('fp_exp_manage_tools');
+                    return current_user_can('fp_exp_manage');
                 },
                 'callback' => [$this, 'tool_resync_brevo'],
             ]
@@ -121,7 +121,7 @@ final class RestRoutes
             [
                 'methods' => 'POST',
                 'permission_callback' => static function (): bool {
-                    return current_user_can('fp_exp_manage_tools');
+                    return current_user_can('fp_exp_manage');
                 },
                 'callback' => [$this, 'tool_replay_events'],
             ]
@@ -133,7 +133,7 @@ final class RestRoutes
             [
                 'methods' => 'POST',
                 'permission_callback' => static function (): bool {
-                    return current_user_can('fp_exp_manage_tools');
+                    return current_user_can('fp_exp_manage');
                 },
                 'callback' => [$this, 'tool_ping'],
             ]
@@ -145,7 +145,7 @@ final class RestRoutes
             [
                 'methods' => 'POST',
                 'permission_callback' => static function (): bool {
-                    return current_user_can('fp_exp_manage_tools');
+                    return current_user_can('fp_exp_manage');
                 },
                 'callback' => [$this, 'tool_clear_cache'],
             ]

--- a/src/Api/Webhooks.php
+++ b/src/Api/Webhooks.php
@@ -47,7 +47,7 @@ final class Webhooks
             [
                 'methods' => WP_REST_Server::READABLE,
                 'permission_callback' => static function (): bool {
-                    return current_user_can('fp_exp_manage_tools');
+                    return current_user_can('fp_exp_manage');
                 },
                 'callback' => [$this, 'handle_ping'],
             ]

--- a/src/MeetingPoints/MeetingPointCPT.php
+++ b/src/MeetingPoints/MeetingPointCPT.php
@@ -49,7 +49,7 @@ final class MeetingPointCPT
             'labels' => $labels,
             'public' => false,
             'show_ui' => true,
-            'show_in_menu' => Helpers::meeting_points_enabled() ? 'fp-exp-settings' : false,
+                'show_in_menu' => false,
             'supports' => ['title'],
             'show_in_rest' => false,
             'rewrite' => false,

--- a/src/MeetingPoints/MeetingPointImporter.php
+++ b/src/MeetingPoints/MeetingPointImporter.php
@@ -55,10 +55,10 @@ final class MeetingPointImporter
         }
 
         add_submenu_page(
-            'fp-exp-settings',
+            'fp_exp_dashboard',
             esc_html__('Import Meeting Points', 'fp-experiences'),
             esc_html__('Import Meeting Points', 'fp-experiences'),
-            'manage_options',
+            'fp_exp_manage',
             'fp-exp-meeting-points-import',
             [$this, 'render_page']
         );
@@ -66,7 +66,7 @@ final class MeetingPointImporter
 
     public function render_page(): void
     {
-        if (! current_user_can('manage_options')) {
+        if (! current_user_can('fp_exp_manage')) {
             wp_die(esc_html__('You do not have permission to access this page.', 'fp-experiences'));
         }
 
@@ -103,7 +103,7 @@ final class MeetingPointImporter
             wp_die(esc_html__('Meeting points are disabled.', 'fp-experiences'));
         }
 
-        if (! current_user_can('manage_options')) {
+        if (! current_user_can('fp_exp_manage')) {
             wp_die(esc_html__('You do not have permission to import meeting points.', 'fp-experiences'));
         }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -8,11 +8,17 @@ use FP_Exp\Api\RestRoutes;
 use FP_Exp\Api\Webhooks;
 use FP_Exp\Booking\Cart;
 use FP_Exp\Booking\Checkout as BookingCheckout;
+use FP_Exp\Admin\AdminMenu;
 use FP_Exp\Admin\CalendarAdmin;
 use FP_Exp\Admin\RequestsPage;
 use FP_Exp\Admin\ExperienceMetaBoxes;
 use FP_Exp\Admin\SettingsPage;
 use FP_Exp\Admin\LogsPage;
+use FP_Exp\Admin\ToolsPage;
+use FP_Exp\Admin\CheckinPage;
+use FP_Exp\Admin\OrdersPage;
+use FP_Exp\Admin\HelpPage;
+use FP_Exp\Admin\ExperiencePageCreator;
 use FP_Exp\Booking\Emails;
 use FP_Exp\Booking\Orders;
 use FP_Exp\Booking\Reservations;
@@ -77,6 +83,18 @@ final class Plugin
 
     private ?ExperienceMetaBoxes $experience_meta_boxes = null;
 
+    private ?ToolsPage $tools_page = null;
+
+    private ?CheckinPage $checkin_page = null;
+
+    private ?OrdersPage $orders_page = null;
+
+    private ?HelpPage $help_page = null;
+
+    private ?ExperiencePageCreator $page_creator = null;
+
+    private ?AdminMenu $admin_menu = null;
+
     private ?ElementorWidgetsRegistrar $elementor_widgets = null;
 
     private ?RestRoutes $rest_routes = null;
@@ -122,6 +140,22 @@ final class Plugin
             $this->logs_page = new LogsPage();
             $this->requests_page = new RequestsPage($this->request_to_book);
             $this->experience_meta_boxes = new ExperienceMetaBoxes();
+            $this->tools_page = new ToolsPage($this->settings_page);
+            $this->checkin_page = new CheckinPage();
+            $this->orders_page = new OrdersPage();
+            $this->help_page = new HelpPage();
+            $this->page_creator = new ExperiencePageCreator();
+            $this->admin_menu = new AdminMenu(
+                $this->settings_page,
+                $this->calendar_admin,
+                $this->logs_page,
+                $this->requests_page,
+                $this->tools_page,
+                $this->checkin_page,
+                $this->orders_page,
+                $this->help_page,
+                $this->page_creator
+            );
         }
     }
 
@@ -180,6 +214,26 @@ final class Plugin
 
         if ($this->experience_meta_boxes instanceof ExperienceMetaBoxes) {
             $this->experience_meta_boxes->register_hooks();
+        }
+
+        if ($this->tools_page instanceof ToolsPage) {
+            $this->tools_page->register_hooks();
+        }
+
+        if ($this->checkin_page instanceof CheckinPage) {
+            $this->checkin_page->register_hooks();
+        }
+
+        if ($this->page_creator instanceof ExperiencePageCreator) {
+            $this->page_creator->register_hooks();
+        }
+
+        if ($this->orders_page instanceof OrdersPage) {
+            $this->orders_page->register_hooks();
+        }
+
+        if ($this->admin_menu instanceof AdminMenu) {
+            $this->admin_menu->register_hooks();
         }
 
         if ($this->elementor_widgets instanceof ElementorWidgetsRegistrar) {

--- a/src/PostTypes/ExperienceCPT.php
+++ b/src/PostTypes/ExperienceCPT.php
@@ -69,7 +69,7 @@ final class ExperienceCPT
                 ],
                 'public' => true,
                 'show_ui' => true,
-                'show_in_menu' => true,
+                'show_in_menu' => false,
                 'menu_position' => 20,
                 'menu_icon' => 'dashicons-location-alt',
                 'show_in_rest' => true,
@@ -81,7 +81,9 @@ final class ExperienceCPT
                 ],
                 'exclude_from_search' => true,
                 'publicly_queryable' => true,
-                'capability_type' => 'post',
+                'capability_type' => ['fp_experience', 'fp_experiences'],
+                'map_meta_cap' => true,
+                'capabilities' => $this->get_capabilities(),
             ]
         );
     }
@@ -186,6 +188,29 @@ final class ExperienceCPT
 
             register_post_meta('fp_experience', $key, $args);
         }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function get_capabilities(): array
+    {
+        return [
+            'edit_post' => 'edit_fp_experience',
+            'read_post' => 'read_fp_experience',
+            'delete_post' => 'delete_fp_experience',
+            'edit_posts' => 'edit_fp_experiences',
+            'edit_others_posts' => 'edit_others_fp_experiences',
+            'publish_posts' => 'publish_fp_experiences',
+            'read_private_posts' => 'read_private_fp_experiences',
+            'delete_posts' => 'delete_fp_experiences',
+            'delete_private_posts' => 'delete_private_fp_experiences',
+            'delete_published_posts' => 'delete_published_fp_experiences',
+            'delete_others_posts' => 'delete_others_fp_experiences',
+            'edit_private_posts' => 'edit_private_fp_experiences',
+            'edit_published_posts' => 'edit_published_fp_experiences',
+            'create_posts' => 'edit_fp_experiences',
+        ];
     }
 
     /**


### PR DESCRIPTION
## Summary
- add a first-level "FP Experiences" admin menu with all plugin pages and conditional submenu visibility
- wire new dashboard, tools, orders, check-in, and help pages with role-aware capability checks and shared assets
- document the menu structure, update role capabilities, and adjust REST/webhook permissions and WooCommerce order filtering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da9a323688832f91cb326b8c57cbf8