### PR TITLE
Allow non-managers to open menu and add admin capability fallbacks

### DIFF
--- a/src/Admin/AdminMenu.php
+++ b/src/Admin/AdminMenu.php
@@ -75,7 +75,7 @@ final class AdminMenu
         add_menu_page(
             esc_html__('FP Experiences', 'fp-experiences'),
             esc_html__('FP Experiences', 'fp-experiences'),
-            'fp_exp_manage',
+            'fp_exp_guide',
             'fp_exp_dashboard',
             [Dashboard::class, 'render'],
             'dashicons-location',
@@ -146,7 +146,7 @@ final class AdminMenu
             [$this->checkin_page, 'render_page']
         );
 
-        if (current_user_can('manage_woocommerce') && current_user_can('fp_exp_manage')) {
+        if (current_user_can('manage_woocommerce') && Helpers::can_manage_fp()) {
             add_submenu_page(
                 'fp_exp_dashboard',
                 esc_html__('Orders', 'fp-experiences'),
@@ -213,7 +213,7 @@ final class AdminMenu
 
     public function register_admin_bar_links(WP_Admin_Bar $admin_bar): void
     {
-        if (! current_user_can('fp_exp_guide')) {
+        if (! Helpers::can_access_guides()) {
             return;
         }
 
@@ -229,7 +229,7 @@ final class AdminMenu
         $admin_bar->add_node([
             'id' => 'fp-exp',
             'title' => esc_html__('FP Experiences', 'fp-experiences'),
-            'href' => current_user_can('fp_exp_manage')
+            'href' => Helpers::can_manage_fp()
                 ? admin_url('admin.php?page=fp_exp_dashboard')
                 : admin_url('post-new.php?post_type=fp_experience'),
             'meta' => $root_meta,
@@ -246,7 +246,7 @@ final class AdminMenu
             ]);
         }
 
-        if (current_user_can('fp_exp_operate')) {
+        if (Helpers::can_operate_fp()) {
             $admin_bar->add_node([
                 'id' => 'fp-exp-calendar',
                 'parent' => 'fp-exp',
@@ -266,7 +266,7 @@ final class AdminMenu
             }
         }
 
-        if (current_user_can('fp_exp_manage')) {
+        if (Helpers::can_manage_fp()) {
             $admin_bar->add_node([
                 'id' => 'fp-exp-settings',
                 'parent' => 'fp-exp',

--- a/src/Admin/CalendarAdmin.php
+++ b/src/Admin/CalendarAdmin.php
@@ -19,7 +19,6 @@ use function admin_url;
 use function array_filter;
 use function check_admin_referer;
 use function checked;
-use function current_user_can;
 use function esc_attr;
 use function esc_html;
 use function esc_html__;
@@ -109,7 +108,7 @@ final class CalendarAdmin
 
     public function render_page(): void
     {
-        if (! current_user_can('fp_exp_operate')) {
+        if (! Helpers::can_operate_fp()) {
             wp_die(esc_html__('You do not have permission to manage FP Experiences bookings.', 'fp-experiences'));
         }
 
@@ -402,7 +401,7 @@ final class CalendarAdmin
     {
         check_admin_referer('fp_exp_manual_booking', 'fp_exp_manual_booking_nonce');
 
-        if (! current_user_can('fp_exp_operate')) {
+        if (! Helpers::can_operate_fp()) {
             return new WP_Error('fp_exp_manual_permission', esc_html__('You do not have permission to create manual bookings.', 'fp-experiences'));
         }
 

--- a/src/Admin/CheckinPage.php
+++ b/src/Admin/CheckinPage.php
@@ -9,12 +9,12 @@ use DateTimeImmutable;
 use DateTimeZone;
 use FP_Exp\Booking\Reservations;
 use FP_Exp\Booking\Slots;
+use FP_Exp\Utils\Helpers;
 use function absint;
 use function add_action;
 use function add_query_arg;
 use function admin_url;
 use function check_admin_referer;
-use function current_user_can;
 use function esc_attr;
 use function esc_html;
 use function esc_html__;
@@ -46,7 +46,7 @@ final class CheckinPage
 
     public function maybe_handle_action(): void
     {
-        if (! current_user_can('fp_exp_operate')) {
+        if (! Helpers::can_operate_fp()) {
             return;
         }
 
@@ -89,7 +89,7 @@ final class CheckinPage
 
     public function render_page(): void
     {
-        if (! current_user_can('fp_exp_operate')) {
+        if (! Helpers::can_operate_fp()) {
             wp_die(esc_html__('You do not have permission to access the check-in console.', 'fp-experiences'));
         }
 

--- a/src/Admin/Dashboard.php
+++ b/src/Admin/Dashboard.php
@@ -32,7 +32,7 @@ final class Dashboard
 {
     public static function render(): void
     {
-        if (! current_user_can('fp_exp_manage')) {
+        if (! Helpers::can_manage_fp()) {
             wp_die(esc_html__('You do not have permission to access the FP Experiences dashboard.', 'fp-experiences'));
         }
 
@@ -101,7 +101,7 @@ final class Dashboard
             echo '<li><a class="button button-primary" href="' . esc_url(admin_url('post-new.php?post_type=fp_experience')) . '">' . esc_html__('Crea nuova esperienza', 'fp-experiences') . '</a></li>';
         }
         echo '<li><a class="button" href="' . esc_url(admin_url('edit.php?post_type=fp_experience')) . '">' . esc_html__('Gestisci vetrina', 'fp-experiences') . '</a></li>';
-        if (current_user_can('fp_exp_manage')) {
+        if (Helpers::can_manage_fp()) {
             echo '<li><a class="button" href="' . esc_url(admin_url('admin.php?page=fp_exp_settings')) . '">' . esc_html__('Apri impostazioni', 'fp-experiences') . '</a></li>';
         }
         echo '</ul>';

--- a/src/Admin/ExperiencePageCreator.php
+++ b/src/Admin/ExperiencePageCreator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FP_Exp\Admin;
 
+use FP_Exp\Utils\Helpers;
 use FP_Exp\Utils\Logger;
 use WP_Error;
 use WP_Post;
@@ -16,7 +17,6 @@ use function add_filter;
 use function add_query_arg;
 use function admin_url;
 use function check_admin_referer;
-use function current_user_can;
 use function esc_attr;
 use function esc_html;
 use function esc_html__;
@@ -54,7 +54,7 @@ final class ExperiencePageCreator
 
     public function maybe_handle_submit(): void
     {
-        if (! current_user_can('fp_exp_manage')) {
+        if (! Helpers::can_manage_fp()) {
             return;
         }
 
@@ -106,7 +106,7 @@ final class ExperiencePageCreator
 
     public function render_page(): void
     {
-        if (! current_user_can('fp_exp_manage')) {
+        if (! Helpers::can_manage_fp()) {
             wp_die(esc_html__('You do not have permission to generate experience pages.', 'fp-experiences'));
         }
 

--- a/src/Admin/HelpPage.php
+++ b/src/Admin/HelpPage.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace FP_Exp\Admin;
 
-use function current_user_can;
+use FP_Exp\Utils\Helpers;
+
 use function esc_html;
 use function esc_html__;
 use function wp_die;
@@ -13,7 +14,7 @@ final class HelpPage
 {
     public function render_page(): void
     {
-        if (! current_user_can('fp_exp_guide')) {
+        if (! Helpers::can_access_guides()) {
             wp_die(esc_html__('You do not have permission to access the FP Experiences guide.', 'fp-experiences'));
         }
 

--- a/src/Admin/LogsPage.php
+++ b/src/Admin/LogsPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FP_Exp\Admin;
 
+use FP_Exp\Utils\Helpers;
 use FP_Exp\Utils\Logger;
 
 use function add_action;
@@ -34,7 +35,7 @@ final class LogsPage
 
     public function render_page(): void
     {
-        if (! current_user_can('fp_exp_manage')) {
+        if (! Helpers::can_manage_fp()) {
             wp_die(esc_html__('You do not have permission to view FP Experiences logs.', 'fp-experiences'));
         }
 

--- a/src/Admin/Onboarding.php
+++ b/src/Admin/Onboarding.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace FP_Exp\Admin;
 
+use FP_Exp\Utils\Helpers;
+
 use function absint;
 use function add_action;
 use function add_submenu_page;
 use function admin_url;
 use function check_admin_referer;
-use function current_user_can;
 use function esc_attr;
 use function esc_html;
 use function esc_html__;
@@ -70,7 +71,7 @@ final class Onboarding
      */
     public function render(): void
     {
-        if (! current_user_can('fp_exp_manage')) {
+        if (! Helpers::can_manage_fp()) {
             wp_die(esc_html__('You do not have permission to manage FP Experiences.', 'fp-experiences'));
         }
 
@@ -135,7 +136,7 @@ final class Onboarding
      */
     public function handle_submission(): void
     {
-        if (! current_user_can('fp_exp_manage')) {
+        if (! Helpers::can_manage_fp()) {
             wp_die(esc_html__('You do not have permission to manage FP Experiences.', 'fp-experiences'));
         }
 
@@ -155,7 +156,7 @@ final class Onboarding
 
     public function maybe_show_notice(): void
     {
-        if (! current_user_can('fp_exp_manage') || $this->is_completed()) {
+        if (! Helpers::can_manage_fp() || $this->is_completed()) {
             return;
         }
 

--- a/src/Admin/OrdersPage.php
+++ b/src/Admin/OrdersPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FP_Exp\Admin;
 
+use FP_Exp\Utils\Helpers;
 use WP_Query;
 
 use function add_action;
@@ -30,7 +31,7 @@ final class OrdersPage
 
     public function render_page(): void
     {
-        if (! current_user_can('fp_exp_manage') || ! current_user_can('manage_woocommerce')) {
+        if (! Helpers::can_manage_fp() || ! current_user_can('manage_woocommerce')) {
             wp_die(esc_html__('You do not have permission to view experience orders.', 'fp-experiences'));
         }
 

--- a/src/Admin/RequestsPage.php
+++ b/src/Admin/RequestsPage.php
@@ -6,6 +6,7 @@ namespace FP_Exp\Admin;
 
 use FP_Exp\Booking\RequestToBook;
 use FP_Exp\Booking\Reservations;
+use FP_Exp\Utils\Helpers;
 use WP_Error;
 
 use function absint;
@@ -15,7 +16,6 @@ use function add_settings_error;
 use function admin_url;
 use function check_admin_referer;
 use function current_time;
-use function current_user_can;
 use function delete_transient;
 use function esc_attr;
 use function esc_html;
@@ -54,7 +54,7 @@ final class RequestsPage
 
     public function maybe_handle_action(): void
     {
-        if (! current_user_can('fp_exp_operate')) {
+        if (! Helpers::can_operate_fp()) {
             return;
         }
 
@@ -116,7 +116,7 @@ final class RequestsPage
 
     public function render_page(): void
     {
-        if (! current_user_can('fp_exp_operate')) {
+        if (! Helpers::can_operate_fp()) {
             return;
         }
 

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -92,7 +92,7 @@ final class SettingsPage
 
     public function render_page(): void
     {
-        if (! current_user_can('fp_exp_manage')) {
+        if (! Helpers::can_manage_fp()) {
             wp_die(esc_html__('You do not have permission to manage FP Experiences settings.', 'fp-experiences'));
         }
 
@@ -2201,7 +2201,7 @@ final class SettingsPage
             return;
         }
 
-        if (! current_user_can('fp_exp_manage')) {
+        if (! Helpers::can_manage_fp()) {
             return;
         }
 

--- a/src/Admin/ToolsPage.php
+++ b/src/Admin/ToolsPage.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace FP_Exp\Admin;
 
+use FP_Exp\Utils\Helpers;
+
 use function add_action;
-use function current_user_can;
 use function esc_html__;
 use function get_current_screen;
 use function settings_errors;
@@ -37,7 +38,7 @@ final class ToolsPage
 
     public function render_page(): void
     {
-        if (! current_user_can('fp_exp_manage')) {
+        if (! Helpers::can_manage_fp()) {
             wp_die(esc_html__('You do not have permission to run FP Experiences tools.', 'fp-experiences'));
         }
 

--- a/src/Api/RestRoutes.php
+++ b/src/Api/RestRoutes.php
@@ -17,7 +17,6 @@ use function __;
 use function absint;
 use function add_action;
 use function apply_filters;
-use function current_user_can;
 use function do_action;
 use function home_url;
 use function is_array;
@@ -56,7 +55,7 @@ final class RestRoutes
             [
                 'methods' => 'GET',
                 'permission_callback' => static function (): bool {
-                    return current_user_can('fp_exp_operate');
+                    return Helpers::can_operate_fp();
                 },
                 'callback' => [$this, 'get_calendar_slots'],
                 'args' => [
@@ -86,7 +85,7 @@ final class RestRoutes
             [
                 'methods' => 'POST',
                 'permission_callback' => static function (): bool {
-                    return current_user_can('fp_exp_operate');
+                    return Helpers::can_operate_fp();
                 },
                 'callback' => [$this, 'move_calendar_slot'],
                 'args' => [
@@ -108,7 +107,7 @@ final class RestRoutes
             [
                 'methods' => 'POST',
                 'permission_callback' => static function (): bool {
-                    return current_user_can('fp_exp_operate');
+                    return Helpers::can_operate_fp();
                 },
                 'callback' => [$this, 'update_slot_capacity'],
             ]
@@ -120,7 +119,7 @@ final class RestRoutes
             [
                 'methods' => 'POST',
                 'permission_callback' => static function (): bool {
-                    return current_user_can('fp_exp_operate');
+                    return Helpers::can_operate_fp();
                 },
                 'callback' => [$this, 'preview_recurrence_slots'],
             ]
@@ -132,7 +131,7 @@ final class RestRoutes
             [
                 'methods' => 'POST',
                 'permission_callback' => static function (): bool {
-                    return current_user_can('fp_exp_operate');
+                    return Helpers::can_operate_fp();
                 },
                 'callback' => [$this, 'generate_recurrence_slots'],
             ]
@@ -144,7 +143,7 @@ final class RestRoutes
             [
                 'methods' => 'POST',
                 'permission_callback' => static function (): bool {
-                    return current_user_can('fp_exp_manage');
+                    return Helpers::can_manage_fp();
                 },
                 'callback' => [$this, 'tool_resync_brevo'],
             ]
@@ -156,7 +155,7 @@ final class RestRoutes
             [
                 'methods' => 'POST',
                 'permission_callback' => static function (): bool {
-                    return current_user_can('fp_exp_manage');
+                    return Helpers::can_manage_fp();
                 },
                 'callback' => [$this, 'tool_replay_events'],
             ]
@@ -168,7 +167,7 @@ final class RestRoutes
             [
                 'methods' => 'POST',
                 'permission_callback' => static function (): bool {
-                    return current_user_can('fp_exp_manage');
+                    return Helpers::can_manage_fp();
                 },
                 'callback' => [$this, 'tool_ping'],
             ]
@@ -180,7 +179,7 @@ final class RestRoutes
             [
                 'methods' => 'POST',
                 'permission_callback' => static function (): bool {
-                    return current_user_can('fp_exp_manage');
+                    return Helpers::can_manage_fp();
                 },
                 'callback' => [$this, 'tool_clear_cache'],
             ]
@@ -192,7 +191,7 @@ final class RestRoutes
             [
                 'methods' => 'POST',
                 'permission_callback' => static function (): bool {
-                    return current_user_can('fp_exp_manage');
+                    return Helpers::can_manage_fp();
                 },
                 'callback' => [$this, 'tool_resync_pages'],
             ]

--- a/src/Api/Webhooks.php
+++ b/src/Api/Webhooks.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FP_Exp\Api;
 
+use FP_Exp\Utils\Helpers;
 use FP_Exp\Utils\Logger;
 use WP_Error;
 use WP_REST_Request;
@@ -14,7 +15,6 @@ use function __;
 use function add_action;
 use function array_filter;
 use function current_time;
-use function current_user_can;
 use function get_option;
 use function get_transient;
 use function hash_equals;
@@ -47,7 +47,7 @@ final class Webhooks
             [
                 'methods' => WP_REST_Server::READABLE,
                 'permission_callback' => static function (): bool {
-                    return current_user_can('fp_exp_manage');
+                    return Helpers::can_manage_fp();
                 },
                 'callback' => [$this, 'handle_ping'],
             ]

--- a/src/Gift/VoucherCPT.php
+++ b/src/Gift/VoucherCPT.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FP_Exp\Gift;
 
+use FP_Exp\Utils\Helpers;
 use WP_Post;
 
 use function absint;
@@ -11,7 +12,6 @@ use function add_action;
 use function add_filter;
 use function add_query_arg;
 use function admin_url;
-use function current_user_can;
 use function date_i18n;
 use function esc_attr;
 use function esc_html;
@@ -182,7 +182,7 @@ final class VoucherCPT
      */
     public function filter_row_actions(array $actions, WP_Post $post): array
     {
-        if (self::POST_TYPE !== $post->post_type || ! current_user_can('fp_exp_manage')) {
+        if (self::POST_TYPE !== $post->post_type || ! Helpers::can_manage_fp()) {
             return $actions;
         }
 
@@ -214,7 +214,7 @@ final class VoucherCPT
 
     public function handle_admin_action(): void
     {
-        if (! current_user_can('fp_exp_manage')) {
+        if (! Helpers::can_manage_fp()) {
             wp_die(esc_html__('You do not have permission to manage vouchers.', 'fp-experiences'));
         }
 

--- a/src/MeetingPoints/MeetingPointImporter.php
+++ b/src/MeetingPoints/MeetingPointImporter.php
@@ -11,7 +11,6 @@ use function add_action;
 use function add_query_arg;
 use function add_submenu_page;
 use function admin_url;
-use function current_user_can;
 use function esc_attr;
 use function esc_html;
 use function esc_html__;
@@ -66,7 +65,7 @@ final class MeetingPointImporter
 
     public function render_page(): void
     {
-        if (! current_user_can('fp_exp_manage')) {
+        if (! Helpers::can_manage_fp()) {
             wp_die(esc_html__('You do not have permission to access this page.', 'fp-experiences'));
         }
 
@@ -111,7 +110,7 @@ final class MeetingPointImporter
             wp_die(esc_html__('Meeting point import is disabled.', 'fp-experiences'));
         }
 
-        if (! current_user_can('fp_exp_manage')) {
+        if (! Helpers::can_manage_fp()) {
             wp_die(esc_html__('You do not have permission to import meeting points.', 'fp-experiences'));
         }
 

--- a/src/Utils/Helpers.php
+++ b/src/Utils/Helpers.php
@@ -12,6 +12,7 @@ use function array_filter;
 use function array_map;
 use function array_unique;
 use function array_values;
+use function current_user_can;
 use function delete_transient;
 use function explode;
 use function do_action;
@@ -55,6 +56,21 @@ final class Helpers
      * @var array<string, string>
      */
     private static array $asset_version_cache = [];
+
+    public static function can_manage_fp(): bool
+    {
+        return current_user_can('fp_exp_manage') || current_user_can('manage_options');
+    }
+
+    public static function can_operate_fp(): bool
+    {
+        return current_user_can('fp_exp_operate') || self::can_manage_fp();
+    }
+
+    public static function can_access_guides(): bool
+    {
+        return current_user_can('fp_exp_guide') || self::can_operate_fp();
+    }
 
     /**
      * @return array<string, mixed>


### PR DESCRIPTION
## Summary
- lower the FP Experiences top-level menu capability to `fp_exp_guide` so non-manager FP roles can open the menu shell
- add shared helper checks that fall back to core admin caps and use them across admin pages, REST endpoints, and tools
- update admin bar links and help page access to honor the new helper logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd0c52e4a0832faafe78a1e0ec1114