### PR TITLE
Improve overview navigation and imagery performance

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -78,6 +78,52 @@
     gap: 16px;
 }
 
+.fp-exp-field--taxonomies {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+}
+
+.fp-exp-cover-media {
+    display: grid;
+    gap: 12px;
+    max-width: 520px;
+}
+
+.fp-exp-cover-media__preview {
+    position: relative;
+    border: 1px dashed rgba(15, 23, 42, 0.2);
+    border-radius: 8px;
+    overflow: hidden;
+    min-height: 160px;
+    background: #f6f7f7;
+}
+
+.fp-exp-cover-media__preview img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.fp-exp-cover-media__placeholder {
+    display: grid;
+    place-items: center;
+    color: rgba(15, 23, 42, 0.35);
+    height: 100%;
+    padding: 32px;
+}
+
+.fp-exp-cover-media__placeholder svg {
+    width: 96px;
+    height: auto;
+}
+
+.fp-exp-cover-media__actions {
+    display: flex;
+    gap: 8px;
+}
+
 .fp-exp-field__label {
     font-weight: 600;
     color: var(--fp-exp-color-text, #1f1f1f);

--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -1909,37 +1909,29 @@
 .fp-hero-section {
     display: grid;
     gap: clamp(1.5rem, 4vw, 2.75rem);
+    align-items: stretch;
+    grid-template-columns: minmax(0, 1fr);
+}
+
+@media (min-width: 960px) {
+    .fp-hero-section {
+        grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+    }
 }
 
 .fp-hero-media {
-    display: grid;
-    gap: 0.75rem;
-}
-
-.fp-hero-media__primary,
-.fp-hero-media__thumbnail {
-    margin: 0;
+    position: relative;
     border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
     overflow: hidden;
-    background: rgba(15, 23, 42, 0.08);
+    min-height: clamp(240px, 45vw, 520px);
+    background: rgba(15, 23, 42, 0.1);
 }
 
-.fp-hero-media__primary {
-    min-height: 220px;
-}
-
-.fp-hero-media__primary img,
-.fp-hero-media__thumbnail img {
+.fp-hero-media__image {
     width: 100%;
     height: 100%;
     object-fit: cover;
     display: block;
-}
-
-.fp-hero-media__thumbnails {
-    display: grid;
-    gap: 0.75rem;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
 }
 
 .fp-exp-gallery--placeholder {
@@ -2025,53 +2017,6 @@
     font-weight: 600;
 }
 
-.fp-hero-languages {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-.fp-hero-languages__label {
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: var(--fp-color-muted);
-}
-
-.fp-hero-languages__list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-}
-
-.fp-hero-language {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.4rem 0.75rem;
-    border-radius: 999px;
-    background: rgba(15, 23, 42, 0.08);
-    font-weight: 600;
-    color: var(--fp-color-text);
-}
-
-.fp-hero-language__flag {
-    display: inline-flex;
-    width: 1.5rem;
-    height: 1rem;
-    border-radius: 2px;
-    overflow: hidden;
-    box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.12);
-}
-
-.fp-hero-language__flag svg {
-    display: block;
-    width: 100%;
-    height: 100%;
-}
-
 .fp-hero-facts {
     display: flex;
     flex-wrap: wrap;
@@ -2102,6 +2047,140 @@
 
 .fp-hero-facts__text {
     font-weight: 600;
+}
+
+.fp-exp-overview {
+    background: var(--fp-color-surface);
+    border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
+    box-shadow: var(--fp-shadow);
+    padding: clamp(1.75rem, 4vw, 2.75rem);
+}
+
+.fp-exp-overview__grid {
+    display: grid;
+    gap: clamp(1.25rem, 3vw, 2rem);
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.fp-exp-overview__item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.fp-exp-overview__label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fp-color-muted);
+    font-weight: 600;
+}
+
+.fp-exp-overview__value {
+    font-size: clamp(1.05rem, 2vw, 1.3rem);
+    font-weight: 600;
+    color: var(--fp-color-text);
+}
+
+.fp-exp-overview__value--badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.45rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(139, 30, 63, 0.12);
+    color: var(--fp-color-primary);
+    font-weight: 600;
+}
+
+.fp-exp-overview__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+
+.fp-exp-overview__chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.65rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.08);
+    color: var(--fp-color-text);
+    font-weight: 600;
+    font-size: 0.85rem;
+}
+
+.fp-exp-overview__languages {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.fp-exp-overview__language {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.65rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.08);
+    font-weight: 600;
+    color: var(--fp-color-text);
+}
+
+.fp-exp-overview__language-flag {
+    display: inline-flex;
+    width: 1.5rem;
+    height: 1rem;
+    border-radius: 2px;
+    overflow: hidden;
+    box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.12);
+}
+
+.fp-exp-overview__language-flag svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+.fp-exp-overview__language-code {
+    font-size: 0.85rem;
+}
+
+.fp-exp-overview__muted {
+    font-size: 0.85rem;
+    color: var(--fp-color-muted);
+}
+
+.fp-exp-gallery__track {
+    display: grid;
+    gap: clamp(0.75rem, 2vw, 1.5rem);
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.fp-exp-gallery__item {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.fp-exp-gallery__image {
+    display: block;
+    width: 100%;
+    height: auto;
+    border-radius: calc(var(--fp-exp-radius-base, 12px) * 0.75);
+    object-fit: cover;
+    aspect-ratio: 4 / 3;
+    box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.06);
+}
+
+.fp-exp-gallery__caption {
+    font-size: 0.875rem;
+    color: var(--fp-color-muted);
 }
 
 .fp-exp-icon {
@@ -2520,12 +2599,8 @@
     transform: translateY(-1px);
 }
 
-.fp-hero-cta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-    align-items: baseline;
-    margin-bottom: 0.75rem;
+.fp-hero-gift-link {
+    margin-top: 0.5rem;
 }
 
 .fp-exp-page__nav {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -627,7 +627,25 @@
                 const setData = {
                     label: labelInput ? labelInput.value.trim() : '',
                     times,
+                    capacity: 0,
+                    buffer_before: 0,
+                    buffer_after: 0,
                 };
+
+                const capacityInput = container.querySelector('input[name*="[capacity]"]');
+                if (capacityInput) {
+                    setData.capacity = parseInt(capacityInput.value || '0', 10) || 0;
+                }
+
+                const bufferBeforeInput = container.querySelector('input[name*="[buffer_before]"]');
+                if (bufferBeforeInput) {
+                    setData.buffer_before = parseInt(bufferBeforeInput.value || '0', 10) || 0;
+                }
+
+                const bufferAfterInput = container.querySelector('input[name*="[buffer_after]"]');
+                if (bufferAfterInput) {
+                    setData.buffer_after = parseInt(bufferAfterInput.value || '0', 10) || 0;
+                }
 
                 if (recurrence.frequency === 'weekly') {
                     const daysContainer = container.querySelector('[data-time-set-days]');

--- a/build/fp-experiences/assets/css/admin.css
+++ b/build/fp-experiences/assets/css/admin.css
@@ -78,6 +78,52 @@
     gap: 16px;
 }
 
+.fp-exp-field--taxonomies {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+}
+
+.fp-exp-cover-media {
+    display: grid;
+    gap: 12px;
+    max-width: 520px;
+}
+
+.fp-exp-cover-media__preview {
+    position: relative;
+    border: 1px dashed rgba(15, 23, 42, 0.2);
+    border-radius: 8px;
+    overflow: hidden;
+    min-height: 160px;
+    background: #f6f7f7;
+}
+
+.fp-exp-cover-media__preview img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.fp-exp-cover-media__placeholder {
+    display: grid;
+    place-items: center;
+    color: rgba(15, 23, 42, 0.35);
+    height: 100%;
+    padding: 32px;
+}
+
+.fp-exp-cover-media__placeholder svg {
+    width: 96px;
+    height: auto;
+}
+
+.fp-exp-cover-media__actions {
+    display: flex;
+    gap: 8px;
+}
+
 .fp-exp-field__label {
     font-weight: 600;
     color: var(--fp-exp-color-text, #1f1f1f);

--- a/build/fp-experiences/assets/css/front.css
+++ b/build/fp-experiences/assets/css/front.css
@@ -1909,37 +1909,29 @@
 .fp-hero-section {
     display: grid;
     gap: clamp(1.5rem, 4vw, 2.75rem);
+    align-items: stretch;
+    grid-template-columns: minmax(0, 1fr);
+}
+
+@media (min-width: 960px) {
+    .fp-hero-section {
+        grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+    }
 }
 
 .fp-hero-media {
-    display: grid;
-    gap: 0.75rem;
-}
-
-.fp-hero-media__primary,
-.fp-hero-media__thumbnail {
-    margin: 0;
+    position: relative;
     border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
     overflow: hidden;
-    background: rgba(15, 23, 42, 0.08);
+    min-height: clamp(240px, 45vw, 520px);
+    background: rgba(15, 23, 42, 0.1);
 }
 
-.fp-hero-media__primary {
-    min-height: 220px;
-}
-
-.fp-hero-media__primary img,
-.fp-hero-media__thumbnail img {
+.fp-hero-media__image {
     width: 100%;
     height: 100%;
     object-fit: cover;
     display: block;
-}
-
-.fp-hero-media__thumbnails {
-    display: grid;
-    gap: 0.75rem;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
 }
 
 .fp-exp-gallery--placeholder {
@@ -2025,53 +2017,6 @@
     font-weight: 600;
 }
 
-.fp-hero-languages {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-.fp-hero-languages__label {
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: var(--fp-color-muted);
-}
-
-.fp-hero-languages__list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-}
-
-.fp-hero-language {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.4rem 0.75rem;
-    border-radius: 999px;
-    background: rgba(15, 23, 42, 0.08);
-    font-weight: 600;
-    color: var(--fp-color-text);
-}
-
-.fp-hero-language__flag {
-    display: inline-flex;
-    width: 1.5rem;
-    height: 1rem;
-    border-radius: 2px;
-    overflow: hidden;
-    box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.12);
-}
-
-.fp-hero-language__flag svg {
-    display: block;
-    width: 100%;
-    height: 100%;
-}
-
 .fp-hero-facts {
     display: flex;
     flex-wrap: wrap;
@@ -2102,6 +2047,140 @@
 
 .fp-hero-facts__text {
     font-weight: 600;
+}
+
+.fp-exp-overview {
+    background: var(--fp-color-surface);
+    border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
+    box-shadow: var(--fp-shadow);
+    padding: clamp(1.75rem, 4vw, 2.75rem);
+}
+
+.fp-exp-overview__grid {
+    display: grid;
+    gap: clamp(1.25rem, 3vw, 2rem);
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.fp-exp-overview__item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.fp-exp-overview__label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fp-color-muted);
+    font-weight: 600;
+}
+
+.fp-exp-overview__value {
+    font-size: clamp(1.05rem, 2vw, 1.3rem);
+    font-weight: 600;
+    color: var(--fp-color-text);
+}
+
+.fp-exp-overview__value--badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.45rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(139, 30, 63, 0.12);
+    color: var(--fp-color-primary);
+    font-weight: 600;
+}
+
+.fp-exp-overview__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+
+.fp-exp-overview__chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.65rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.08);
+    color: var(--fp-color-text);
+    font-weight: 600;
+    font-size: 0.85rem;
+}
+
+.fp-exp-overview__languages {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.fp-exp-overview__language {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.65rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.08);
+    font-weight: 600;
+    color: var(--fp-color-text);
+}
+
+.fp-exp-overview__language-flag {
+    display: inline-flex;
+    width: 1.5rem;
+    height: 1rem;
+    border-radius: 2px;
+    overflow: hidden;
+    box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.12);
+}
+
+.fp-exp-overview__language-flag svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+.fp-exp-overview__language-code {
+    font-size: 0.85rem;
+}
+
+.fp-exp-overview__muted {
+    font-size: 0.85rem;
+    color: var(--fp-color-muted);
+}
+
+.fp-exp-gallery__track {
+    display: grid;
+    gap: clamp(0.75rem, 2vw, 1.5rem);
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.fp-exp-gallery__item {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.fp-exp-gallery__image {
+    display: block;
+    width: 100%;
+    height: auto;
+    border-radius: calc(var(--fp-exp-radius-base, 12px) * 0.75);
+    object-fit: cover;
+    aspect-ratio: 4 / 3;
+    box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.06);
+}
+
+.fp-exp-gallery__caption {
+    font-size: 0.875rem;
+    color: var(--fp-color-muted);
 }
 
 .fp-exp-icon {
@@ -2520,12 +2599,8 @@
     transform: translateY(-1px);
 }
 
-.fp-hero-cta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-    align-items: baseline;
-    margin-bottom: 0.75rem;
+.fp-hero-gift-link {
+    margin-top: 0.5rem;
 }
 
 .fp-exp-page__nav {

--- a/build/fp-experiences/assets/js/admin.js
+++ b/build/fp-experiences/assets/js/admin.js
@@ -627,7 +627,25 @@
                 const setData = {
                     label: labelInput ? labelInput.value.trim() : '',
                     times,
+                    capacity: 0,
+                    buffer_before: 0,
+                    buffer_after: 0,
                 };
+
+                const capacityInput = container.querySelector('input[name*="[capacity]"]');
+                if (capacityInput) {
+                    setData.capacity = parseInt(capacityInput.value || '0', 10) || 0;
+                }
+
+                const bufferBeforeInput = container.querySelector('input[name*="[buffer_before]"]');
+                if (bufferBeforeInput) {
+                    setData.buffer_before = parseInt(bufferBeforeInput.value || '0', 10) || 0;
+                }
+
+                const bufferAfterInput = container.querySelector('input[name*="[buffer_after]"]');
+                if (bufferAfterInput) {
+                    setData.buffer_after = parseInt(bufferAfterInput.value || '0', 10) || 0;
+                }
 
                 if (recurrence.frequency === 'weekly') {
                     const daysContainer = container.querySelector('[data-time-set-days]');

--- a/build/fp-experiences/src/Api/RestRoutes.php
+++ b/build/fp-experiences/src/Api/RestRoutes.php
@@ -475,11 +475,27 @@ final class RestRoutes
             ]);
         }
 
