### PR TITLE
Use asset modification times for admin cache busting

### DIFF
--- a/src/Admin/AdminMenu.php
+++ b/src/Admin/AdminMenu.php
@@ -297,8 +297,20 @@ final class AdminMenu
             return;
         }
 
-        wp_enqueue_style('fp-exp-admin', FP_EXP_PLUGIN_URL . 'assets/css/admin.css', [], FP_EXP_VERSION);
-        wp_enqueue_script('fp-exp-admin', FP_EXP_PLUGIN_URL . 'assets/js/admin.js', ['wp-api-fetch', 'wp-i18n'], FP_EXP_VERSION, true);
+        wp_enqueue_style(
+            'fp-exp-admin',
+            FP_EXP_PLUGIN_URL . 'assets/css/admin.css',
+            [],
+            Helpers::asset_version('assets/css/admin.css')
+        );
+
+        wp_enqueue_script(
+            'fp-exp-admin',
+            FP_EXP_PLUGIN_URL . 'assets/js/admin.js',
+            ['wp-api-fetch', 'wp-i18n'],
+            Helpers::asset_version('assets/js/admin.js'),
+            true
+        );
 
         wp_localize_script('fp-exp-admin', 'fpExpAdmin', [
             'strings' => [

--- a/src/Admin/CalendarAdmin.php
+++ b/src/Admin/CalendarAdmin.php
@@ -8,6 +8,7 @@ use FP_Exp\Booking\Orders;
 use FP_Exp\Booking\Pricing;
 use FP_Exp\Booking\Reservations;
 use FP_Exp\Booking\Slots;
+use FP_Exp\Utils\Helpers;
 use WC_Order;
 use WP_Error;
 
@@ -70,14 +71,14 @@ final class CalendarAdmin
             'fp-exp-admin',
             FP_EXP_PLUGIN_URL . 'assets/css/admin.css',
             [],
-            FP_EXP_VERSION
+            Helpers::asset_version('assets/css/admin.css')
         );
 
         wp_enqueue_script(
             'fp-exp-admin',
             FP_EXP_PLUGIN_URL . 'assets/js/admin.js',
             ['wp-api-fetch', 'wp-i18n'],
-            FP_EXP_VERSION,
+            Helpers::asset_version('assets/js/admin.js'),
             true
         );
 

--- a/src/Admin/ExperienceMetaBoxes.php
+++ b/src/Admin/ExperienceMetaBoxes.php
@@ -111,14 +111,14 @@ final class ExperienceMetaBoxes
             'fp-exp-admin',
             FP_EXP_PLUGIN_URL . 'assets/css/admin.css',
             [],
-            FP_EXP_VERSION
+            Helpers::asset_version('assets/css/admin.css')
         );
 
         wp_enqueue_script(
             'fp-exp-admin',
             FP_EXP_PLUGIN_URL . 'assets/js/admin.js',
             [],
-            FP_EXP_VERSION,
+            Helpers::asset_version('assets/js/admin.js'),
             true
         );
 

--- a/src/Admin/LanguageAdmin.php
+++ b/src/Admin/LanguageAdmin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FP_Exp\Admin;
 
+use FP_Exp\Utils\Helpers;
 use FP_Exp\Utils\LanguageHelper;
 use WP_Screen;
 use WP_Term;
@@ -75,6 +76,11 @@ final class LanguageAdmin
             return;
         }
 
-        wp_enqueue_style('fp-exp-admin', FP_EXP_PLUGIN_URL . 'assets/css/admin.css', [], FP_EXP_VERSION);
+        wp_enqueue_style(
+            'fp-exp-admin',
+            FP_EXP_PLUGIN_URL . 'assets/css/admin.css',
+            [],
+            Helpers::asset_version('assets/css/admin.css')
+        );
     }
 }

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -191,8 +191,20 @@ final class SettingsPage
 
     public function enqueue_tools_assets(): void
     {
-        wp_enqueue_style('fp-exp-admin', FP_EXP_PLUGIN_URL . 'assets/css/admin.css', [], FP_EXP_VERSION);
-        wp_enqueue_script('fp-exp-admin', FP_EXP_PLUGIN_URL . 'assets/js/admin.js', ['wp-api-fetch', 'wp-i18n'], FP_EXP_VERSION, true);
+        wp_enqueue_style(
+            'fp-exp-admin',
+            FP_EXP_PLUGIN_URL . 'assets/css/admin.css',
+            [],
+            Helpers::asset_version('assets/css/admin.css')
+        );
+
+        wp_enqueue_script(
+            'fp-exp-admin',
+            FP_EXP_PLUGIN_URL . 'assets/js/admin.js',
+            ['wp-api-fetch', 'wp-i18n'],
+            Helpers::asset_version('assets/js/admin.js'),
+            true
+        );
 
         wp_localize_script('fp-exp-admin', 'fpExpTools', [
             'nonce' => wp_create_nonce('wp_rest'),

--- a/src/Shortcodes/Assets.php
+++ b/src/Shortcodes/Assets.php
@@ -8,11 +8,9 @@ use FP_Exp\Utils\Helpers;
 use FP_Exp\Utils\Theme;
 
 use function admin_url;
-use function filemtime;
 use function function_exists;
 use function get_woocommerce_currency;
 use function get_option;
-use function is_readable;
 use function is_string;
 use function trailingslashit;
 use function wp_add_inline_style;
@@ -31,11 +29,6 @@ final class Assets
     private bool $registered = false;
 
     private bool $tokens_injected = false;
-
-    /**
-     * @var array<string, string>
-     */
-    private array $version_cache = [];
 
     private function __construct()
     {
@@ -92,13 +85,13 @@ final class Assets
         $front_js = trailingslashit(FP_EXP_PLUGIN_URL) . 'assets/js/front.js';
         $checkout_js = trailingslashit(FP_EXP_PLUGIN_URL) . 'assets/js/checkout.js';
 
-        wp_register_style('fp-exp-front', $style_url, [], $this->asset_version('assets/css/front.css'));
+        wp_register_style('fp-exp-front', $style_url, [], Helpers::asset_version('assets/css/front.css'));
 
         wp_register_script(
             'fp-exp-front',
             $front_js,
             ['wp-i18n'],
-            $this->asset_version('assets/js/front.js'),
+            Helpers::asset_version('assets/js/front.js'),
             true
         );
 
@@ -106,7 +99,7 @@ final class Assets
             'fp-exp-checkout',
             $checkout_js,
             ['fp-exp-front'],
-            $this->asset_version('assets/js/checkout.js'),
+            Helpers::asset_version('assets/js/checkout.js'),
             true
         );
 
@@ -138,24 +131,4 @@ final class Assets
         );
     }
 
-    private function asset_version(string $relative): string
-    {
-        if (isset($this->version_cache[$relative])) {
-            return $this->version_cache[$relative];
-        }
-
-        $path = trailingslashit(FP_EXP_PLUGIN_DIR) . ltrim($relative, '/');
-        if (is_readable($path)) {
-            $mtime = filemtime($path);
-            if (false !== $mtime) {
-                $this->version_cache[$relative] = (string) $mtime;
-
-                return $this->version_cache[$relative];
-            }
-        }
-
-        $this->version_cache[$relative] = FP_EXP_VERSION;
-
-        return $this->version_cache[$relative];
-    }
 }


### PR DESCRIPTION
## Summary
- add a shared Helpers::asset_version utility that falls back to file modification times when available
- update admin and shortcode asset enqueues to rely on the shared helper for consistent cache busting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcf7e093fc832f8d08df765bd09750