### PR TITLE
Refine experience page layout and controls

### DIFF
--- a/.rebuild-state.json
+++ b/.rebuild-state.json
@@ -46,8 +46,8 @@
     }
   },
   "rebuild": {
-    "feature": "admin-menu",
-    "step": "POLISH"
+    "feature": "exp-layout",
+    "step": "DOCS"
   },
   "verify_current": "FRONT-BINDING"
 }

--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -1055,34 +1055,50 @@
     }
 }
 
-.fp-exp-page {
+.fp-layout {
     position: relative;
     display: block;
-    --fp-exp-spacing: clamp(1.5rem, 4vw, 3rem);
+    width: 100%;
+    --fp-exp-spacing: clamp(1rem, 4vw, 1.5rem);
+    margin-inline: auto;
+    padding-inline: clamp(16px, 5vw, 24px);
 }
 
-.fp-exp-page__layout {
+.fp-grid {
     display: flex;
     flex-direction: column;
     gap: var(--fp-exp-spacing);
 }
 
-.fp-exp-page__main {
+.fp-main {
     display: flex;
     flex-direction: column;
     gap: var(--fp-exp-spacing);
 }
 
-.fp-exp-page__hero {
+.fp-main > section {
+    background: var(--fp-exp-color-surface, #f7f4f0);
+    border-radius: var(--fp-btn-radius, 12px);
+    padding: clamp(16px, 2vw, 24px);
+}
+
+.fp-layout.is-full {
+    width: 100vw;
+    margin-left: calc(50% - 50vw);
+    padding-inline: clamp(16px, 4vw, 48px);
+    max-width: none;
+}
+
+.fp-section.fp-hero {
     display: grid;
-    gap: clamp(1.5rem, 4vw, 2.5rem);
+    gap: clamp(1.25rem, 4vw, 2.5rem);
     background: var(--fp-exp-color-surface, #f7f4f0);
     padding: clamp(1.5rem, 4vw, 2.75rem);
     border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
     box-shadow: var(--fp-exp-shadow-base, 0 14px 40px rgba(0,0,0,0.08));
 }
 
-.fp-exp-page__hero-media {
+.fp-hero-media {
     position: relative;
     border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
     overflow: hidden;
@@ -1090,15 +1106,16 @@
     background: linear-gradient(135deg, var(--fp-exp-color-primary, #8B1E3F), var(--fp-exp-color-accent, #5B8C5A));
 }
 
-.fp-exp-gallery {
+.fp-hero {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 0.75rem;
+    gap: 0.5rem;
     width: 100%;
     height: 100%;
 }
 
-.fp-exp-gallery__item {
+.fp-hero-main,
+.fp-hero-item {
     margin: 0;
     position: relative;
     border-radius: var(--fp-exp-radius-base, 12px);
@@ -1106,7 +1123,11 @@
     background: rgba(0, 0, 0, 0.08);
 }
 
-.fp-exp-gallery__item img {
+.fp-hero-main {
+    aspect-ratio: 16 / 9;
+}
+
+.fp-hero img {
     width: 100%;
     height: 100%;
     object-fit: cover;
@@ -1118,6 +1139,8 @@
     width: 100%;
     height: 100%;
     min-height: 220px;
+    border-radius: var(--fp-exp-radius-base, 12px);
+    overflow: hidden;
 }
 
 .fp-exp-gallery--placeholder span {
@@ -1132,44 +1155,48 @@
     );
 }
 
-.fp-exp-page__hero-body {
+.fp-hero-body {
     display: flex;
     flex-direction: column;
     gap: 1rem;
 }
 
-.fp-exp-page__eyebrow {
+.fp-eyebrow {
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.12em;
     color: var(--fp-exp-color-muted, #666666);
 }
 
-.fp-exp-page__title {
+.fp-title {
     margin: 0;
-    font-size: clamp(2rem, 5vw, 3.25rem);
-    line-height: 1.05;
+    font-size: clamp(28px, 3vw, 40px);
+    line-height: 1.1;
     color: var(--fp-exp-color-text, #1F1F1F);
 }
 
-.fp-exp-page__badges {
+.fp-meta {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5rem;
+    gap: 0.625rem;
     padding: 0;
     margin: 0;
     list-style: none;
 }
 
-.fp-exp-page__badge-item {
+.fp-badge {
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    background: rgba(0, 0, 0, 0.05);
+    background: var(--fp-exp-color-surface, #f7f4f0);
     color: var(--fp-exp-color-text, #1F1F1F);
     padding: 0.45rem 0.75rem;
     border-radius: 999px;
     font-size: 0.875rem;
+}
+
+.fp-badge__label {
+    font-weight: 500;
 }
 
 .fp-exp-icon {
@@ -1181,9 +1208,9 @@
     color: var(--fp-exp-color-primary, #8B1E3F);
 }
 
-.fp-exp-page__summary {
+.fp-summary {
     margin: 0;
-    font-size: 1.125rem;
+    font-size: 1.05rem;
     line-height: 1.6;
     color: var(--fp-exp-color-text, #1F1F1F);
 }
@@ -1201,12 +1228,18 @@
     border: none;
     cursor: pointer;
     transition: background 0.2s ease, transform 0.2s ease;
-}
-
 .fp-exp-button:hover,
 .fp-exp-button:focus {
     background: var(--fp-exp-color-secondary, #405F3B);
     transform: translateY(-1px);
+}
+
+.fp-hero-cta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: baseline;
+    margin-bottom: 0.75rem;
 }
 
 .fp-exp-page__nav {
@@ -1409,7 +1442,7 @@
     line-height: 1.6;
 }
 
-.fp-exp-page__aside {
+.fp-aside {
     position: relative;
 }
 
@@ -1456,36 +1489,74 @@
 }
 
 @media (min-width: 768px) {
-    .fp-exp-gallery {
+    .fp-hero {
         grid-template-columns: repeat(3, minmax(0, 1fr));
-        grid-auto-rows: 140px;
+        grid-auto-rows: 160px;
     }
 
-    .fp-exp-gallery__item:nth-child(1) {
+    .fp-hero > .fp-hero-main {
         grid-column: span 2;
         grid-row: span 2;
     }
 }
 
 @media (min-width: 1024px) {
-    .fp-exp-page__layout {
-        flex-direction: row;
-        align-items: flex-start;
+    .fp-layout {
+        --fp-max: var(--fp-exp-max, 1200px);
+        --fp-gutter: var(--fp-exp-gutter, 24px);
+        margin-inline: auto;
+        width: min(100%, var(--fp-max));
+        padding-inline: var(--fp-gutter);
     }
 
-    .fp-exp-page__main {
-        flex: 1 1 auto;
+    .fp-grid {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 360px);
+        gap: clamp(20px, 3vw, 40px);
+        align-items: start;
     }
 
-    .fp-exp-page__aside {
-        flex: 0 0 360px;
+    .fp-main {
+        grid-column: 1;
+    }
+
+    .fp-aside {
+        grid-column: 2;
         position: sticky;
-        top: 2rem;
-        max-height: calc(100vh - 4rem);
+        top: 24px;
+        align-self: start;
     }
 
-    .fp-exp-page__hero {
-        grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+    .fp-section.fp-hero {
+        padding: clamp(20px, 3vw, 36px);
+    }
+
+    .fp-hero {
+        grid-template-columns: 2fr 1fr;
+        grid-auto-rows: 180px;
+        gap: 8px;
+    }
+
+    .fp-hero > .fp-hero-main {
+        grid-row: 1 / span 2;
+        aspect-ratio: 16 / 9;
+    }
+
+    .fp-layout[data-sidebar="left"] .fp-main {
+        grid-column: 2;
+    }
+
+    .fp-layout[data-sidebar="left"] .fp-aside {
+        grid-column: 1;
+    }
+
+    .fp-layout[data-sidebar="left"] .fp-grid {
+        grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
+    }
+
+    .fp-layout[data-sidebar="none"] .fp-grid,
+    .fp-layout.is-single .fp-grid {
+        grid-template-columns: minmax(0, 1fr);
     }
 
     .fp-exp-columns {
@@ -1502,7 +1573,7 @@
 }
 
 @media (min-width: 1280px) {
-    .fp-exp-page__hero {
+    .fp-hero {
         grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
     }
 }

--- a/docs/VERIFY-EXPERIENCE-LAYOUT.md
+++ b/docs/VERIFY-EXPERIENCE-LAYOUT.md
@@ -1,0 +1,26 @@
+# Verify Experience Page Layout
+
+## Desktop layout
+- Place `[fp_exp_page id="{ID}"]` on a page and view at ≥1024px.
+- Confirm the layout shows two columns with content on the left and the booking widget in a sticky aside on the right.
+- Scroll to ensure the aside sticks within the viewport and the main sections keep rounded cards with comfortable spacing.
+- Toggle the shortcode to `[fp_exp_page ... sidebar="left"]` and verify the widget column moves to the left while the DOM order (main then aside) remains unchanged.
+- Test `[fp_exp_page ... sidebar="none"]` and ensure the page becomes single-column, the widget is hidden, and sticky CTA buttons disappear.
+
+## Full-width breakout
+- Set shortcode attributes `container="full" max_width="1280" gutter="32"` (or adjust defaults in **Settings → Experience Page Layout**).
+- Confirm the layout breaks out of narrow theme containers, aligning edge-to-edge with the configured gutter.
+- Resize to ensure the layout recenters correctly when returning to boxed mode.
+
+## Mobile behaviour
+- View the page at ≤1023px.
+- Check that sections stack vertically with consistent 16–20px spacing and the widget appears below the content.
+- Scroll to confirm the sticky CTA bar still appears only when the widget exists.
+
+## Settings defaults
+- In **FP Experiences → Settings → Experience Page Layout**, adjust container, max-width, gutter, and sidebar defaults.
+- Save and verify a shortcode without explicit layout attributes inherits the updated defaults.
+
+## Elementor widget
+- Drop the “FP Experience Page” widget in Elementor and confirm the new layout controls (Container, Maximum width, Side padding, Sidebar) appear.
+- Change controls and observe the live preview updates after applying; publish and verify the rendered page matches the selected options.

--- a/readme.txt
+++ b/readme.txt
@@ -36,13 +36,15 @@ FP Experiences brings GetYourGuide-style booking flows to WooCommerce without to
 * `[fp_exp_calendar id="123" months="2"]` – Inline availability calendar for a single experience.
 * `[fp_exp_checkout]` – Isolated checkout that finalises the FP Experiences cart only.
 * `[fp_exp_meeting_points id="123"]` – Outputs the primary meeting point and optional alternatives for an experience, with map links built client-side.
-* `[fp_exp_page id="123" sections="hero,highlights,inclusions,meeting,extras,faq,reviews" sticky_widget="1"]` – Full experience detail page with hero gallery, highlights, inclusions/exclusions, meeting point block, FAQ accordion, reviews, and sticky availability widget. Supports the usual theming overrides (`preset`, `mode`, color variables, `radius`, `shadow`, `font`).
+* `[fp_exp_page id="123" sections="hero,highlights,inclusions,meeting,extras,faq,reviews" sticky_widget="1" container="boxed" max_width="1200" gutter="24" sidebar="right"]` – Full experience detail page with hero gallery, highlights, inclusions/exclusions, meeting point block, FAQ accordion, reviews, and sticky availability widget. Supports theming overrides (`preset`, `mode`, color variables, `radius`, `shadow`, `font`) plus layout controls: `container` (`boxed` or `full`), `max_width`/`gutter` (pixels) and `sidebar` (`right`, `left`, `none`).
 
 The `sections` attribute accepts a comma-separated list of sections to render (hero, highlights, inclusions, meeting, extras, faq, reviews). Meeting point data automatically reuses the Meeting Points module when enabled; otherwise the section is hidden. Set `sticky_widget="0"` to disable the mobile CTA bar.
 
 == Elementor Widgets ==
 
 Six Elementor widgets mirror the shortcodes: List, Widget, Calendar, Checkout, Meeting Points, and the new Experience Page layout. The List widget now bundles the full showcase controls (filters, search, ordering, map toggle, CTA behaviour) plus responsive style controls for columns, card spacing, and badge/price visibility. Each widget exposes theming overrides (colors, radius, fonts) alongside behavioural toggles (sticky mode, inline calendar, consent defaults). The Experience Page widget lets editors pick sections to display and toggle the sticky availability bar while reusing the `[fp_exp_page]` shortcode under the hood.
+
+If your theme applies a narrow content container you can break the layout out to the full viewport with `container="full"` (optionally adjusting `max_width`/`gutter`).
 
 == Admin menu ==
 

--- a/src/Elementor/WidgetExperiencePage.php
+++ b/src/Elementor/WidgetExperiencePage.php
@@ -92,6 +92,58 @@ final class WidgetExperiencePage extends Widget_Base
             ]
         );
 
+        $this->add_control(
+            'container',
+            [
+                'label' => esc_html__('Container', 'fp-experiences'),
+                'type' => Controls_Manager::SELECT,
+                'options' => [
+                    '' => esc_html__('Default', 'fp-experiences'),
+                    'boxed' => esc_html__('Boxed', 'fp-experiences'),
+                    'full' => esc_html__('Full width', 'fp-experiences'),
+                ],
+                'default' => '',
+                'separator' => 'before',
+            ]
+        );
+
+        $this->add_control(
+            'max_width',
+            [
+                'label' => esc_html__('Maximum width (px)', 'fp-experiences'),
+                'type' => Controls_Manager::NUMBER,
+                'min' => 0,
+                'step' => 10,
+                'default' => '',
+            ]
+        );
+
+        $this->add_control(
+            'gutter',
+            [
+                'label' => esc_html__('Side padding (px)', 'fp-experiences'),
+                'type' => Controls_Manager::NUMBER,
+                'min' => 0,
+                'step' => 4,
+                'default' => '',
+            ]
+        );
+
+        $this->add_control(
+            'sidebar',
+            [
+                'label' => esc_html__('Sidebar position', 'fp-experiences'),
+                'type' => Controls_Manager::SELECT,
+                'options' => [
+                    '' => esc_html__('Default', 'fp-experiences'),
+                    'right' => esc_html__('Right column', 'fp-experiences'),
+                    'left' => esc_html__('Left column', 'fp-experiences'),
+                    'none' => esc_html__('No sidebar (single column)', 'fp-experiences'),
+                ],
+                'default' => '',
+            ]
+        );
+
         $this->end_controls_section();
 
         $this->start_controls_section(
@@ -119,6 +171,10 @@ final class WidgetExperiencePage extends Widget_Base
             'id' => (string) ($settings['experience_id'] ?? ''),
             'sections' => $sections ?: 'hero,highlights,inclusions,meeting,extras,faq,reviews',
             'sticky_widget' => ('yes' === ($settings['sticky_widget'] ?? 'yes')) ? '1' : '0',
+            'container' => (string) ($settings['container'] ?? ''),
+            'max_width' => (string) ($settings['max_width'] ?? ''),
+            'gutter' => (string) ($settings['gutter'] ?? ''),
+            'sidebar' => (string) ($settings['sidebar'] ?? ''),
         ];
 
         $atts = array_merge($atts, $this->collect_theme_atts($settings));

--- a/templates/front/experience.php
+++ b/templates/front/experience.php
@@ -28,7 +28,47 @@ if (! defined('ABSPATH')) {
 }
 
 $scope_class = $scope_class ?? '';
-$container_classes = trim('fp-exp fp-exp-page ' . $scope_class);
+$layout = $layout ?? [
+    'container' => 'boxed',
+    'max_width' => null,
+    'gutter' => null,
+    'sidebar' => 'right',
+];
+
+$layout_container = $layout['container'] ?? 'boxed';
+$layout_max_width = isset($layout['max_width']) ? (int) $layout['max_width'] : 0;
+$layout_gutter = isset($layout['gutter']) ? (int) $layout['gutter'] : 0;
+$sidebar_position = $layout['sidebar'] ?? 'right';
+
+$wrapper_classes = ['fp-exp', 'fp-layout', 'fp-exp-page'];
+
+if ('' !== $scope_class) {
+    $wrapper_classes[] = $scope_class;
+}
+
+if ('full' === $layout_container) {
+    $wrapper_classes[] = 'is-full';
+}
+
+if ('none' === $sidebar_position) {
+    $wrapper_classes[] = 'is-single';
+}
+
+if ('left' === $sidebar_position) {
+    $wrapper_classes[] = 'is-sidebar-left';
+}
+
+$layout_style = [];
+
+if ($layout_max_width > 0) {
+    $layout_style[] = '--fp-exp-max:' . $layout_max_width . 'px';
+}
+
+if ($layout_gutter > 0) {
+    $layout_style[] = '--fp-exp-gutter:' . $layout_gutter . 'px';
+}
+
+$layout_style_attr = empty($layout_style) ? '' : implode(';', $layout_style);
 
 $navigation = isset($navigation) && is_array($navigation) ? $navigation : [];
 $has_navigation = ! empty($navigation);
@@ -40,9 +80,17 @@ $has_faq = ! empty($faq);
 $has_reviews = ! empty($reviews);
 
 $cta_label = esc_html__('Controlla disponibilità', 'fp-experiences');
+$layout_data = 'none' === $sidebar_position ? 'single' : 'auto';
+$sidebar_data = in_array($sidebar_position, ['left', 'none'], true) ? $sidebar_position : 'right';
 
 ?>
-<section class="<?php echo esc_attr($container_classes); ?>" data-fp-shortcode="experience">
+<div
+    class="<?php echo esc_attr(implode(' ', $wrapper_classes)); ?>"
+    data-fp-shortcode="experience"
+    data-layout="<?php echo esc_attr($layout_data); ?>"
+    data-sidebar="<?php echo esc_attr($sidebar_data); ?>"
+    <?php if ('' !== $layout_style_attr) : ?>style="<?php echo esc_attr($layout_style_attr); ?>"<?php endif; ?>
+>
     <?php if (! empty($data_layer)) : ?>
         <script>
             window.dataLayer = window.dataLayer || [];
@@ -50,15 +98,18 @@ $cta_label = esc_html__('Controlla disponibilità', 'fp-experiences');
         </script>
     <?php endif; ?>
 
-    <div class="fp-exp-page__layout" data-fp-page>
-        <main class="fp-exp-page__main">
+    <div class="fp-grid" data-fp-page>
+        <main class="fp-main">
             <?php if (! empty($sections['hero'])) : ?>
-                <header class="fp-exp-page__hero" id="fp-exp-section-hero" data-fp-section="hero">
-                    <div class="fp-exp-page__hero-media" aria-hidden="<?php echo empty($gallery) ? 'true' : 'false'; ?>">
+                <section class="fp-section fp-hero" id="fp-exp-section-hero" data-fp-section="hero">
+                    <div class="fp-hero-media" aria-hidden="<?php echo empty($gallery) ? 'true' : 'false'; ?>">
                         <?php if (! empty($gallery)) : ?>
-                            <div class="fp-exp-gallery" data-fp-gallery>
-                                <?php foreach ($gallery as $index => $image) : ?>
-                                    <figure class="fp-exp-gallery__item" data-index="<?php echo esc_attr((string) $index); ?>">
+                            <div class="fp-hero fp-exp-gallery" data-fp-gallery>
+                                <?php foreach ($gallery as $index => $image) :
+                                    $figure_classes = ['fp-exp-gallery__item'];
+                                    $figure_classes[] = 0 === $index ? 'fp-hero-main' : 'fp-hero-item';
+                                    ?>
+                                    <figure class="<?php echo esc_attr(implode(' ', $figure_classes)); ?>" data-index="<?php echo esc_attr((string) $index); ?>">
                                         <img
                                             src="<?php echo esc_url($image['url']); ?>"
                                             <?php if (! empty($image['srcset'])) : ?>srcset="<?php echo esc_attr($image['srcset']); ?>"<?php endif; ?>
@@ -71,20 +122,20 @@ $cta_label = esc_html__('Controlla disponibilità', 'fp-experiences');
                                 <?php endforeach; ?>
                             </div>
                         <?php else : ?>
-                            <div class="fp-exp-gallery fp-exp-gallery--placeholder">
+                            <div class="fp-hero fp-exp-gallery fp-exp-gallery--placeholder">
                                 <span aria-hidden="true"></span>
                             </div>
                         <?php endif; ?>
                     </div>
-                    <div class="fp-exp-page__hero-body">
-                        <div class="fp-exp-page__eyebrow">
-                            <span class="fp-exp-page__badge">FP Experiences</span>
+                    <div class="fp-hero-body">
+                        <div class="fp-eyebrow">
+                            <span class="fp-badge">FP Experiences</span>
                         </div>
-                        <h1 class="fp-exp-page__title"><?php echo esc_html($experience['title']); ?></h1>
+                        <h1 class="fp-title"><?php echo esc_html($experience['title']); ?></h1>
                         <?php if (! empty($badges)) : ?>
-                            <ul class="fp-exp-page__badges" role="list">
+                            <ul class="fp-meta" role="list">
                                 <?php foreach ($badges as $badge) : ?>
-                                    <li class="fp-exp-page__badge-item">
+                                    <li class="fp-badge">
                                         <span class="fp-exp-icon fp-exp-icon--<?php echo esc_attr($badge['icon']); ?>" aria-hidden="true">
                                             <?php if ('clock' === $badge['icon']) : ?>
                                                 <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm1 10.59 2.12 2.12-1.41 1.41-2.83-2.83V7h2.12Z"/></svg>
@@ -94,15 +145,15 @@ $cta_label = esc_html__('Controlla disponibilità', 'fp-experiences');
                                                 <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M12 12.88 9.17 10H5a3 3 0 0 0-3 3v7h6v-4h2v4h6v-7a3 3 0 0 0-3-3h-1.17Zm9-2.88a4 4 0 1 0-4-4 4 4 0 0 0 4 4Z"/></svg>
                                             <?php endif; ?>
                                         </span>
-                                        <span class="fp-exp-page__badge-label"><?php echo esc_html($badge['label']); ?></span>
+                                        <span class="fp-badge__label"><?php echo esc_html($badge['label']); ?></span>
                                     </li>
                                 <?php endforeach; ?>
                             </ul>
                         <?php endif; ?>
                         <?php if (! empty($experience['summary'])) : ?>
-                            <p class="fp-exp-page__summary"><?php echo esc_html($experience['summary']); ?></p>
+                            <p class="fp-summary"><?php echo esc_html($experience['summary']); ?></p>
                         <?php endif; ?>
-                        <div class="fp-exp-page__hero-cta">
+                        <div class="fp-hero-cta">
                             <a
                                 href="#fp-exp-widget"
                                 class="fp-exp-button"
@@ -113,7 +164,7 @@ $cta_label = esc_html__('Controlla disponibilità', 'fp-experiences');
                             </a>
                         </div>
                     </div>
-                </header>
+                </section>
             <?php endif; ?>
 
             <?php if ($has_navigation) : ?>
@@ -316,18 +367,25 @@ $cta_label = esc_html__('Controlla disponibilità', 'fp-experiences');
             <?php endif; ?>
         </main>
 
-        <aside class="fp-exp-page__aside" data-fp-sticky-container>
-            <div class="fp-exp-page__widget" id="fp-exp-widget">
-                <?php echo $widget_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-            </div>
-        </aside>
+        <?php if ('none' !== $sidebar_position && ! empty($widget_html)) : ?>
+            <aside
+                class="fp-aside"
+                id="fp-exp-widget"
+                data-fp-sticky-container
+                aria-label="<?php esc_attr_e('Riepilogo prenotazione', 'fp-experiences'); ?>"
+            >
+                <div class="fp-exp-page__widget">
+                    <?php echo $widget_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                </div>
+            </aside>
+        <?php endif; ?>
     </div>
 
-    <?php if ($sticky_widget) : ?>
+    <?php if ($sticky_widget && 'none' !== $sidebar_position && ! empty($widget_html)) : ?>
         <div class="fp-exp-page__sticky-bar" data-fp-sticky-bar>
             <button type="button" class="fp-exp-page__sticky-button" data-fp-scroll="widget" data-fp-cta="sticky">
                 <?php echo $cta_label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
             </button>
         </div>
     <?php endif; ?>
-</section>
+</div>


### PR DESCRIPTION
## Summary
- wrap the experience template in the new layout container, update the hero markup, and hide the sidebar when disabled
- overhaul the front-end styles to support boxed/full-width layouts with configurable gutters, responsive hero gallery, and sticky sidebar behaviour
- add layout defaults to settings, propagate the attributes through the shortcode and Elementor widget, and document the verification steps

## Testing
- php -l src/Shortcodes/ExperienceShortcode.php
- php -l src/Admin/SettingsPage.php
- php -l src/Elementor/WidgetExperiencePage.php
- php -l templates/front/experience.php

------
https://chatgpt.com/codex/tasks/task_e_68daa2b7edb8832f8fbd61b92f810c4a