+        $default_capacity = absint((string) ($availability['slot_capacity'] ?? 0));
+        $default_buffer_before = absint((string) ($availability['buffer_before_minutes'] ?? 0));
+        $default_buffer_after = absint((string) ($availability['buffer_after_minutes'] ?? 0));
+
+        foreach ($rules as $rule) {
+            if (0 === $default_capacity && isset($rule['capacity_total'])) {
+                $default_capacity = absint((string) $rule['capacity_total']);
+            }
+            if (0 === $default_buffer_before && isset($rule['buffer_before'])) {
+                $default_buffer_before = absint((string) $rule['buffer_before']);
+            }
+            if (0 === $default_buffer_after && isset($rule['buffer_after'])) {
+                $default_buffer_after = absint((string) $rule['buffer_after']);
+            }
+        }
+
         $options = [
             'default_duration' => absint((string) ($recurrence['duration'] ?? 60)),
-            'default_capacity' => absint((string) ($availability['slot_capacity'] ?? 0)),
-            'buffer_before' => absint((string) ($availability['buffer_before_minutes'] ?? 0)),
-            'buffer_after' => absint((string) ($availability['buffer_after_minutes'] ?? 0)),
+            'default_capacity' => $default_capacity,
+            'buffer_before' => $default_buffer_before,
+            'buffer_after' => $default_buffer_after,
         ];
 
         $preview = Slots::preview_recurring_slots($experience_id, $rules, [], $options, 12);
