### PR TITLE
Keep experience widget open and improve calendar feedback

### DIFF
--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -1287,12 +1287,13 @@
     margin: 0;
     padding: 0;
     display: grid;
-    gap: 0.75rem;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 .fp-exp-addon label {
     display: grid;
-    grid-template-columns: auto minmax(64px, 80px) 1fr auto;
+    grid-template-columns: auto minmax(140px, 180px) 1fr auto;
     gap: 0.75rem;
     align-items: center;
     padding: 0.85rem 1rem;
@@ -1317,7 +1318,7 @@
 
 .fp-exp-addon__media {
     width: 100%;
-    aspect-ratio: 1 / 1;
+    aspect-ratio: 4 / 3;
     border-radius: 12px;
     overflow: hidden;
     background: rgba(15, 23, 42, 0.05);
@@ -1361,19 +1362,21 @@
 
 .fp-exp-addon__description {
     color: var(--fp-color-muted, #475569);
+    font-size: 0.875rem;
+    line-height: 1.4;
     margin: 0;
 }
 
 .fp-exp-addon__price {
-    font-weight: 600;
-    color: var(--fp-color-primary);
+    font-weight: 700;
+    color: var(--fp-color-text);
     justify-self: end;
     white-space: nowrap;
 }
 
 @media (max-width: 640px) {
     .fp-exp-addon label {
-        grid-template-columns: auto 72px 1fr;
+        grid-template-columns: auto 120px 1fr;
         grid-template-rows: auto auto;
     }
 
@@ -1407,6 +1410,21 @@
     border-color: var(--fp-color-primary);
     box-shadow: 0 0 0 3px rgba(11, 110, 253, 0.15);
     transform: translateY(-2px);
+}
+
+.fp-exp-calendar__day.is-selected,
+.fp-exp-calendar-only__day.is-selected {
+    border-color: var(--fp-color-primary);
+    background: color-mix(in srgb, var(--fp-color-primary) 12%, #fff);
+    box-shadow: 0 0 0 3px rgba(11, 110, 253, 0.15);
+}
+
+.fp-exp-calendar__day:disabled,
+.fp-exp-calendar-only__day:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+    box-shadow: none;
+    transform: none;
 }
 
 .fp-exp-slots {
@@ -1484,12 +1502,20 @@
 }
 
 .fp-exp-quantity__input {
-    width: 3.5rem;
+    width: 4.25rem;
     text-align: center;
     padding: 0.45rem;
     border-radius: 8px;
     border: 1px solid rgba(15, 23, 42, 0.15);
     font-weight: 600;
+    color: var(--fp-color-text);
+}
+
+.fp-exp-ticket__price,
+.fp-exp-summary__total-amount,
+.fp-exp-summary__lines strong,
+.fp-exp-summary__adjustments strong {
+    font-weight: 700;
     color: var(--fp-color-text);
 }
 
@@ -1874,51 +1900,46 @@
     max-width: none;
 }
 
+.fp-main > .fp-hero-section {
+    background: transparent;
+    padding: 0;
+    box-shadow: none;
+}
+
 .fp-hero-section {
     display: grid;
-    gap: clamp(1.25rem, 4vw, 2.5rem);
-    background: var(--fp-color-surface);
-    padding: clamp(1.5rem, 4vw, 2.75rem);
-    border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
-    box-shadow: var(--fp-shadow);
+    gap: clamp(1.5rem, 4vw, 2.75rem);
 }
 
 .fp-hero-media {
-    position: relative;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.fp-hero-media__primary,
+.fp-hero-media__thumbnail {
+    margin: 0;
     border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
     overflow: hidden;
+    background: rgba(15, 23, 42, 0.08);
+}
+
+.fp-hero-media__primary {
     min-height: 220px;
-    background: linear-gradient(135deg, var(--fp-color-primary), var(--fp-color-accent));
 }
 
-.fp-hero {
-    display: grid;
-    grid-template-columns: repeat(1, minmax(0, 1fr));
-    grid-auto-rows: minmax(140px, 1fr);
-    gap: 8px;
-    width: 100%;
-    height: 100%;
-}
-
-.fp-hero-main,
-.fp-hero-item {
-    margin: 0;
-    position: relative;
-    border-radius: var(--fp-exp-radius-base, 12px);
-    overflow: hidden;
-    background: rgba(0, 0, 0, 0.08);
-}
-
-.fp-hero-main {
-    aspect-ratio: 16 / 9;
-}
-
-.fp-hero img {
+.fp-hero-media__primary img,
+.fp-hero-media__thumbnail img {
     width: 100%;
     height: 100%;
     object-fit: cover;
     display: block;
-    border-radius: 12px;
+}
+
+.fp-hero-media__thumbnails {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
 }
 
 .fp-exp-gallery--placeholder {
@@ -1943,9 +1964,33 @@
 }
 
 .fp-hero-body {
+    background: var(--fp-color-surface);
+    border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
+    box-shadow: var(--fp-shadow);
+    padding: clamp(1.5rem, 4vw, 2.75rem);
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 1.25rem;
+}
+
+.fp-hero-body__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.fp-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(139, 30, 63, 0.12);
+    color: var(--fp-color-primary);
+    font-weight: 600;
+    font-size: 0.75rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
 }
 
 .fp-eyebrow {
@@ -1962,36 +2007,57 @@
     color: var(--fp-color-text);
 }
 
-.fp-meta {
+
+.fp-hero-highlights {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.625rem;
-    padding: 0;
+    gap: 0.5rem;
     margin: 0;
+    padding: 0;
     list-style: none;
 }
 
-.fp-badge {
+.fp-hero-highlights__item {
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(139, 30, 63, 0.12);
+    color: var(--fp-color-primary);
+    font-weight: 600;
+}
+
+.fp-hero-languages {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.fp-hero-languages__label {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--fp-color-muted);
+}
+
+.fp-hero-languages__list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.fp-hero-language {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    background: var(--fp-color-surface);
-    color: var(--fp-color-text);
-    padding: 0.45rem 0.75rem;
+    gap: 0.4rem;
+    padding: 0.4rem 0.75rem;
     border-radius: 999px;
-    font-size: 0.875rem;
+    background: rgba(15, 23, 42, 0.08);
+    font-weight: 600;
+    color: var(--fp-color-text);
 }
 
-.fp-badge__label {
-    font-weight: 500;
-}
-
-.fp-badge--language {
-    background: rgba(15, 23, 42, 0.06);
-    padding: 0.35rem 0.65rem;
-}
-
-.fp-badge__flag {
+.fp-hero-language__flag {
     display: inline-flex;
     width: 1.5rem;
     height: 1rem;
@@ -2000,10 +2066,42 @@
     box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.12);
 }
 
-.fp-badge__flag svg {
+.fp-hero-language__flag svg {
     display: block;
     width: 100%;
     height: 100%;
+}
+
+.fp-hero-facts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.fp-hero-facts__item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.9rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.06);
+    color: var(--fp-color-text);
+}
+
+.fp-hero-facts__icon {
+    display: inline-flex;
+    width: 1.25rem;
+    height: 1.25rem;
+    align-items: center;
+    justify-content: center;
+    color: var(--fp-color-primary);
+}
+
+.fp-hero-facts__text {
+    font-weight: 600;
 }
 
 .fp-exp-icon {
@@ -2012,7 +2110,6 @@
     height: 1.25rem;
     align-items: center;
     justify-content: center;
-    color: var(--fp-color-primary);
 }
 
 .fp-summary {
@@ -2470,6 +2567,10 @@
     box-shadow: var(--fp-shadow);
 }
 
+[data-fp-section] {
+    scroll-margin-top: 96px;
+}
+
 .fp-exp-section__title {
     margin: 0 0 1rem;
     font-size: clamp(1.5rem, 3vw, 2rem);
@@ -2677,18 +2778,6 @@
     pointer-events: none;
 }
 
-@media (min-width: 768px) {
-    .fp-hero {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        grid-auto-rows: 160px;
-    }
-
-    .fp-hero > .fp-hero-main {
-        grid-column: span 2;
-        grid-row: span 2;
-    }
-}
-
 @media (min-width: 1024px) {
     .fp-layout {
         --fp-max: var(--fp-exp-max, 1200px);
@@ -2717,18 +2806,12 @@
     }
 
     .fp-hero-section {
-        padding: clamp(20px, 3vw, 36px);
+        grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+        align-items: stretch;
     }
 
-    .fp-hero {
-        grid-template-columns: 2fr 1fr;
-        grid-auto-rows: 180px;
-        gap: 8px;
-    }
-
-    .fp-hero > .fp-hero-main {
-        grid-row: 1 / span 2;
-        aspect-ratio: 16 / 9;
+    .fp-hero-media__primary {
+        min-height: 100%;
     }
 
     .fp-layout[data-sidebar="left"] .fp-main {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -508,11 +508,20 @@
         }
 
         function updateDaysVisibility() {
-            if (!daysContainer || !frequency) {
+            if (!frequency) {
                 return;
             }
+
             const show = frequency.value === 'weekly';
-            daysContainer.toggleAttribute('hidden', !show);
+
+            if (daysContainer) {
+                daysContainer.toggleAttribute('hidden', !show);
+            }
+
+            const perSetContainers = Array.from(settings.querySelectorAll('[data-time-set-days]'));
+            perSetContainers.forEach((container) => {
+                container.toggleAttribute('hidden', !show);
+            });
         }
 
         function clearStatus() {
@@ -615,10 +624,23 @@
                 if (!times.length) {
                     return;
                 }
-                recurrence.time_sets.push({
+                const setData = {
                     label: labelInput ? labelInput.value.trim() : '',
                     times,
-                });
+                };
+
+                if (recurrence.frequency === 'weekly') {
+                    const daysContainer = container.querySelector('[data-time-set-days]');
+                    if (daysContainer) {
+                        const checkedDays = Array.from(daysContainer.querySelectorAll('input[type="checkbox"]:checked'));
+                        const days = checkedDays.map((input) => input.value).filter(Boolean);
+                        if (days.length) {
+                            setData.days = days;
+                        }
+                    }
+                }
+
+                recurrence.time_sets.push(setData);
             });
 
             if (!recurrence.time_sets.length) {

--- a/build/fp-experiences/assets/css/front.css
+++ b/build/fp-experiences/assets/css/front.css
@@ -1287,12 +1287,13 @@
     margin: 0;
     padding: 0;
     display: grid;
-    gap: 0.75rem;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 .fp-exp-addon label {
     display: grid;
-    grid-template-columns: auto minmax(64px, 80px) 1fr auto;
+    grid-template-columns: auto minmax(140px, 180px) 1fr auto;
     gap: 0.75rem;
     align-items: center;
     padding: 0.85rem 1rem;
@@ -1317,7 +1318,7 @@
 
 .fp-exp-addon__media {
     width: 100%;
-    aspect-ratio: 1 / 1;
+    aspect-ratio: 4 / 3;
     border-radius: 12px;
     overflow: hidden;
     background: rgba(15, 23, 42, 0.05);
@@ -1361,19 +1362,21 @@
 
 .fp-exp-addon__description {
     color: var(--fp-color-muted, #475569);
+    font-size: 0.875rem;
+    line-height: 1.4;
     margin: 0;
 }
 
 .fp-exp-addon__price {
-    font-weight: 600;
-    color: var(--fp-color-primary);
+    font-weight: 700;
+    color: var(--fp-color-text);
     justify-self: end;
     white-space: nowrap;
 }
 
 @media (max-width: 640px) {
     .fp-exp-addon label {
-        grid-template-columns: auto 72px 1fr;
+        grid-template-columns: auto 120px 1fr;
         grid-template-rows: auto auto;
     }
 
@@ -1407,6 +1410,21 @@
     border-color: var(--fp-color-primary);
     box-shadow: 0 0 0 3px rgba(11, 110, 253, 0.15);
     transform: translateY(-2px);
+}
+
+.fp-exp-calendar__day.is-selected,
+.fp-exp-calendar-only__day.is-selected {
+    border-color: var(--fp-color-primary);
+    background: color-mix(in srgb, var(--fp-color-primary) 12%, #fff);
+    box-shadow: 0 0 0 3px rgba(11, 110, 253, 0.15);
+}
+
+.fp-exp-calendar__day:disabled,
+.fp-exp-calendar-only__day:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+    box-shadow: none;
+    transform: none;
 }
 
 .fp-exp-slots {
@@ -1484,12 +1502,20 @@
 }
 
 .fp-exp-quantity__input {
-    width: 3.5rem;
+    width: 4.25rem;
     text-align: center;
     padding: 0.45rem;
     border-radius: 8px;
     border: 1px solid rgba(15, 23, 42, 0.15);
     font-weight: 600;
+    color: var(--fp-color-text);
+}
+
+.fp-exp-ticket__price,
+.fp-exp-summary__total-amount,
+.fp-exp-summary__lines strong,
+.fp-exp-summary__adjustments strong {
+    font-weight: 700;
     color: var(--fp-color-text);
 }
 
@@ -1874,51 +1900,46 @@
     max-width: none;
 }
 
+.fp-main > .fp-hero-section {
+    background: transparent;
+    padding: 0;
+    box-shadow: none;
+}
+
 .fp-hero-section {
     display: grid;
-    gap: clamp(1.25rem, 4vw, 2.5rem);
-    background: var(--fp-color-surface);
-    padding: clamp(1.5rem, 4vw, 2.75rem);
-    border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
-    box-shadow: var(--fp-shadow);
+    gap: clamp(1.5rem, 4vw, 2.75rem);
 }
 
 .fp-hero-media {
-    position: relative;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.fp-hero-media__primary,
+.fp-hero-media__thumbnail {
+    margin: 0;
     border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
     overflow: hidden;
+    background: rgba(15, 23, 42, 0.08);
+}
+
+.fp-hero-media__primary {
     min-height: 220px;
-    background: linear-gradient(135deg, var(--fp-color-primary), var(--fp-color-accent));
 }
 
-.fp-hero {
-    display: grid;
-    grid-template-columns: repeat(1, minmax(0, 1fr));
-    grid-auto-rows: minmax(140px, 1fr);
-    gap: 8px;
-    width: 100%;
-    height: 100%;
-}
-
-.fp-hero-main,
-.fp-hero-item {
-    margin: 0;
-    position: relative;
-    border-radius: var(--fp-exp-radius-base, 12px);
-    overflow: hidden;
-    background: rgba(0, 0, 0, 0.08);
-}
-
-.fp-hero-main {
-    aspect-ratio: 16 / 9;
-}
-
-.fp-hero img {
+.fp-hero-media__primary img,
+.fp-hero-media__thumbnail img {
     width: 100%;
     height: 100%;
     object-fit: cover;
     display: block;
-    border-radius: 12px;
+}
+
+.fp-hero-media__thumbnails {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
 }
 
 .fp-exp-gallery--placeholder {
@@ -1943,9 +1964,33 @@
 }
 
 .fp-hero-body {
+    background: var(--fp-color-surface);
+    border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
+    box-shadow: var(--fp-shadow);
+    padding: clamp(1.5rem, 4vw, 2.75rem);
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 1.25rem;
+}
+
+.fp-hero-body__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.fp-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(139, 30, 63, 0.12);
+    color: var(--fp-color-primary);
+    font-weight: 600;
+    font-size: 0.75rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
 }
 
 .fp-eyebrow {
@@ -1962,36 +2007,57 @@
     color: var(--fp-color-text);
 }
 
-.fp-meta {
+
+.fp-hero-highlights {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.625rem;
-    padding: 0;
+    gap: 0.5rem;
     margin: 0;
+    padding: 0;
     list-style: none;
 }
 
-.fp-badge {
+.fp-hero-highlights__item {
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(139, 30, 63, 0.12);
+    color: var(--fp-color-primary);
+    font-weight: 600;
+}
+
+.fp-hero-languages {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.fp-hero-languages__label {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--fp-color-muted);
+}
+
+.fp-hero-languages__list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.fp-hero-language {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    background: var(--fp-color-surface);
-    color: var(--fp-color-text);
-    padding: 0.45rem 0.75rem;
+    gap: 0.4rem;
+    padding: 0.4rem 0.75rem;
     border-radius: 999px;
-    font-size: 0.875rem;
+    background: rgba(15, 23, 42, 0.08);
+    font-weight: 600;
+    color: var(--fp-color-text);
 }
 
-.fp-badge__label {
-    font-weight: 500;
-}
-
-.fp-badge--language {
-    background: rgba(15, 23, 42, 0.06);
-    padding: 0.35rem 0.65rem;
-}
-
-.fp-badge__flag {
+.fp-hero-language__flag {
     display: inline-flex;
     width: 1.5rem;
     height: 1rem;
@@ -2000,10 +2066,42 @@
     box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.12);
 }
 
-.fp-badge__flag svg {
+.fp-hero-language__flag svg {
     display: block;
     width: 100%;
     height: 100%;
+}
+
+.fp-hero-facts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.fp-hero-facts__item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.9rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.06);
+    color: var(--fp-color-text);
+}
+
+.fp-hero-facts__icon {
+    display: inline-flex;
+    width: 1.25rem;
+    height: 1.25rem;
+    align-items: center;
+    justify-content: center;
+    color: var(--fp-color-primary);
+}
+
+.fp-hero-facts__text {
+    font-weight: 600;
 }
 
 .fp-exp-icon {
@@ -2012,7 +2110,6 @@
     height: 1.25rem;
     align-items: center;
     justify-content: center;
-    color: var(--fp-color-primary);
 }
 
 .fp-summary {
@@ -2470,6 +2567,10 @@
     box-shadow: var(--fp-shadow);
 }
 
+[data-fp-section] {
+    scroll-margin-top: 96px;
+}
+
 .fp-exp-section__title {
     margin: 0 0 1rem;
     font-size: clamp(1.5rem, 3vw, 2rem);
@@ -2677,18 +2778,6 @@
     pointer-events: none;
 }
 
-@media (min-width: 768px) {
-    .fp-hero {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        grid-auto-rows: 160px;
-    }
-
-    .fp-hero > .fp-hero-main {
-        grid-column: span 2;
-        grid-row: span 2;
-    }
-}
-
 @media (min-width: 1024px) {
     .fp-layout {
         --fp-max: var(--fp-exp-max, 1200px);
@@ -2717,18 +2806,12 @@
     }
 
     .fp-hero-section {
-        padding: clamp(20px, 3vw, 36px);
+        grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+        align-items: stretch;
     }
 
-    .fp-hero {
-        grid-template-columns: 2fr 1fr;
-        grid-auto-rows: 180px;
-        gap: 8px;
-    }
-
-    .fp-hero > .fp-hero-main {
-        grid-row: 1 / span 2;
-        aspect-ratio: 16 / 9;
+    .fp-hero-media__primary {
+        min-height: 100%;
     }
 
     .fp-layout[data-sidebar="left"] .fp-main {

--- a/build/fp-experiences/assets/js/admin.js
+++ b/build/fp-experiences/assets/js/admin.js
@@ -508,11 +508,20 @@
         }
 
         function updateDaysVisibility() {
-            if (!daysContainer || !frequency) {
+            if (!frequency) {
                 return;
             }
+
             const show = frequency.value === 'weekly';
-            daysContainer.toggleAttribute('hidden', !show);
+
+            if (daysContainer) {
+                daysContainer.toggleAttribute('hidden', !show);
+            }
+
+            const perSetContainers = Array.from(settings.querySelectorAll('[data-time-set-days]'));
+            perSetContainers.forEach((container) => {
+                container.toggleAttribute('hidden', !show);
+            });
         }
 
         function clearStatus() {
@@ -615,10 +624,23 @@
                 if (!times.length) {
                     return;
                 }
-                recurrence.time_sets.push({
+                const setData = {
                     label: labelInput ? labelInput.value.trim() : '',
                     times,
-                });
+                };
+
+                if (recurrence.frequency === 'weekly') {
+                    const daysContainer = container.querySelector('[data-time-set-days]');
+                    if (daysContainer) {
+                        const checkedDays = Array.from(daysContainer.querySelectorAll('input[type="checkbox"]:checked'));
+                        const days = checkedDays.map((input) => input.value).filter(Boolean);
+                        if (days.length) {
+                            setData.days = days;
+                        }
+                    }
+                }
+
+                recurrence.time_sets.push(setData);
             });
 
             if (!recurrence.time_sets.length) {

--- a/build/fp-experiences/src/Admin/ExperienceMetaBoxes.php
+++ b/build/fp-experiences/src/Admin/ExperienceMetaBoxes.php
@@ -619,17 +619,6 @@ final class ExperienceMetaBoxes
     private function render_calendar_tab(array $availability): void
     {
         $panel_id = 'fp-exp-tab-calendar-panel';
-        $times = $availability['times'];
-        if (empty($times)) {
-            $times = [''];
-        }
-
-        $custom_slots = $availability['custom_slots'];
-        if (empty($custom_slots)) {
-            $custom_slots = [['date' => '', 'time' => '']];
-        }
-
-        $days = $availability['days_of_week'];
         $recurrence = $availability['recurrence'] ?? Recurrence::defaults();
         if (! is_array($recurrence)) {
             $recurrence = Recurrence::defaults();
@@ -639,7 +628,7 @@ final class ExperienceMetaBoxes
 
         $time_sets = $recurrence['time_sets'];
         if (empty($time_sets)) {
-            $time_sets = [['label' => '', 'times' => ['']]];
+            $time_sets = [['label' => '', 'times' => [''], 'days' => []]];
         }
         ?>
         <section
@@ -651,68 +640,6 @@ final class ExperienceMetaBoxes
             data-tab-panel="calendar"
             hidden
         >
-            <fieldset class="fp-exp-fieldset">
-                <legend><?php esc_html_e('Frequenza', 'fp-experiences'); ?></legend>
-                <div class="fp-exp-field">
-                    <label class="fp-exp-field__label" for="fp-exp-frequency">
-                        <?php esc_html_e('Ricorrenza slot', 'fp-experiences'); ?>
-                        <?php $this->render_tooltip('fp-exp-frequency-help', esc_html__('Scegli se generare slot giornalieri, settimanali o manuali.', 'fp-experiences')); ?>
-                    </label>
-                    <select id="fp-exp-frequency" name="fp_exp_availability[frequency]" data-frequency-selector aria-describedby="fp-exp-frequency-help">
-                        <option value="daily" <?php selected($availability['frequency'], 'daily'); ?>><?php esc_html_e('Giornaliera', 'fp-experiences'); ?></option>
-                        <option value="weekly" <?php selected($availability['frequency'], 'weekly'); ?>><?php esc_html_e('Settimanale', 'fp-experiences'); ?></option>
-                        <option value="custom" <?php selected($availability['frequency'], 'custom'); ?>><?php esc_html_e('Personalizzata', 'fp-experiences'); ?></option>
-                    </select>
-                    <p class="fp-exp-field__description" id="fp-exp-frequency-help"><?php esc_html_e('La frequenza determina quali blocchi attivare qui sotto.', 'fp-experiences'); ?></p>
-                </div>
-            </fieldset>
-
-            <fieldset class="fp-exp-fieldset" data-frequency-panel="weekly" <?php echo 'weekly' === $availability['frequency'] ? '' : 'hidden'; ?>>
-                <legend><?php esc_html_e('Giorni disponibili', 'fp-experiences'); ?></legend>
-                <div class="fp-exp-checkbox-grid">
-                    <?php foreach ($this->get_week_days() as $day_key => $day_label) : ?>
-                        <label>
-                            <input type="checkbox" name="fp_exp_availability[days_of_week][]" value="<?php echo esc_attr($day_key); ?>" <?php checked(in_array($day_key, $days, true)); ?> />
-                            <span><?php echo esc_html($day_label); ?></span>
-                        </label>
-                    <?php endforeach; ?>
-                </div>
-            </fieldset>
-
-            <fieldset class="fp-exp-fieldset" data-frequency-panel="daily" data-frequency-panel-secondary="weekly" <?php echo in_array($availability['frequency'], ['daily', 'weekly'], true) ? '' : 'hidden'; ?>>
-                <legend><?php esc_html_e('Orari', 'fp-experiences'); ?></legend>
-                <div class="fp-exp-repeater" data-repeater="times" data-repeater-next-index="<?php echo esc_attr((string) count($availability['times'])); ?>">
-                    <div class="fp-exp-repeater__items">
-                        <?php foreach ($times as $index => $time) : ?>
-                            <?php $this->render_time_row((string) $index, $time); ?>
-                        <?php endforeach; ?>
-                    </div>
-                    <template data-repeater-template>
-                        <?php $this->render_time_row('__INDEX__', '', true); ?>
-                    </template>
-                    <p class="fp-exp-repeater__actions">
-                        <button type="button" class="button button-secondary" data-repeater-add><?php esc_html_e('Aggiungi orario', 'fp-experiences'); ?></button>
-                    </p>
-                </div>
-            </fieldset>
-
-            <fieldset class="fp-exp-fieldset" data-frequency-panel="custom" <?php echo 'custom' === $availability['frequency'] ? '' : 'hidden'; ?>>
-                <legend><?php esc_html_e('Slot personalizzati', 'fp-experiences'); ?></legend>
-                <div class="fp-exp-repeater" data-repeater="custom_slots" data-repeater-next-index="<?php echo esc_attr((string) count($availability['custom_slots'])); ?>">
-                    <div class="fp-exp-repeater__items">
-                        <?php foreach ($custom_slots as $index => $slot) : ?>
-                            <?php $this->render_custom_slot_row((string) $index, $slot); ?>
-                        <?php endforeach; ?>
-                    </div>
-                    <template data-repeater-template>
-                        <?php $this->render_custom_slot_row('__INDEX__', ['date' => '', 'time' => ''], true); ?>
-                    </template>
-                    <p class="fp-exp-repeater__actions">
-                        <button type="button" class="button button-secondary" data-repeater-add><?php esc_html_e('Aggiungi slot', 'fp-experiences'); ?></button>
-                    </p>
-                </div>
-            </fieldset>
-
             <fieldset class="fp-exp-fieldset">
                 <legend><?php esc_html_e('Ricorrenza automatica', 'fp-experiences'); ?></legend>
                 <div class="fp-exp-field fp-exp-field--switch">
@@ -767,11 +694,11 @@ final class ExperienceMetaBoxes
                     <div class="fp-exp-repeater fp-exp-recurrence__sets" data-repeater="recurrence_time_sets" data-repeater-next-index="<?php echo esc_attr((string) count($time_sets)); ?>">
                         <div class="fp-exp-repeater__items" data-recurrence-time-set-list>
                             <?php foreach ($time_sets as $index => $set) : ?>
-                                <?php $this->render_time_set_row((string) $index, $set); ?>
+                                <?php $this->render_time_set_row((string) $index, $set, false, (string) ($recurrence['frequency'] ?? 'weekly')); ?>
                             <?php endforeach; ?>
                         </div>
                         <template data-repeater-template>
-                            <?php $this->render_time_set_row('__INDEX__', ['label' => '', 'times' => ['']], true); ?>
+                            <?php $this->render_time_set_row('__INDEX__', ['label' => '', 'times' => [''], 'days' => []], true, (string) ($recurrence['frequency'] ?? 'weekly')); ?>
                         </template>
                         <p class="fp-exp-repeater__actions">
                             <button type="button" class="button button-secondary" data-repeater-add><?php esc_html_e('Aggiungi time set', 'fp-experiences'); ?></button>
@@ -1243,7 +1170,7 @@ final class ExperienceMetaBoxes
         <?php
     }
 
-    private function render_time_set_row(string $index, array $set, bool $is_template = false): void
+    private function render_time_set_row(string $index, array $set, bool $is_template = false, string $frequency = 'weekly'): void
     {
         $label_name = $is_template
             ? 'fp_exp_availability[recurrence][time_sets][__INDEX__][label]'
@@ -1251,13 +1178,23 @@ final class ExperienceMetaBoxes
         $times_base = $is_template
             ? 'fp_exp_availability[recurrence][time_sets][__INDEX__][times]'
             : 'fp_exp_availability[recurrence][time_sets][' . $index . '][times]';
+        $days_base = $is_template
+            ? 'fp_exp_availability[recurrence][time_sets][__INDEX__][days]'
+            : 'fp_exp_availability[recurrence][time_sets][' . $index . '][days]';
 
         $label_value = isset($set['label']) ? (string) $set['label'] : '';
         $times = [];
+        $set_days = [];
 
         if (isset($set['times']) && is_array($set['times'])) {
             foreach ($set['times'] as $time) {
                 $times[] = (string) $time;
+            }
+        }
+
+        if (isset($set['days']) && is_array($set['days'])) {
+            foreach ($set['days'] as $day) {
+                $set_days[] = (string) $day;
             }
         }
 
@@ -1295,6 +1232,18 @@ final class ExperienceMetaBoxes
             <p class="fp-exp-recurrence-set__actions">
                 <button type="button" class="button button-secondary" data-time-set-add><?php esc_html_e('Aggiungi orario', 'fp-experiences'); ?></button>
             </p>
+            <div class="fp-exp-field" data-time-set-days <?php echo 'weekly' === $frequency ? '' : 'hidden'; ?>>
+                <span class="fp-exp-field__label"><?php esc_html_e('Giorni attivi per questo set', 'fp-experiences'); ?></span>
+                <div class="fp-exp-checkbox-grid">
+                    <?php foreach ($this->get_week_days() as $day_key => $day_label) : ?>
+                        <label>
+                            <input type="checkbox" <?php echo $this->field_name_attribute($days_base . '[]', $is_template); ?> value="<?php echo esc_attr($day_key); ?>" <?php checked(in_array($this->map_weekday_for_ui($day_key), $set_days, true)); ?> />
+                            <span><?php echo esc_html($day_label); ?></span>
+                        </label>
+                    <?php endforeach; ?>
+                </div>
+                <p class="fp-exp-field__description"><?php esc_html_e('Lascia vuoto per usare i giorni generali della ricorrenza settimanale.', 'fp-experiences'); ?></p>
+            </div>
         </div>
         <?php
     }
@@ -1846,6 +1795,7 @@ final class ExperienceMetaBoxes
 
                 $label = isset($set['label']) ? sanitize_text_field((string) $set['label']) : '';
                 $times = [];
+                $set_days = [];
 
                 if (isset($set['times']) && is_array($set['times'])) {
                     foreach ($set['times'] as $time) {
@@ -1857,6 +1807,16 @@ final class ExperienceMetaBoxes
                     }
                 }
 
+                if (isset($set['days']) && is_array($set['days'])) {
+                    foreach ($set['days'] as $day) {
+                        $day_key = sanitize_key((string) $day);
+                        $mapped = $this->map_weekday_for_ui($day_key);
+                        if ('' !== $mapped && ! in_array($mapped, $set_days, true)) {
+                            $set_days[] = $mapped;
+                        }
+                    }
+                }
+
                 if (empty($times)) {
                     continue;
                 }
@@ -1864,6 +1824,7 @@ final class ExperienceMetaBoxes
                 $time_sets[] = [
                     'label' => $label,
                     'times' => array_values(array_unique($times)),
+                    'days' => $set_days,
                 ];
             }
         }

--- a/build/fp-experiences/src/Shortcodes/ExperienceShortcode.php
+++ b/build/fp-experiences/src/Shortcodes/ExperienceShortcode.php
@@ -208,7 +208,7 @@ final class ExperienceShortcode extends BaseShortcode
 
         $widget_atts = [
             'id' => (string) $experience_id,
-            'sticky' => $is_sticky_widget ? '1' : '0',
+            'sticky' => '0',
             'display_context' => 'page',
         ];
 

--- a/build/fp-experiences/templates/front/experience.php
+++ b/build/fp-experiences/templates/front/experience.php
@@ -94,6 +94,18 @@ $gift_config = [
 ];
 $gift_addons = isset($gift['addons']) && is_array($gift['addons']) ? $gift['addons'] : [];
 
+$primary_image = ! empty($gallery) ? $gallery[0] : null;
+$secondary_images = count($gallery) > 1 ? array_slice($gallery, 1, 4) : [];
+$hero_language_badges = array_values(array_filter(
+    $badges,
+    static fn ($badge) => isset($badge['icon']) && 'language' === $badge['icon']
+));
+$hero_fact_badges = array_values(array_filter(
+    $badges,
+    static fn ($badge) => ! isset($badge['icon']) || 'language' !== $badge['icon']
+));
+$hero_highlights = array_slice($highlights, 0, 3);
+
 ?>
 <div
     class="<?php echo esc_attr(implode(' ', $wrapper_classes)); ?>"
@@ -113,25 +125,34 @@ $gift_addons = isset($gift['addons']) && is_array($gift['addons']) ? $gift['addo
         <main class="fp-main">
             <?php if (! empty($sections['hero'])) : ?>
                 <section class="fp-section fp-hero-section" id="fp-exp-section-hero" data-fp-section="hero">
-                    <div class="fp-hero-media" aria-hidden="<?php echo empty($gallery) ? 'true' : 'false'; ?>">
-                        <?php if (! empty($gallery)) : ?>
-                            <div class="fp-hero fp-exp-gallery" data-fp-gallery>
-                                <?php foreach ($gallery as $index => $image) :
-                                    $figure_classes = ['fp-exp-gallery__item'];
-                                    $figure_classes[] = 0 === $index ? 'fp-hero-main' : 'fp-hero-item';
-                                    ?>
-                                    <figure class="<?php echo esc_attr(implode(' ', $figure_classes)); ?>" data-index="<?php echo esc_attr((string) $index); ?>">
-                                        <img
-                                            src="<?php echo esc_url($image['url']); ?>"
-                                            <?php if (! empty($image['srcset'])) : ?>srcset="<?php echo esc_attr($image['srcset']); ?>"<?php endif; ?>
-                                            <?php if (! empty($image['width'])) : ?>width="<?php echo esc_attr((string) $image['width']); ?>"<?php endif; ?>
-                                            <?php if (! empty($image['height'])) : ?>height="<?php echo esc_attr((string) $image['height']); ?>"<?php endif; ?>
-                                            alt="<?php echo esc_attr($experience['title']); ?>"
-                                            loading="lazy"
-                                        />
-                                    </figure>
-                                <?php endforeach; ?>
-                            </div>
+                    <div class="fp-hero-media" aria-hidden="<?php echo null === $primary_image ? 'true' : 'false'; ?>">
+                        <?php if ($primary_image) : ?>
+                            <figure class="fp-hero-media__primary">
+                                <img
+                                    src="<?php echo esc_url($primary_image['url']); ?>"
+                                    <?php if (! empty($primary_image['srcset'])) : ?>srcset="<?php echo esc_attr($primary_image['srcset']); ?>"<?php endif; ?>
+                                    <?php if (! empty($primary_image['width'])) : ?>width="<?php echo esc_attr((string) $primary_image['width']); ?>"<?php endif; ?>
+                                    <?php if (! empty($primary_image['height'])) : ?>height="<?php echo esc_attr((string) $primary_image['height']); ?>"<?php endif; ?>
+                                    alt="<?php echo esc_attr($experience['title']); ?>"
+                                    loading="lazy"
+                                />
+                            </figure>
+                            <?php if (! empty($secondary_images)) : ?>
+                                <div class="fp-hero-media__thumbnails">
+                                    <?php foreach ($secondary_images as $index => $image) : ?>
+                                        <figure class="fp-hero-media__thumbnail" data-index="<?php echo esc_attr((string) ($index + 1)); ?>">
+                                            <img
+                                                src="<?php echo esc_url($image['url']); ?>"
+                                                <?php if (! empty($image['srcset'])) : ?>srcset="<?php echo esc_attr($image['srcset']); ?>"<?php endif; ?>
+                                                <?php if (! empty($image['width'])) : ?>width="<?php echo esc_attr((string) $image['width']); ?>"<?php endif; ?>
+                                                <?php if (! empty($image['height'])) : ?>height="<?php echo esc_attr((string) $image['height']); ?>"<?php endif; ?>
+                                                alt="<?php echo esc_attr($experience['title']); ?>"
+                                                loading="lazy"
+                                            />
+                                        </figure>
+                                    <?php endforeach; ?>
+                                </div>
+                            <?php endif; ?>
                         <?php else : ?>
                             <div class="fp-hero fp-exp-gallery fp-exp-gallery--placeholder">
                                 <span aria-hidden="true"></span>
@@ -139,47 +160,61 @@ $gift_addons = isset($gift['addons']) && is_array($gift['addons']) ? $gift['addo
                         <?php endif; ?>
                     </div>
                     <div class="fp-hero-body">
-                        <div class="fp-eyebrow">
-                            <span class="fp-badge">FP Experiences</span>
+                        <div class="fp-hero-body__header">
+                            <div class="fp-eyebrow">
+                                <span class="fp-badge">FP Experiences</span>
+                            </div>
+                            <h1 class="fp-title"><?php echo esc_html($experience['title']); ?></h1>
                         </div>
-                        <h1 class="fp-title"><?php echo esc_html($experience['title']); ?></h1>
-                        <?php if (! empty($badges)) : ?>
-                            <ul class="fp-meta" role="list">
-                                <?php foreach ($badges as $badge) : ?>
-                                    <?php if ('language' === ($badge['icon'] ?? '')) :
+                        <?php if (! empty($experience['summary'])) : ?>
+                            <p class="fp-summary"><?php echo esc_html($experience['summary']); ?></p>
+                        <?php endif; ?>
+                        <?php if (! empty($hero_highlights)) : ?>
+                            <ul class="fp-hero-highlights" role="list">
+                                <?php foreach ($hero_highlights as $highlight) : ?>
+                                    <li class="fp-hero-highlights__item"><?php echo esc_html($highlight); ?></li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?>
+                        <?php if (! empty($hero_language_badges)) : ?>
+                            <div class="fp-hero-languages">
+                                <span class="fp-hero-languages__label"><?php esc_html_e('Languages', 'fp-experiences'); ?></span>
+                                <ul class="fp-hero-languages__list" role="list">
+                                    <?php foreach ($hero_language_badges as $badge) :
                                         $language_meta = isset($badge['language']) && is_array($badge['language']) ? $badge['language'] : [];
                                         $sprite_id = isset($language_meta['sprite']) ? (string) $language_meta['sprite'] : '';
                                         $aria_label = isset($language_meta['aria_label']) ? (string) $language_meta['aria_label'] : (string) ($badge['label'] ?? '');
                                         $readable_label = isset($language_meta['label']) ? (string) $language_meta['label'] : (string) ($badge['label'] ?? '');
                                         ?>
-                                        <li class="fp-badge fp-badge--language">
+                                        <li class="fp-hero-language">
                                             <?php if ($sprite_id) : ?>
-                                                <span class="fp-badge__flag" role="img" aria-label="<?php echo esc_attr($aria_label); ?>">
+                                                <span class="fp-hero-language__flag" role="img" aria-label="<?php echo esc_attr($aria_label); ?>">
                                                     <svg viewBox="0 0 24 16" aria-hidden="true" focusable="false">
                                                         <use href="<?php echo esc_url($language_sprite . '#' . $sprite_id); ?>"></use>
                                                     </svg>
                                                 </span>
                                             <?php endif; ?>
-                                            <span class="fp-badge__label" aria-hidden="true"><?php echo esc_html((string) ($badge['label'] ?? '')); ?></span>
-                                            <span class="screen-reader-text"><?php echo esc_html($readable_label); ?></span>
+                                            <span class="fp-hero-language__name"><?php echo esc_html($readable_label); ?></span>
                                         </li>
-                                    <?php else : ?>
-                                        <li class="fp-badge">
-                                            <span class="fp-exp-icon fp-exp-icon--<?php echo esc_attr((string) ($badge['icon'] ?? '')); ?>" aria-hidden="true">
+                                    <?php endforeach; ?>
+                                </ul>
+                            </div>
+                        <?php endif; ?>
+                        <?php if (! empty($hero_fact_badges)) : ?>
+                            <ul class="fp-hero-facts" role="list">
+                                <?php foreach ($hero_fact_badges as $badge) : ?>
+                                    <li class="fp-hero-facts__item">
+                                            <span class="fp-hero-facts__icon" aria-hidden="true">
                                                 <?php if ('clock' === ($badge['icon'] ?? '')) : ?>
                                                     <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm1 10.59 2.12 2.12-1.41 1.41-2.83-2.83V7h2.12Z"/></svg>
                                                 <?php else : ?>
                                                     <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M12 12.88 9.17 10H5a3 3 0 0 0-3 3v7h6v-4h2v4h6v-7a3 3 0 0 0-3-3h-1.17Zm9-2.88a4 4 0 1 0-4-4 4 4 0 0 0 4 4Z"/></svg>
                                                 <?php endif; ?>
                                             </span>
-                                            <span class="fp-badge__label"><?php echo esc_html((string) ($badge['label'] ?? '')); ?></span>
-                                        </li>
-                                    <?php endif; ?>
+                                            <span class="fp-hero-facts__text"><?php echo esc_html((string) ($badge['label'] ?? '')); ?></span>
+                                    </li>
                                 <?php endforeach; ?>
                             </ul>
-                        <?php endif; ?>
-                        <?php if (! empty($experience['summary'])) : ?>
-                            <p class="fp-summary"><?php echo esc_html($experience['summary']); ?></p>
                         <?php endif; ?>
                         <div class="fp-hero-cta">
                             <a

--- a/build/fp-experiences/templates/front/widget.php
+++ b/build/fp-experiences/templates/front/widget.php
@@ -116,33 +116,12 @@ $rtb_submit_label = 'pay_later' === $rtb_mode
             <?php endif; ?>
         </div>
     </div>
-    <?php if ($behavior['sticky']) : ?>
-        <button
-            type="button"
-            class="fp-exp-widget__open"
-            data-fp-widget-open="1"
-            aria-expanded="false"
-            aria-controls="<?php echo esc_attr($dialog_id); ?>"
-        >
-            <span class="fp-exp-widget__open-label"><?php echo esc_html__('Open booking panel', 'fp-experiences'); ?></span>
-        </button>
-    <?php endif; ?>
     <div
         class="fp-exp-widget__body"
         data-sticky="<?php echo esc_attr($behavior['sticky'] ? '1' : '0'); ?>"
         id="<?php echo esc_attr($dialog_id); ?>"
-        <?php if ($behavior['sticky']) : ?>role="dialog" aria-modal="true"<?php else : ?>role="group"<?php endif; ?>
+        <?php if ($behavior['sticky']) : ?>role="region"<?php else : ?>role="group"<?php endif; ?>
     >
-        <?php if ($behavior['sticky']) : ?>
-            <button
-                type="button"
-                class="fp-exp-widget__close"
-                data-fp-widget-close="1"
-                aria-label="<?php echo esc_attr__('Close booking panel', 'fp-experiences'); ?>"
-            >
-                <span aria-hidden="true">&times;</span>
-            </button>
-        <?php endif; ?>
         <ol class="fp-exp-widget__steps">
             <li class="fp-exp-step fp-exp-step--dates" data-fp-step="dates">
                 <header>
@@ -155,10 +134,19 @@ $rtb_submit_label = 'pay_later' === $rtb_mode
                             <section class="fp-exp-calendar__month" data-month="<?php echo esc_attr($month_key); ?>">
                                 <header class="fp-exp-calendar__month-header"><?php echo esc_html($month_data['month_label']); ?></header>
                                 <div class="fp-exp-calendar__grid">
-                                    <?php foreach ($month_data['days'] as $day => $day_slots) : ?>
-                                        <button type="button" class="fp-exp-calendar__day" data-date="<?php echo esc_attr($day); ?>" data-available="<?php echo esc_attr(count($day_slots) > 0 ? '1' : '0'); ?>">
+                                    <?php foreach ($month_data['days'] as $day => $day_slots) :
+                                        $slot_count = count($day_slots);
+                                        $is_available = $slot_count > 0;
+                                        ?>
+                                        <button
+                                            type="button"
+                                            class="fp-exp-calendar__day"
+                                            data-date="<?php echo esc_attr($day); ?>"
+                                            data-available="<?php echo esc_attr($is_available ? '1' : '0'); ?>"
+                                            <?php if (! $is_available) : ?>disabled aria-disabled="true"<?php else : ?>aria-pressed="false"<?php endif; ?>
+                                        >
                                             <span class="fp-exp-calendar__day-label"><?php echo esc_html($day); ?></span>
-                                            <span class="fp-exp-calendar__day-count"><?php echo esc_html(sprintf(esc_html__('%d slots', 'fp-experiences'), count($day_slots))); ?></span>
+                                            <span class="fp-exp-calendar__day-count"><?php echo esc_html(sprintf(esc_html__('%d slots', 'fp-experiences'), $slot_count)); ?></span>
                                         </button>
                                     <?php endforeach; ?>
                                 </div>

--- a/src/Admin/ExperienceMetaBoxes.php
+++ b/src/Admin/ExperienceMetaBoxes.php
@@ -619,17 +619,6 @@ final class ExperienceMetaBoxes
     private function render_calendar_tab(array $availability): void
     {
         $panel_id = 'fp-exp-tab-calendar-panel';
-        $times = $availability['times'];
-        if (empty($times)) {
-            $times = [''];
-        }
-
-        $custom_slots = $availability['custom_slots'];
-        if (empty($custom_slots)) {
-            $custom_slots = [['date' => '', 'time' => '']];
-        }
-
-        $days = $availability['days_of_week'];
         $recurrence = $availability['recurrence'] ?? Recurrence::defaults();
         if (! is_array($recurrence)) {
             $recurrence = Recurrence::defaults();
@@ -639,7 +628,7 @@ final class ExperienceMetaBoxes
 
         $time_sets = $recurrence['time_sets'];
         if (empty($time_sets)) {
-            $time_sets = [['label' => '', 'times' => ['']]];
+            $time_sets = [['label' => '', 'times' => [''], 'days' => []]];
         }
         ?>
         <section
@@ -651,68 +640,6 @@ final class ExperienceMetaBoxes
             data-tab-panel="calendar"
             hidden
         >
-            <fieldset class="fp-exp-fieldset">
-                <legend><?php esc_html_e('Frequenza', 'fp-experiences'); ?></legend>
-                <div class="fp-exp-field">
-                    <label class="fp-exp-field__label" for="fp-exp-frequency">
-                        <?php esc_html_e('Ricorrenza slot', 'fp-experiences'); ?>
-                        <?php $this->render_tooltip('fp-exp-frequency-help', esc_html__('Scegli se generare slot giornalieri, settimanali o manuali.', 'fp-experiences')); ?>
-                    </label>
-                    <select id="fp-exp-frequency" name="fp_exp_availability[frequency]" data-frequency-selector aria-describedby="fp-exp-frequency-help">
-                        <option value="daily" <?php selected($availability['frequency'], 'daily'); ?>><?php esc_html_e('Giornaliera', 'fp-experiences'); ?></option>
-                        <option value="weekly" <?php selected($availability['frequency'], 'weekly'); ?>><?php esc_html_e('Settimanale', 'fp-experiences'); ?></option>
-                        <option value="custom" <?php selected($availability['frequency'], 'custom'); ?>><?php esc_html_e('Personalizzata', 'fp-experiences'); ?></option>
-                    </select>
-                    <p class="fp-exp-field__description" id="fp-exp-frequency-help"><?php esc_html_e('La frequenza determina quali blocchi attivare qui sotto.', 'fp-experiences'); ?></p>
-                </div>
-            </fieldset>
-
-            <fieldset class="fp-exp-fieldset" data-frequency-panel="weekly" <?php echo 'weekly' === $availability['frequency'] ? '' : 'hidden'; ?>>
-                <legend><?php esc_html_e('Giorni disponibili', 'fp-experiences'); ?></legend>
-                <div class="fp-exp-checkbox-grid">
-                    <?php foreach ($this->get_week_days() as $day_key => $day_label) : ?>
-                        <label>
-                            <input type="checkbox" name="fp_exp_availability[days_of_week][]" value="<?php echo esc_attr($day_key); ?>" <?php checked(in_array($day_key, $days, true)); ?> />
-                            <span><?php echo esc_html($day_label); ?></span>
-                        </label>
-                    <?php endforeach; ?>
-                </div>
-            </fieldset>
-
-            <fieldset class="fp-exp-fieldset" data-frequency-panel="daily" data-frequency-panel-secondary="weekly" <?php echo in_array($availability['frequency'], ['daily', 'weekly'], true) ? '' : 'hidden'; ?>>
-                <legend><?php esc_html_e('Orari', 'fp-experiences'); ?></legend>
-                <div class="fp-exp-repeater" data-repeater="times" data-repeater-next-index="<?php echo esc_attr((string) count($availability['times'])); ?>">
-                    <div class="fp-exp-repeater__items">
-                        <?php foreach ($times as $index => $time) : ?>
-                            <?php $this->render_time_row((string) $index, $time); ?>
-                        <?php endforeach; ?>
-                    </div>
-                    <template data-repeater-template>
-                        <?php $this->render_time_row('__INDEX__', '', true); ?>
-                    </template>
-                    <p class="fp-exp-repeater__actions">
-                        <button type="button" class="button button-secondary" data-repeater-add><?php esc_html_e('Aggiungi orario', 'fp-experiences'); ?></button>
-                    </p>
-                </div>
-            </fieldset>
-
-            <fieldset class="fp-exp-fieldset" data-frequency-panel="custom" <?php echo 'custom' === $availability['frequency'] ? '' : 'hidden'; ?>>
-                <legend><?php esc_html_e('Slot personalizzati', 'fp-experiences'); ?></legend>
-                <div class="fp-exp-repeater" data-repeater="custom_slots" data-repeater-next-index="<?php echo esc_attr((string) count($availability['custom_slots'])); ?>">
-                    <div class="fp-exp-repeater__items">
-                        <?php foreach ($custom_slots as $index => $slot) : ?>
-                            <?php $this->render_custom_slot_row((string) $index, $slot); ?>
-                        <?php endforeach; ?>
-                    </div>
-                    <template data-repeater-template>
-                        <?php $this->render_custom_slot_row('__INDEX__', ['date' => '', 'time' => ''], true); ?>
-                    </template>
-                    <p class="fp-exp-repeater__actions">
-                        <button type="button" class="button button-secondary" data-repeater-add><?php esc_html_e('Aggiungi slot', 'fp-experiences'); ?></button>
-                    </p>
-                </div>
-            </fieldset>
-
             <fieldset class="fp-exp-fieldset">
                 <legend><?php esc_html_e('Ricorrenza automatica', 'fp-experiences'); ?></legend>
                 <div class="fp-exp-field fp-exp-field--switch">
@@ -767,11 +694,11 @@ final class ExperienceMetaBoxes
                     <div class="fp-exp-repeater fp-exp-recurrence__sets" data-repeater="recurrence_time_sets" data-repeater-next-index="<?php echo esc_attr((string) count($time_sets)); ?>">
                         <div class="fp-exp-repeater__items" data-recurrence-time-set-list>
                             <?php foreach ($time_sets as $index => $set) : ?>
-                                <?php $this->render_time_set_row((string) $index, $set); ?>
+                                <?php $this->render_time_set_row((string) $index, $set, false, (string) ($recurrence['frequency'] ?? 'weekly')); ?>
                             <?php endforeach; ?>
                         </div>
                         <template data-repeater-template>
-                            <?php $this->render_time_set_row('__INDEX__', ['label' => '', 'times' => ['']], true); ?>
+                            <?php $this->render_time_set_row('__INDEX__', ['label' => '', 'times' => [''], 'days' => []], true, (string) ($recurrence['frequency'] ?? 'weekly')); ?>
                         </template>
                         <p class="fp-exp-repeater__actions">
                             <button type="button" class="button button-secondary" data-repeater-add><?php esc_html_e('Aggiungi time set', 'fp-experiences'); ?></button>
@@ -1243,7 +1170,7 @@ final class ExperienceMetaBoxes
         <?php
     }
 
-    private function render_time_set_row(string $index, array $set, bool $is_template = false): void
+    private function render_time_set_row(string $index, array $set, bool $is_template = false, string $frequency = 'weekly'): void
     {
         $label_name = $is_template
             ? 'fp_exp_availability[recurrence][time_sets][__INDEX__][label]'
@@ -1251,13 +1178,23 @@ final class ExperienceMetaBoxes
         $times_base = $is_template
             ? 'fp_exp_availability[recurrence][time_sets][__INDEX__][times]'
             : 'fp_exp_availability[recurrence][time_sets][' . $index . '][times]';
+        $days_base = $is_template
+            ? 'fp_exp_availability[recurrence][time_sets][__INDEX__][days]'
+            : 'fp_exp_availability[recurrence][time_sets][' . $index . '][days]';
 
         $label_value = isset($set['label']) ? (string) $set['label'] : '';
         $times = [];
+        $set_days = [];
 
         if (isset($set['times']) && is_array($set['times'])) {
             foreach ($set['times'] as $time) {
                 $times[] = (string) $time;
+            }
+        }
+
+        if (isset($set['days']) && is_array($set['days'])) {
+            foreach ($set['days'] as $day) {
+                $set_days[] = (string) $day;
             }
         }
 
@@ -1295,6 +1232,18 @@ final class ExperienceMetaBoxes
             <p class="fp-exp-recurrence-set__actions">
                 <button type="button" class="button button-secondary" data-time-set-add><?php esc_html_e('Aggiungi orario', 'fp-experiences'); ?></button>
             </p>
+            <div class="fp-exp-field" data-time-set-days <?php echo 'weekly' === $frequency ? '' : 'hidden'; ?>>
+                <span class="fp-exp-field__label"><?php esc_html_e('Giorni attivi per questo set', 'fp-experiences'); ?></span>
+                <div class="fp-exp-checkbox-grid">
+                    <?php foreach ($this->get_week_days() as $day_key => $day_label) : ?>
+                        <label>
+                            <input type="checkbox" <?php echo $this->field_name_attribute($days_base . '[]', $is_template); ?> value="<?php echo esc_attr($day_key); ?>" <?php checked(in_array($this->map_weekday_for_ui($day_key), $set_days, true)); ?> />
+                            <span><?php echo esc_html($day_label); ?></span>
+                        </label>
+                    <?php endforeach; ?>
+                </div>
+                <p class="fp-exp-field__description"><?php esc_html_e('Lascia vuoto per usare i giorni generali della ricorrenza settimanale.', 'fp-experiences'); ?></p>
+            </div>
         </div>
         <?php
     }
@@ -1846,6 +1795,7 @@ final class ExperienceMetaBoxes
 
                 $label = isset($set['label']) ? sanitize_text_field((string) $set['label']) : '';
                 $times = [];
+                $set_days = [];
 
                 if (isset($set['times']) && is_array($set['times'])) {
                     foreach ($set['times'] as $time) {
@@ -1857,6 +1807,16 @@ final class ExperienceMetaBoxes
                     }
                 }
 
+                if (isset($set['days']) && is_array($set['days'])) {
+                    foreach ($set['days'] as $day) {
+                        $day_key = sanitize_key((string) $day);
+                        $mapped = $this->map_weekday_for_ui($day_key);
+                        if ('' !== $mapped && ! in_array($mapped, $set_days, true)) {
+                            $set_days[] = $mapped;
+                        }
+                    }
+                }
+
                 if (empty($times)) {
                     continue;
                 }
@@ -1864,6 +1824,7 @@ final class ExperienceMetaBoxes
                 $time_sets[] = [
                     'label' => $label,
                     'times' => array_values(array_unique($times)),
+                    'days' => $set_days,
                 ];
             }
         }

--- a/src/Shortcodes/ExperienceShortcode.php
+++ b/src/Shortcodes/ExperienceShortcode.php
@@ -208,7 +208,7 @@ final class ExperienceShortcode extends BaseShortcode
 
         $widget_atts = [
             'id' => (string) $experience_id,
-            'sticky' => $is_sticky_widget ? '1' : '0',
+            'sticky' => '0',
             'display_context' => 'page',
         ];
 

--- a/templates/front/experience.php
+++ b/templates/front/experience.php
@@ -94,6 +94,18 @@ $gift_config = [
 ];
 $gift_addons = isset($gift['addons']) && is_array($gift['addons']) ? $gift['addons'] : [];
 
+$primary_image = ! empty($gallery) ? $gallery[0] : null;
+$secondary_images = count($gallery) > 1 ? array_slice($gallery, 1, 4) : [];
+$hero_language_badges = array_values(array_filter(
+    $badges,
+    static fn ($badge) => isset($badge['icon']) && 'language' === $badge['icon']
+));
+$hero_fact_badges = array_values(array_filter(
+    $badges,
+    static fn ($badge) => ! isset($badge['icon']) || 'language' !== $badge['icon']
+));
+$hero_highlights = array_slice($highlights, 0, 3);
+
 ?>
 <div
     class="<?php echo esc_attr(implode(' ', $wrapper_classes)); ?>"
@@ -113,25 +125,34 @@ $gift_addons = isset($gift['addons']) && is_array($gift['addons']) ? $gift['addo
         <main class="fp-main">
             <?php if (! empty($sections['hero'])) : ?>
                 <section class="fp-section fp-hero-section" id="fp-exp-section-hero" data-fp-section="hero">
-                    <div class="fp-hero-media" aria-hidden="<?php echo empty($gallery) ? 'true' : 'false'; ?>">
-                        <?php if (! empty($gallery)) : ?>
-                            <div class="fp-hero fp-exp-gallery" data-fp-gallery>
-                                <?php foreach ($gallery as $index => $image) :
-                                    $figure_classes = ['fp-exp-gallery__item'];
-                                    $figure_classes[] = 0 === $index ? 'fp-hero-main' : 'fp-hero-item';
-                                    ?>
-                                    <figure class="<?php echo esc_attr(implode(' ', $figure_classes)); ?>" data-index="<?php echo esc_attr((string) $index); ?>">
-                                        <img
-                                            src="<?php echo esc_url($image['url']); ?>"
-                                            <?php if (! empty($image['srcset'])) : ?>srcset="<?php echo esc_attr($image['srcset']); ?>"<?php endif; ?>
-                                            <?php if (! empty($image['width'])) : ?>width="<?php echo esc_attr((string) $image['width']); ?>"<?php endif; ?>
-                                            <?php if (! empty($image['height'])) : ?>height="<?php echo esc_attr((string) $image['height']); ?>"<?php endif; ?>
-                                            alt="<?php echo esc_attr($experience['title']); ?>"
-                                            loading="lazy"
-                                        />
-                                    </figure>
-                                <?php endforeach; ?>
-                            </div>
+                    <div class="fp-hero-media" aria-hidden="<?php echo null === $primary_image ? 'true' : 'false'; ?>">
+                        <?php if ($primary_image) : ?>
+                            <figure class="fp-hero-media__primary">
+                                <img
+                                    src="<?php echo esc_url($primary_image['url']); ?>"
+                                    <?php if (! empty($primary_image['srcset'])) : ?>srcset="<?php echo esc_attr($primary_image['srcset']); ?>"<?php endif; ?>
+                                    <?php if (! empty($primary_image['width'])) : ?>width="<?php echo esc_attr((string) $primary_image['width']); ?>"<?php endif; ?>
+                                    <?php if (! empty($primary_image['height'])) : ?>height="<?php echo esc_attr((string) $primary_image['height']); ?>"<?php endif; ?>
+                                    alt="<?php echo esc_attr($experience['title']); ?>"
+                                    loading="lazy"
+                                />
+                            </figure>
+                            <?php if (! empty($secondary_images)) : ?>
+                                <div class="fp-hero-media__thumbnails">
+                                    <?php foreach ($secondary_images as $index => $image) : ?>
+                                        <figure class="fp-hero-media__thumbnail" data-index="<?php echo esc_attr((string) ($index + 1)); ?>">
+                                            <img
+                                                src="<?php echo esc_url($image['url']); ?>"
+                                                <?php if (! empty($image['srcset'])) : ?>srcset="<?php echo esc_attr($image['srcset']); ?>"<?php endif; ?>
+                                                <?php if (! empty($image['width'])) : ?>width="<?php echo esc_attr((string) $image['width']); ?>"<?php endif; ?>
+                                                <?php if (! empty($image['height'])) : ?>height="<?php echo esc_attr((string) $image['height']); ?>"<?php endif; ?>
+                                                alt="<?php echo esc_attr($experience['title']); ?>"
+                                                loading="lazy"
+                                            />
+                                        </figure>
+                                    <?php endforeach; ?>
+                                </div>
+                            <?php endif; ?>
                         <?php else : ?>
                             <div class="fp-hero fp-exp-gallery fp-exp-gallery--placeholder">
                                 <span aria-hidden="true"></span>
@@ -139,47 +160,61 @@ $gift_addons = isset($gift['addons']) && is_array($gift['addons']) ? $gift['addo
                         <?php endif; ?>
                     </div>
                     <div class="fp-hero-body">
-                        <div class="fp-eyebrow">
-                            <span class="fp-badge">FP Experiences</span>
+                        <div class="fp-hero-body__header">
+                            <div class="fp-eyebrow">
+                                <span class="fp-badge">FP Experiences</span>
+                            </div>
+                            <h1 class="fp-title"><?php echo esc_html($experience['title']); ?></h1>
                         </div>
-                        <h1 class="fp-title"><?php echo esc_html($experience['title']); ?></h1>
-                        <?php if (! empty($badges)) : ?>
-                            <ul class="fp-meta" role="list">
-                                <?php foreach ($badges as $badge) : ?>
-                                    <?php if ('language' === ($badge['icon'] ?? '')) :
+                        <?php if (! empty($experience['summary'])) : ?>
+                            <p class="fp-summary"><?php echo esc_html($experience['summary']); ?></p>
+                        <?php endif; ?>
+                        <?php if (! empty($hero_highlights)) : ?>
+                            <ul class="fp-hero-highlights" role="list">
+                                <?php foreach ($hero_highlights as $highlight) : ?>
+                                    <li class="fp-hero-highlights__item"><?php echo esc_html($highlight); ?></li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?>
+                        <?php if (! empty($hero_language_badges)) : ?>
+                            <div class="fp-hero-languages">
+                                <span class="fp-hero-languages__label"><?php esc_html_e('Languages', 'fp-experiences'); ?></span>
+                                <ul class="fp-hero-languages__list" role="list">
+                                    <?php foreach ($hero_language_badges as $badge) :
                                         $language_meta = isset($badge['language']) && is_array($badge['language']) ? $badge['language'] : [];
                                         $sprite_id = isset($language_meta['sprite']) ? (string) $language_meta['sprite'] : '';
                                         $aria_label = isset($language_meta['aria_label']) ? (string) $language_meta['aria_label'] : (string) ($badge['label'] ?? '');
                                         $readable_label = isset($language_meta['label']) ? (string) $language_meta['label'] : (string) ($badge['label'] ?? '');
                                         ?>
-                                        <li class="fp-badge fp-badge--language">
+                                        <li class="fp-hero-language">
                                             <?php if ($sprite_id) : ?>
-                                                <span class="fp-badge__flag" role="img" aria-label="<?php echo esc_attr($aria_label); ?>">
+                                                <span class="fp-hero-language__flag" role="img" aria-label="<?php echo esc_attr($aria_label); ?>">
                                                     <svg viewBox="0 0 24 16" aria-hidden="true" focusable="false">
                                                         <use href="<?php echo esc_url($language_sprite . '#' . $sprite_id); ?>"></use>
                                                     </svg>
                                                 </span>
                                             <?php endif; ?>
-                                            <span class="fp-badge__label" aria-hidden="true"><?php echo esc_html((string) ($badge['label'] ?? '')); ?></span>
-                                            <span class="screen-reader-text"><?php echo esc_html($readable_label); ?></span>
+                                            <span class="fp-hero-language__name"><?php echo esc_html($readable_label); ?></span>
                                         </li>
-                                    <?php else : ?>
-                                        <li class="fp-badge">
-                                            <span class="fp-exp-icon fp-exp-icon--<?php echo esc_attr((string) ($badge['icon'] ?? '')); ?>" aria-hidden="true">
+                                    <?php endforeach; ?>
+                                </ul>
+                            </div>
+                        <?php endif; ?>
+                        <?php if (! empty($hero_fact_badges)) : ?>
+                            <ul class="fp-hero-facts" role="list">
+                                <?php foreach ($hero_fact_badges as $badge) : ?>
+                                    <li class="fp-hero-facts__item">
+                                            <span class="fp-hero-facts__icon" aria-hidden="true">
                                                 <?php if ('clock' === ($badge['icon'] ?? '')) : ?>
                                                     <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm1 10.59 2.12 2.12-1.41 1.41-2.83-2.83V7h2.12Z"/></svg>
                                                 <?php else : ?>
                                                     <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M12 12.88 9.17 10H5a3 3 0 0 0-3 3v7h6v-4h2v4h6v-7a3 3 0 0 0-3-3h-1.17Zm9-2.88a4 4 0 1 0-4-4 4 4 0 0 0 4 4Z"/></svg>
                                                 <?php endif; ?>
                                             </span>
-                                            <span class="fp-badge__label"><?php echo esc_html((string) ($badge['label'] ?? '')); ?></span>
-                                        </li>
-                                    <?php endif; ?>
+                                            <span class="fp-hero-facts__text"><?php echo esc_html((string) ($badge['label'] ?? '')); ?></span>
+                                    </li>
                                 <?php endforeach; ?>
                             </ul>
-                        <?php endif; ?>
-                        <?php if (! empty($experience['summary'])) : ?>
-                            <p class="fp-summary"><?php echo esc_html($experience['summary']); ?></p>
                         <?php endif; ?>
                         <div class="fp-hero-cta">
                             <a

--- a/templates/front/widget.php
+++ b/templates/front/widget.php
@@ -116,33 +116,12 @@ $rtb_submit_label = 'pay_later' === $rtb_mode
             <?php endif; ?>
         </div>
     </div>
-    <?php if ($behavior['sticky']) : ?>
-        <button
-            type="button"
-            class="fp-exp-widget__open"
-            data-fp-widget-open="1"
-            aria-expanded="false"
-            aria-controls="<?php echo esc_attr($dialog_id); ?>"
-        >
-            <span class="fp-exp-widget__open-label"><?php echo esc_html__('Open booking panel', 'fp-experiences'); ?></span>
-        </button>
-    <?php endif; ?>
     <div
         class="fp-exp-widget__body"
         data-sticky="<?php echo esc_attr($behavior['sticky'] ? '1' : '0'); ?>"
         id="<?php echo esc_attr($dialog_id); ?>"
-        <?php if ($behavior['sticky']) : ?>role="dialog" aria-modal="true"<?php else : ?>role="group"<?php endif; ?>
+        <?php if ($behavior['sticky']) : ?>role="region"<?php else : ?>role="group"<?php endif; ?>
     >
-        <?php if ($behavior['sticky']) : ?>
-            <button
-                type="button"
-                class="fp-exp-widget__close"
-                data-fp-widget-close="1"
-                aria-label="<?php echo esc_attr__('Close booking panel', 'fp-experiences'); ?>"
-            >
-                <span aria-hidden="true">&times;</span>
-            </button>
-        <?php endif; ?>
         <ol class="fp-exp-widget__steps">
             <li class="fp-exp-step fp-exp-step--dates" data-fp-step="dates">
                 <header>
@@ -155,10 +134,19 @@ $rtb_submit_label = 'pay_later' === $rtb_mode
                             <section class="fp-exp-calendar__month" data-month="<?php echo esc_attr($month_key); ?>">
                                 <header class="fp-exp-calendar__month-header"><?php echo esc_html($month_data['month_label']); ?></header>
                                 <div class="fp-exp-calendar__grid">
-                                    <?php foreach ($month_data['days'] as $day => $day_slots) : ?>
-                                        <button type="button" class="fp-exp-calendar__day" data-date="<?php echo esc_attr($day); ?>" data-available="<?php echo esc_attr(count($day_slots) > 0 ? '1' : '0'); ?>">
+                                    <?php foreach ($month_data['days'] as $day => $day_slots) :
+                                        $slot_count = count($day_slots);
+                                        $is_available = $slot_count > 0;
+                                        ?>
+                                        <button
+                                            type="button"
+                                            class="fp-exp-calendar__day"
+                                            data-date="<?php echo esc_attr($day); ?>"
+                                            data-available="<?php echo esc_attr($is_available ? '1' : '0'); ?>"
+                                            <?php if (! $is_available) : ?>disabled aria-disabled="true"<?php else : ?>aria-pressed="false"<?php endif; ?>
+                                        >
                                             <span class="fp-exp-calendar__day-label"><?php echo esc_html($day); ?></span>
-                                            <span class="fp-exp-calendar__day-count"><?php echo esc_html(sprintf(esc_html__('%d slots', 'fp-experiences'), count($day_slots))); ?></span>
+                                            <span class="fp-exp-calendar__day-count"><?php echo esc_html(sprintf(esc_html__('%d slots', 'fp-experiences'), $slot_count)); ?></span>
                                         </button>
                                     <?php endforeach; ?>
                                 </div>


### PR DESCRIPTION
## Summary
- keep the booking widget permanently open by removing the toggle controls and exposing only the region markup
- add disabled/selected styling and aria state updates to the calendar days while skipping empty dates
- localize slot availability labels in the booking widget and document recurrence time-set day support

## Testing
- php -l templates/front/widget.php
- php -l build/fp-experiences/templates/front/widget.php
- php -l src/Booking/Recurrence.php
- php -l build/fp-experiences/src/Booking/Recurrence.php

------
https://chatgpt.com/codex/tasks/task_e_68dd5f973768832f952c10888d34c2cb