### PR TITLE
Restore administrator FP Experiences menu access

### DIFF
--- a/src/Activation.php
+++ b/src/Activation.php
@@ -66,6 +66,18 @@ final class Activation
     }
 
     /**
+     * Return the capabilities required by FP Experiences managers.
+     *
+     * @return array<string, bool>
+     */
+    public static function manager_capabilities(): array
+    {
+        $roles = self::roles_definition();
+
+        return $roles['fp_exp_manager']['capabilities'];
+    }
+
+    /**
      * @return array<string, array{label: string, primary_capability: string, capabilities: array<string, bool>}>
      */
     private static function roles_definition(): array


### PR DESCRIPTION
## Summary
- detect missing FP Experiences capabilities on the administrator role and the current admin user
- reapply the role capabilities and grant them directly to the logged-in administrator when required

## Testing
- php -l src/Plugin.php
- php -l src/Activation.php

------
https://chatgpt.com/codex/tasks/task_e_68dd01054fe0832f9cd3e35e4837b75d