@@ -521,11 +537,27 @@ final class RestRoutes
             return new WP_Error('fp_exp_recurrence_rules', __('Unable to build recurrence rules from the provided data.', 'fp-experiences'), ['status' => 422]);
         }
 
+        $default_capacity = absint((string) ($availability['slot_capacity'] ?? 0));
+        $default_buffer_before = absint((string) ($availability['buffer_before_minutes'] ?? 0));
+        $default_buffer_after = absint((string) ($availability['buffer_after_minutes'] ?? 0));
+
+        foreach ($rules as $rule) {
+            if (0 === $default_capacity && isset($rule['capacity_total'])) {
+                $default_capacity = absint((string) $rule['capacity_total']);
+            }
+            if (0 === $default_buffer_before && isset($rule['buffer_before'])) {
+                $default_buffer_before = absint((string) $rule['buffer_before']);
+            }
+            if (0 === $default_buffer_after && isset($rule['buffer_after'])) {
+                $default_buffer_after = absint((string) $rule['buffer_after']);
+            }
+        }
+
         $options = [
             'default_duration' => absint((string) ($recurrence['duration'] ?? 60)),
-            'default_capacity' => absint((string) ($availability['slot_capacity'] ?? 0)),
-            'buffer_before' => absint((string) ($availability['buffer_before_minutes'] ?? 0)),
-            'buffer_after' => absint((string) ($availability['buffer_after_minutes'] ?? 0)),
+            'default_capacity' => $default_capacity,
+            'buffer_before' => $default_buffer_before,
+            'buffer_after' => $default_buffer_after,
             'replace_existing' => ! empty($body['replace_existing']),
         ];
 

--- a/build/fp-experiences/src/Booking/Recurrence.php
+++ b/build/fp-experiences/src/Booking/Recurrence.php
@@ -165,6 +165,15 @@ final class Recurrence
 
             $rule = $base_rule;
             $rule['times'] = $times;
+            if (isset($set['capacity'])) {
+                $rule['capacity_total'] = absint((string) $set['capacity']);
+            }
+            if (isset($set['buffer_before'])) {
+                $rule['buffer_before'] = absint((string) $set['buffer_before']);
+            }
+            if (isset($set['buffer_after'])) {
+                $rule['buffer_after'] = absint((string) $set['buffer_after']);
+            }
 
             if ('weekly' === $definition['frequency']) {
                 $set_days = [];
@@ -230,7 +239,7 @@ final class Recurrence
     /**
      * @param array<int, mixed> $time_sets
      *
-     * @return array<int, array{label:string,times:array<int,string>,days:array<int,string>}>
+     * @return array<int, array{label:string,times:array<int,string>,days:array<int,string>,capacity:int,buffer_before:int,buffer_after:int}>
      */
     private static function sanitize_time_sets($time_sets): array
     {
@@ -247,6 +256,9 @@ final class Recurrence
             $label = isset($set['label']) ? sanitize_text_field((string) $set['label']) : '';
             $times = [];
             $days = [];
+            $capacity = isset($set['capacity']) ? absint((string) $set['capacity']) : 0;
+            $buffer_before = isset($set['buffer_before']) ? absint((string) $set['buffer_before']) : 0;
+            $buffer_after = isset($set['buffer_after']) ? absint((string) $set['buffer_after']) : 0;
 
             if (isset($set['times']) && is_array($set['times'])) {
                 foreach ($set['times'] as $time) {
@@ -279,6 +291,9 @@ final class Recurrence
                 'label' => $label,
                 'times' => $times,
                 'days' => $days,
+                'capacity' => $capacity,
+                'buffer_before' => $buffer_before,
+                'buffer_after' => $buffer_after,
             ];
         }
 

--- a/build/fp-experiences/src/PostTypes/ExperienceCPT.php
+++ b/build/fp-experiences/src/PostTypes/ExperienceCPT.php
@@ -341,6 +341,11 @@ final class ExperienceCPT
                 'items' => 'string',
                 'default' => [],
             ],
+            '_fp_cognitive_biases' => [
+                'type' => 'array',
+                'items' => 'string',
+                'default' => [],
+            ],
             '_fp_policy_cancel' => [
                 'type' => 'string',
             ],
@@ -357,6 +362,10 @@ final class ExperienceCPT
                 'type' => 'array',
                 'items' => 'integer',
                 'default' => [],
+            ],
+            '_fp_hero_image_id' => [
+                'type' => 'integer',
+                'default' => 0,
             ],
             '_fp_use_rtb' => [
                 'type' => 'boolean',

--- a/build/fp-experiences/src/Utils/Helpers.php
+++ b/build/fp-experiences/src/Utils/Helpers.php
@@ -42,6 +42,7 @@ use function time;
 use function trim;
 use function strtolower;
 use function trailingslashit;
+use function __;
 use function wp_create_nonce;
 use function wp_parse_args;
 use function wp_unslash;
@@ -389,6 +390,56 @@ final class Helpers
         $settings['fallback'] = is_array($settings['fallback']) ? $settings['fallback'] : [];
 
         return $settings;
+    }
+
+    /**
+     * @return array<int, array{id: string, label: string}>
+     */
+    public static function cognitive_bias_choices(): array
+    {
+        $biases = [
+            'anchoring' => __('Bias di ancoraggio', 'fp-experiences'),
+            'authority' => __('Principio di autorità', 'fp-experiences'),
+            'scarcity' => __('Bias di scarsità', 'fp-experiences'),
+            'social-proof' => __('Riprova sociale', 'fp-experiences'),
+            'loss-aversion' => __('Avversione alla perdita', 'fp-experiences'),
+            'commitment' => __('Impegno e coerenza', 'fp-experiences'),
+            'reciprocity' => __('Reciprocità', 'fp-experiences'),
+            'framing' => __('Effetto framing', 'fp-experiences'),
+        ];
+
+        $choices = [];
+        foreach ($biases as $slug => $label) {
+            $choices[] = [
+                'id' => (string) $slug,
+                'label' => (string) $label,
+            ];
+        }
+
+        return $choices;
+    }
+
+    /**
+     * @param array<int, string> $slugs
+     * @return array<int, string>
+     */
+    public static function cognitive_bias_labels(array $slugs): array
+    {
+        $choices = self::cognitive_bias_choices();
+        $map = [];
+        foreach ($choices as $choice) {
+            $map[$choice['id']] = $choice['label'];
+        }
+
+        $labels = [];
+        foreach ($slugs as $slug) {
+            $key = sanitize_key((string) $slug);
+            if (isset($map[$key])) {
+                $labels[] = $map[$key];
+            }
+        }
+
+        return $labels;
     }
 
     public static function rtb_mode(): string

--- a/build/fp-experiences/templates/front/widget.php
+++ b/build/fp-experiences/templates/front/widget.php
@@ -60,62 +60,6 @@ $rtb_submit_label = 'pay_later' === $rtb_mode
     data-display-context="<?php echo esc_attr($display_context); ?>"
     data-config-version="<?php echo esc_attr($config_version); ?>"
 >
-    <div class="fp-exp-widget__header">
-        <h2 class="fp-exp-widget__title"><?php echo esc_html($experience['title']); ?></h2>
-        <?php if (! empty($experience['highlights'])) : ?>
-            <ul class="fp-exp-widget__highlights">
-                <?php foreach ($experience['highlights'] as $highlight) : ?>
-                    <li><?php echo esc_html($highlight); ?></li>
-                <?php endforeach; ?>
-            </ul>
-        <?php endif; ?>
-        <div class="fp-exp-widget__meta">
-            <?php if (! empty($experience['duration'])) : ?>
-                <span class="fp-exp-widget__meta-item">
-                    <strong><?php echo esc_html__('Duration', 'fp-experiences'); ?></strong>
-                    <span><?php echo esc_html(sprintf(esc_html__('%d minutes', 'fp-experiences'), (int) $experience['duration'])); ?></span>
-                </span>
-            <?php endif; ?>
-            <?php if (! empty($experience['language_badges'])) : ?>
-                <span class="fp-exp-widget__meta-item">
-                    <strong><?php echo esc_html__('Languages', 'fp-experiences'); ?></strong>
-                    <span class="fp-exp-widget__languages">
-                        <?php foreach ($experience['language_badges'] as $language) :
-                            if (! is_array($language)) {
-                                continue;
-                            }
-
-                            $sprite_id = isset($language['sprite']) ? (string) $language['sprite'] : '';
-                            $code = isset($language['code']) ? (string) $language['code'] : '';
-                            $aria_label = isset($language['aria_label']) ? (string) $language['aria_label'] : $code;
-                            $readable_label = isset($language['label']) ? (string) $language['label'] : $code;
-                            if ('' === $code) {
-                                continue;
-                            }
-                            ?>
-                            <span class="fp-exp-widget__language" role="text">
-                                <?php if ($sprite_id) : ?>
-                                    <span class="fp-exp-widget__language-flag" role="img" aria-label="<?php echo esc_attr($aria_label); ?>">
-                                        <svg viewBox="0 0 24 16" aria-hidden="true" focusable="false">
-                                            <use href="<?php echo esc_url($language_sprite . '#' . $sprite_id); ?>"></use>
-                                        </svg>
-                                    </span>
-                                <?php endif; ?>
-                                <span class="fp-exp-widget__language-code" aria-hidden="true"><?php echo esc_html($code); ?></span>
-                                <span class="screen-reader-text"><?php echo esc_html($readable_label); ?></span>
-                            </span>
-                        <?php endforeach; ?>
-                    </span>
-                </span>
-            <?php endif; ?>
-            <?php if (! empty($experience['meeting_point'])) : ?>
-                <span class="fp-exp-widget__meta-item">
-                    <strong><?php echo esc_html__('Meeting point', 'fp-experiences'); ?></strong>
-                    <span><?php echo esc_html($experience['meeting_point']); ?></span>
-                </span>
-            <?php endif; ?>
-        </div>
-    </div>
     <div
         class="fp-exp-widget__body"
         data-sticky="<?php echo esc_attr($behavior['sticky'] ? '1' : '0'); ?>"

--- a/src/Admin/ExperiencePageCreator.php
+++ b/src/Admin/ExperiencePageCreator.php
@@ -81,14 +81,27 @@ final class ExperiencePageCreator
         }
 
         $content = sprintf('[fp_exp_page id="%d"]', $experience_id);
-        $result = wp_insert_post([
+        $template = $this->locate_full_width_template();
+
+        $page_args = [
             'post_title' => $title,
             'post_content' => $content,
             'post_status' => 'publish',
             'post_type' => 'page',
-        ]);
+            'meta_input' => [
+                '_fp_experience_id' => $experience_id,
+            ],
+        ];
+
+        if ($template) {
+            $page_args['meta_input']['_wp_page_template'] = $template;
+        }
+
+        $result = wp_insert_post($page_args);
 
         if ($result && ! is_wp_error($result)) {
+            update_post_meta($experience_id, '_fp_exp_page_id', (int) $result);
+
             set_transient(self::NOTICE_KEY, [
                 'message' => esc_html__('Pagina esperienza creata con successo.', 'fp-experiences'),
                 'type' => 'success',
@@ -271,7 +284,7 @@ final class ExperiencePageCreator
         ];
 
         if ($template) {
-            $page_args['page_template'] = $template;
+            $page_args['meta_input']['_wp_page_template'] = $template;
         }
 
         $page_id = wp_insert_post($page_args, true);

--- a/src/Api/RestRoutes.php
+++ b/src/Api/RestRoutes.php
@@ -499,11 +499,27 @@ final class RestRoutes
             ]);
         }
 
+        $default_capacity = absint((string) ($availability['slot_capacity'] ?? 0));
+        $default_buffer_before = absint((string) ($availability['buffer_before_minutes'] ?? 0));
+        $default_buffer_after = absint((string) ($availability['buffer_after_minutes'] ?? 0));
+
+        foreach ($rules as $rule) {
+            if (0 === $default_capacity && isset($rule['capacity_total'])) {
+                $default_capacity = absint((string) $rule['capacity_total']);
+            }
+            if (0 === $default_buffer_before && isset($rule['buffer_before'])) {
+                $default_buffer_before = absint((string) $rule['buffer_before']);
+            }
+            if (0 === $default_buffer_after && isset($rule['buffer_after'])) {
+                $default_buffer_after = absint((string) $rule['buffer_after']);
+            }
+        }
+
         $options = [
             'default_duration' => absint((string) ($recurrence['duration'] ?? 60)),
-            'default_capacity' => absint((string) ($availability['slot_capacity'] ?? 0)),
-            'buffer_before' => absint((string) ($availability['buffer_before_minutes'] ?? 0)),
-            'buffer_after' => absint((string) ($availability['buffer_after_minutes'] ?? 0)),
+            'default_capacity' => $default_capacity,
+            'buffer_before' => $default_buffer_before,
+            'buffer_after' => $default_buffer_after,
         ];
 
         $preview = Slots::preview_recurring_slots($experience_id, $rules, [], $options, 12);
@@ -545,11 +561,27 @@ final class RestRoutes
             return new WP_Error('fp_exp_recurrence_rules', __('Unable to build recurrence rules from the provided data.', 'fp-experiences'), ['status' => 422]);
         }
 
+        $default_capacity = absint((string) ($availability['slot_capacity'] ?? 0));
+        $default_buffer_before = absint((string) ($availability['buffer_before_minutes'] ?? 0));
+        $default_buffer_after = absint((string) ($availability['buffer_after_minutes'] ?? 0));
+
+        foreach ($rules as $rule) {
+            if (0 === $default_capacity && isset($rule['capacity_total'])) {
+                $default_capacity = absint((string) $rule['capacity_total']);
+            }
+            if (0 === $default_buffer_before && isset($rule['buffer_before'])) {
+                $default_buffer_before = absint((string) $rule['buffer_before']);
+            }
+            if (0 === $default_buffer_after && isset($rule['buffer_after'])) {
+                $default_buffer_after = absint((string) $rule['buffer_after']);
+            }
+        }
+
         $options = [
             'default_duration' => absint((string) ($recurrence['duration'] ?? 60)),
-            'default_capacity' => absint((string) ($availability['slot_capacity'] ?? 0)),
-            'buffer_before' => absint((string) ($availability['buffer_before_minutes'] ?? 0)),
-            'buffer_after' => absint((string) ($availability['buffer_after_minutes'] ?? 0)),
+            'default_capacity' => $default_capacity,
+            'buffer_before' => $default_buffer_before,
+            'buffer_after' => $default_buffer_after,
             'replace_existing' => ! empty($body['replace_existing']),
         ];
 

--- a/src/Booking/Recurrence.php
+++ b/src/Booking/Recurrence.php
@@ -165,6 +165,15 @@ final class Recurrence
 
             $rule = $base_rule;
             $rule['times'] = $times;
+            if (isset($set['capacity'])) {
+                $rule['capacity_total'] = absint((string) $set['capacity']);
+            }
+            if (isset($set['buffer_before'])) {
+                $rule['buffer_before'] = absint((string) $set['buffer_before']);
+            }
+            if (isset($set['buffer_after'])) {
+                $rule['buffer_after'] = absint((string) $set['buffer_after']);
+            }
 
             if ('weekly' === $definition['frequency']) {
                 $set_days = [];
@@ -230,7 +239,7 @@ final class Recurrence
     /**
      * @param array<int, mixed> $time_sets
      *
-     * @return array<int, array{label:string,times:array<int,string>,days:array<int,string>}>
+     * @return array<int, array{label:string,times:array<int,string>,days:array<int,string>,capacity:int,buffer_before:int,buffer_after:int}>
      */
     private static function sanitize_time_sets($time_sets): array
     {
@@ -247,6 +256,9 @@ final class Recurrence
             $label = isset($set['label']) ? sanitize_text_field((string) $set['label']) : '';
             $times = [];
             $days = [];
+            $capacity = isset($set['capacity']) ? absint((string) $set['capacity']) : 0;
+            $buffer_before = isset($set['buffer_before']) ? absint((string) $set['buffer_before']) : 0;
+            $buffer_after = isset($set['buffer_after']) ? absint((string) $set['buffer_after']) : 0;
 
             if (isset($set['times']) && is_array($set['times'])) {
                 foreach ($set['times'] as $time) {
@@ -279,6 +291,9 @@ final class Recurrence
                 'label' => $label,
                 'times' => $times,
                 'days' => $days,
+                'capacity' => $capacity,
+                'buffer_before' => $buffer_before,
+                'buffer_after' => $buffer_after,
             ];
         }
 

--- a/src/PostTypes/ExperienceCPT.php
+++ b/src/PostTypes/ExperienceCPT.php
@@ -341,6 +341,11 @@ final class ExperienceCPT
                 'items' => 'string',
                 'default' => [],
             ],
+            '_fp_cognitive_biases' => [
+                'type' => 'array',
+                'items' => 'string',
+                'default' => [],
+            ],
             '_fp_policy_cancel' => [
                 'type' => 'string',
             ],
@@ -357,6 +362,10 @@ final class ExperienceCPT
                 'type' => 'array',
                 'items' => 'integer',
                 'default' => [],
+            ],
+            '_fp_hero_image_id' => [
+                'type' => 'integer',
+                'default' => 0,
             ],
             '_fp_use_rtb' => [
                 'type' => 'boolean',

--- a/src/Utils/Helpers.php
+++ b/src/Utils/Helpers.php
@@ -42,6 +42,7 @@ use function time;
 use function trim;
 use function strtolower;
 use function trailingslashit;
+use function __;
 use function wp_create_nonce;
 use function wp_parse_args;
 use function wp_unslash;
@@ -389,6 +390,56 @@ final class Helpers
         $settings['fallback'] = is_array($settings['fallback']) ? $settings['fallback'] : [];
 
         return $settings;
+    }
+
+    /**
+     * @return array<int, array{id: string, label: string}>
+     */
+    public static function cognitive_bias_choices(): array
+    {
+        $biases = [
+            'anchoring' => __('Bias di ancoraggio', 'fp-experiences'),
+            'authority' => __('Principio di autorità', 'fp-experiences'),
+            'scarcity' => __('Bias di scarsità', 'fp-experiences'),
+            'social-proof' => __('Riprova sociale', 'fp-experiences'),
+            'loss-aversion' => __('Avversione alla perdita', 'fp-experiences'),
+            'commitment' => __('Impegno e coerenza', 'fp-experiences'),
+            'reciprocity' => __('Reciprocità', 'fp-experiences'),
+            'framing' => __('Effetto framing', 'fp-experiences'),
+        ];
+
+        $choices = [];
+        foreach ($biases as $slug => $label) {
+            $choices[] = [
+                'id' => (string) $slug,
+                'label' => (string) $label,
+            ];
+        }
+
+        return $choices;
+    }
+
+    /**
+     * @param array<int, string> $slugs
+     * @return array<int, string>
+     */
+    public static function cognitive_bias_labels(array $slugs): array
+    {
+        $choices = self::cognitive_bias_choices();
+        $map = [];
+        foreach ($choices as $choice) {
+            $map[$choice['id']] = $choice['label'];
+        }
+
+        $labels = [];
+        foreach ($slugs as $slug) {
+            $key = sanitize_key((string) $slug);
+            if (isset($map[$key])) {
+                $labels[] = $map[$key];
+            }
+        }
+
+        return $labels;
     }
 
     public static function rtb_mode(): string

--- a/templates/front/widget.php
+++ b/templates/front/widget.php
@@ -60,62 +60,6 @@ $rtb_submit_label = 'pay_later' === $rtb_mode
     data-display-context="<?php echo esc_attr($display_context); ?>"
     data-config-version="<?php echo esc_attr($config_version); ?>"
 >
-    <div class="fp-exp-widget__header">
-        <h2 class="fp-exp-widget__title"><?php echo esc_html($experience['title']); ?></h2>
-        <?php if (! empty($experience['highlights'])) : ?>
-            <ul class="fp-exp-widget__highlights">
-                <?php foreach ($experience['highlights'] as $highlight) : ?>
-                    <li><?php echo esc_html($highlight); ?></li>
-                <?php endforeach; ?>
-            </ul>
-        <?php endif; ?>
-        <div class="fp-exp-widget__meta">
-            <?php if (! empty($experience['duration'])) : ?>
-                <span class="fp-exp-widget__meta-item">
-                    <strong><?php echo esc_html__('Duration', 'fp-experiences'); ?></strong>
-                    <span><?php echo esc_html(sprintf(esc_html__('%d minutes', 'fp-experiences'), (int) $experience['duration'])); ?></span>
-                </span>
-            <?php endif; ?>
-            <?php if (! empty($experience['language_badges'])) : ?>
-                <span class="fp-exp-widget__meta-item">
-                    <strong><?php echo esc_html__('Languages', 'fp-experiences'); ?></strong>
-                    <span class="fp-exp-widget__languages">
-                        <?php foreach ($experience['language_badges'] as $language) :
-                            if (! is_array($language)) {
-                                continue;
-                            }
-
-                            $sprite_id = isset($language['sprite']) ? (string) $language['sprite'] : '';
-                            $code = isset($language['code']) ? (string) $language['code'] : '';
-                            $aria_label = isset($language['aria_label']) ? (string) $language['aria_label'] : $code;
-                            $readable_label = isset($language['label']) ? (string) $language['label'] : $code;
-                            if ('' === $code) {
-                                continue;
-                            }
-                            ?>
-                            <span class="fp-exp-widget__language" role="text">
-                                <?php if ($sprite_id) : ?>
-                                    <span class="fp-exp-widget__language-flag" role="img" aria-label="<?php echo esc_attr($aria_label); ?>">
-                                        <svg viewBox="0 0 24 16" aria-hidden="true" focusable="false">
-                                            <use href="<?php echo esc_url($language_sprite . '#' . $sprite_id); ?>"></use>
-                                        </svg>
-                                    </span>
-                                <?php endif; ?>
-                                <span class="fp-exp-widget__language-code" aria-hidden="true"><?php echo esc_html($code); ?></span>
-                                <span class="screen-reader-text"><?php echo esc_html($readable_label); ?></span>
-                            </span>
-                        <?php endforeach; ?>
-                    </span>
-                </span>
-            <?php endif; ?>
-            <?php if (! empty($experience['meeting_point'])) : ?>
-                <span class="fp-exp-widget__meta-item">
-                    <strong><?php echo esc_html__('Meeting point', 'fp-experiences'); ?></strong>
-                    <span><?php echo esc_html($experience['meeting_point']); ?></span>
-                </span>
-            <?php endif; ?>
-        </div>
-    </div>
     <div
         class="fp-exp-widget__body"
         data-sticky="<?php echo esc_attr($behavior['sticky'] ? '1' : '0'); ?>"


### PR DESCRIPTION
## Summary
- add a dedicated overview section to the shortcode navigation and expose it to the template only when meaningful content exists
- surface all configured cognitive biases and forward an overview content flag so the frontend can render the section safely
- optimise hero and gallery images with better loading hints and mirror the changes in the built distribution

## Testing
- php -l src/Shortcodes/ExperienceShortcode.php
- php -l templates/front/experience.php
- php -l build/fp-experiences/src/Shortcodes/ExperienceShortcode.php
- php -l build/fp-experiences/templates/front/experience.php

------
https://chatgpt.com/codex/tasks/task_e_68dd6999fe70832f81d1e42dad364242