### PR TITLE
Simplify branding palette to the default preset

### DIFF
--- a/build/fp-experiences/languages/fp-experiences.pot
+++ b/build/fp-experiences/languages/fp-experiences.pot
@@ -1612,12 +1612,8 @@ msgstr ""
 msgid "Clear caches"
 msgstr ""
 
-#: src/Admin/SettingsPage.php:881
-msgid "Tune the booking UI to match your visual identity. Choose a preset, then refine individual colors, borders, and fonts."
-msgstr ""
-
-#: src/Admin/SettingsPage.php:882
-msgid "Dark mode can be applied automatically or when wrapping the shortcode output with the .fp-theme-dark class."
+#: src/Admin/SettingsPage.php:1115
+msgid "FP Experiences now uses a single default color palette that keeps every experience readable and on brand."
 msgstr ""
 
 #: src/Admin/SettingsPage.php:887
@@ -1662,142 +1658,28 @@ msgstr ""
 msgid "Create an OAuth client in Google Cloud and add the redirect URI below. After saving credentials, connect the account to sync reservations."
 msgstr ""
 
-#: src/Admin/SettingsPage.php:966
-msgid "Custom"
+#: src/Admin/SettingsPage.php:1208
+msgid "Color palette"
 msgstr ""
 
-#: src/Admin/SettingsPage.php:975
-#: src/Elementor/WidgetCalendar.php:106
-#: src/Elementor/WidgetCheckout.php:70
-#: src/Elementor/WidgetExperiencePage.php:190
-#: src/Elementor/WidgetList.php:287
-#: src/Elementor/WidgetWidget.php:121
-msgid "Preset"
+#: src/Admin/SettingsPage.php:1210
+msgid "Brand colors use the default palette and cannot be customized."
 msgstr ""
 
-#: src/Admin/SettingsPage.php:977
-msgid "Start from a curated palette, then adjust specific values as needed."
+#: src/Elementor/WidgetCalendar.php:108
+#: src/Elementor/WidgetCheckout.php:72
+#: src/Elementor/WidgetExperiencePage.php:192
+#: src/Elementor/WidgetList.php:418
+#: src/Elementor/WidgetWidget.php:123
+msgid "Brand colors use the default FP Experiences palette."
 msgstr ""
 
-#: src/Admin/SettingsPage.php:982
-#: src/Elementor/WidgetCalendar.php:121
-#: src/Elementor/WidgetCheckout.php:85
-#: src/Elementor/WidgetExperiencePage.php:205
-#: src/Elementor/WidgetList.php:302
-#: src/Elementor/WidgetWidget.php:136
-msgid "Color mode"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:984
-#: src/Elementor/WidgetCalendar.php:110
-#: src/Elementor/WidgetCalendar.php:125
-#: src/Elementor/WidgetCheckout.php:74
-#: src/Elementor/WidgetCheckout.php:89
-#: src/Elementor/WidgetExperiencePage.php:194
-#: src/Elementor/WidgetExperiencePage.php:209
-#: src/Elementor/WidgetList.php:291
-#: src/Elementor/WidgetList.php:306
-#: src/Elementor/WidgetWidget.php:125
-#: src/Elementor/WidgetWidget.php:140
-#: src/Utils/Theme.php:39
-msgid "Light"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:985
-msgid "Dark (requires .fp-theme-dark wrapper)"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:986
-msgid "Automatic (prefers-color-scheme + .fp-theme-dark)"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:989
-msgid "Primary color"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:990
-msgid "Secondary color"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:991
-msgid "Accent color"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:992
-#: src/Elementor/WidgetCalendar.php:136
-#: src/Elementor/WidgetCheckout.php:100
-#: src/Elementor/WidgetExperiencePage.php:220
-#: src/Elementor/WidgetList.php:317
-#: src/Elementor/WidgetWidget.php:151
-msgid "Background"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:993
-#: src/Elementor/WidgetCalendar.php:137
-#: src/Elementor/WidgetCheckout.php:101
-#: src/Elementor/WidgetExperiencePage.php:221
-#: src/Elementor/WidgetList.php:318
-#: src/Elementor/WidgetWidget.php:152
-msgid "Surface"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:994
-msgid "Text color"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:995
-msgid "Muted text"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:996
-#: src/Elementor/WidgetCalendar.php:140
-#: src/Elementor/WidgetCheckout.php:104
-#: src/Elementor/WidgetExperiencePage.php:224
-#: src/Elementor/WidgetList.php:321
-#: src/Elementor/WidgetWidget.php:155
-msgid "Success"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:997
-#: src/Elementor/WidgetCalendar.php:141
-#: src/Elementor/WidgetCheckout.php:105
-#: src/Elementor/WidgetExperiencePage.php:225
-#: src/Elementor/WidgetList.php:322
-#: src/Elementor/WidgetWidget.php:156
-msgid "Warning"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:998
-#: src/Elementor/WidgetCalendar.php:142
-#: src/Elementor/WidgetCheckout.php:106
-#: src/Elementor/WidgetExperiencePage.php:226
-#: src/Elementor/WidgetList.php:323
-#: src/Elementor/WidgetWidget.php:157
-msgid "Danger"
-msgstr ""
 
 #: src/Admin/SettingsPage.php:999
 #: src/Elementor/WidgetCalendar.php:158
 #: src/Elementor/WidgetCheckout.php:122
 #: src/Elementor/WidgetExperiencePage.php:242
 #: src/Elementor/WidgetList.php:339
-#: src/Elementor/WidgetWidget.php:173
-msgid "Border radius"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:1000
-#: src/Elementor/WidgetCalendar.php:167
-#: src/Elementor/WidgetCheckout.php:131
-#: src/Elementor/WidgetExperiencePage.php:251
-#: src/Elementor/WidgetList.php:348
-#: src/Elementor/WidgetWidget.php:182
-msgid "Shadow"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:1001
-msgid "Preferred font family"
-msgstr ""
-
 #: src/Admin/SettingsPage.php:1014
 #: src/Elementor/WidgetList.php:79
 msgid "Experiences per page"
@@ -2565,41 +2447,8 @@ msgstr ""
 msgid "Months to display"
 msgstr ""
 
-#: src/Elementor/WidgetCalendar.php:109
-#: src/Elementor/WidgetCheckout.php:73
-#: src/Elementor/WidgetExperiencePage.php:101
-#: src/Elementor/WidgetExperiencePage.php:138
-#: src/Elementor/WidgetExperiencePage.php:193
-#: src/Elementor/WidgetList.php:290
-#: src/Elementor/WidgetWidget.php:124
+#: src/Utils/Theme.php:37
 msgid "Default"
-msgstr ""
-
-#: src/Elementor/WidgetCalendar.php:111
-#: src/Elementor/WidgetCheckout.php:75
-#: src/Elementor/WidgetExperiencePage.php:195
-#: src/Elementor/WidgetList.php:292
-#: src/Elementor/WidgetWidget.php:126
-#: src/Utils/Theme.php:43
-msgid "Dark"
-msgstr ""
-
-#: src/Elementor/WidgetCalendar.php:112
-#: src/Elementor/WidgetCheckout.php:76
-#: src/Elementor/WidgetExperiencePage.php:196
-#: src/Elementor/WidgetList.php:293
-#: src/Elementor/WidgetWidget.php:127
-#: src/Utils/Theme.php:53
-msgid "Natural (green)"
-msgstr ""
-
-#: src/Elementor/WidgetCalendar.php:113
-#: src/Elementor/WidgetCheckout.php:77
-#: src/Elementor/WidgetExperiencePage.php:197
-#: src/Elementor/WidgetList.php:294
-#: src/Elementor/WidgetWidget.php:128
-#: src/Utils/Theme.php:62
-msgid "Wine / Burgundy"
 msgstr ""
 
 #: src/Elementor/WidgetCalendar.php:124

--- a/build/fp-experiences/src/Elementor/WidgetCalendar.php
+++ b/build/fp-experiences/src/Elementor/WidgetCalendar.php
@@ -6,6 +6,7 @@ namespace FP_Exp\Elementor;
 
 use Elementor\Controls_Manager;
 use Elementor\Widget_Base;
+use FP_Exp\Utils\Theme;
 
 use function do_shortcode;
 use function esc_attr;
@@ -101,81 +102,11 @@ final class WidgetCalendar extends Widget_Base
     private function add_theme_controls(): void
     {
         $this->add_control(
-            'preset',
+            'branding_notice',
             [
-                'label' => esc_html__('Preset', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    '' => esc_html__('Default', 'fp-experiences'),
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark', 'fp-experiences'),
-                    'natural' => esc_html__('Natural (green)', 'fp-experiences'),
-                    'wine' => esc_html__('Wine / Burgundy', 'fp-experiences'),
-                ],
-            ]
-        );
-
-        $this->add_control(
-            'mode',
-            [
-                'label' => esc_html__('Color mode', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    '' => esc_html__('Inherit', 'fp-experiences'),
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark (.fp-theme-dark)', 'fp-experiences'),
-                    'auto' => esc_html__('Automatic (prefers-color-scheme)', 'fp-experiences'),
-                ],
-            ]
-        );
-
-        $color_labels = [
-            'primary' => esc_html__('Primary', 'fp-experiences'),
-            'secondary' => esc_html__('Secondary', 'fp-experiences'),
-            'accent' => esc_html__('Accent', 'fp-experiences'),
-            'background' => esc_html__('Background', 'fp-experiences'),
-            'surface' => esc_html__('Surface', 'fp-experiences'),
-            'text' => esc_html__('Text', 'fp-experiences'),
-            'muted' => esc_html__('Muted', 'fp-experiences'),
-            'success' => esc_html__('Success', 'fp-experiences'),
-            'warning' => esc_html__('Warning', 'fp-experiences'),
-            'danger' => esc_html__('Danger', 'fp-experiences'),
-        ];
-
-        foreach ($color_labels as $key => $label) {
-            $this->add_control(
-                $key,
-                [
-                    'label' => $label,
-                    'type' => Controls_Manager::COLOR,
-                ]
-            );
-        }
-
-        $this->add_control(
-            'radius',
-            [
-                'label' => esc_html__('Border radius', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '12px',
-            ]
-        );
-
-        $this->add_control(
-            'shadow',
-            [
-                'label' => esc_html__('Shadow', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '0 10px 30px rgba(0,0,0,0.08)',
-            ]
-        );
-
-        $this->add_control(
-            'font',
-            [
-                'label' => esc_html__('Font family', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '"Red Hat Display", sans-serif',
+                'type' => Controls_Manager::RAW_HTML,
+                'raw' => esc_html__('Brand colors use the default FP Experiences palette.', 'fp-experiences'),
+                'content_classes' => 'elementor-panel-alert elementor-panel-alert-info',
             ]
         );
     }
@@ -187,16 +118,7 @@ final class WidgetCalendar extends Widget_Base
      */
     private function collect_theme_atts(array $settings): array
     {
-        $keys = ['preset', 'mode', 'primary', 'secondary', 'accent', 'background', 'surface', 'text', 'muted', 'success', 'warning', 'danger', 'radius', 'shadow', 'font'];
-        $atts = [];
-
-        foreach ($keys as $key) {
-            if (! empty($settings[$key])) {
-                $atts[$key] = (string) $settings[$key];
-            }
-        }
-
-        return $atts;
+        return ['preset' => Theme::default_preset()];
     }
 
     /**

--- a/build/fp-experiences/src/Elementor/WidgetCheckout.php
+++ b/build/fp-experiences/src/Elementor/WidgetCheckout.php
@@ -6,6 +6,7 @@ namespace FP_Exp\Elementor;
 
 use Elementor\Controls_Manager;
 use Elementor\Widget_Base;
+use FP_Exp\Utils\Theme;
 
 use function do_shortcode;
 use function esc_attr;
@@ -65,81 +66,11 @@ final class WidgetCheckout extends Widget_Base
     private function add_theme_controls(): void
     {
         $this->add_control(
-            'preset',
+            'branding_notice',
             [
-                'label' => esc_html__('Preset', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    '' => esc_html__('Default', 'fp-experiences'),
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark', 'fp-experiences'),
-                    'natural' => esc_html__('Natural (green)', 'fp-experiences'),
-                    'wine' => esc_html__('Wine / Burgundy', 'fp-experiences'),
-                ],
-            ]
-        );
-
-        $this->add_control(
-            'mode',
-            [
-                'label' => esc_html__('Color mode', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    '' => esc_html__('Inherit', 'fp-experiences'),
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark (.fp-theme-dark)', 'fp-experiences'),
-                    'auto' => esc_html__('Automatic (prefers-color-scheme)', 'fp-experiences'),
-                ],
-            ]
-        );
-
-        $color_labels = [
-            'primary' => esc_html__('Primary', 'fp-experiences'),
-            'secondary' => esc_html__('Secondary', 'fp-experiences'),
-            'accent' => esc_html__('Accent', 'fp-experiences'),
-            'background' => esc_html__('Background', 'fp-experiences'),
-            'surface' => esc_html__('Surface', 'fp-experiences'),
-            'text' => esc_html__('Text', 'fp-experiences'),
-            'muted' => esc_html__('Muted', 'fp-experiences'),
-            'success' => esc_html__('Success', 'fp-experiences'),
-            'warning' => esc_html__('Warning', 'fp-experiences'),
-            'danger' => esc_html__('Danger', 'fp-experiences'),
-        ];
-
-        foreach ($color_labels as $key => $label) {
-            $this->add_control(
-                $key,
-                [
-                    'label' => $label,
-                    'type' => Controls_Manager::COLOR,
-                ]
-            );
-        }
-
-        $this->add_control(
-            'radius',
-            [
-                'label' => esc_html__('Border radius', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '12px',
-            ]
-        );
-
-        $this->add_control(
-            'shadow',
-            [
-                'label' => esc_html__('Shadow', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '0 10px 30px rgba(0,0,0,0.08)',
-            ]
-        );
-
-        $this->add_control(
-            'font',
-            [
-                'label' => esc_html__('Font family', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '"Red Hat Display", sans-serif',
+                'type' => Controls_Manager::RAW_HTML,
+                'raw' => esc_html__('Brand colors use the default FP Experiences palette.', 'fp-experiences'),
+                'content_classes' => 'elementor-panel-alert elementor-panel-alert-info',
             ]
         );
     }
@@ -151,16 +82,7 @@ final class WidgetCheckout extends Widget_Base
      */
     private function collect_theme_atts(array $settings): array
     {
-        $keys = ['preset', 'mode', 'primary', 'secondary', 'accent', 'background', 'surface', 'text', 'muted', 'success', 'warning', 'danger', 'radius', 'shadow', 'font'];
-        $atts = [];
-
-        foreach ($keys as $key) {
-            if (! empty($settings[$key])) {
-                $atts[$key] = (string) $settings[$key];
-            }
-        }
-
-        return $atts;
+        return ['preset' => Theme::default_preset()];
     }
 
     /**

--- a/build/fp-experiences/src/Elementor/WidgetExperiencePage.php
+++ b/build/fp-experiences/src/Elementor/WidgetExperiencePage.php
@@ -6,6 +6,7 @@ namespace FP_Exp\Elementor;
 
 use Elementor\Controls_Manager;
 use Elementor\Widget_Base;
+use FP_Exp\Utils\Theme;
 
 use function array_filter;
 use function array_map;
@@ -185,81 +186,11 @@ final class WidgetExperiencePage extends Widget_Base
     private function add_theme_controls(): void
     {
         $this->add_control(
-            'preset',
+            'branding_notice',
             [
-                'label' => esc_html__('Preset', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    '' => esc_html__('Default', 'fp-experiences'),
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark', 'fp-experiences'),
-                    'natural' => esc_html__('Natural (green)', 'fp-experiences'),
-                    'wine' => esc_html__('Wine / Burgundy', 'fp-experiences'),
-                ],
-            ]
-        );
-
-        $this->add_control(
-            'mode',
-            [
-                'label' => esc_html__('Color mode', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    '' => esc_html__('Inherit', 'fp-experiences'),
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark (.fp-theme-dark)', 'fp-experiences'),
-                    'auto' => esc_html__('Automatic (prefers-color-scheme)', 'fp-experiences'),
-                ],
-            ]
-        );
-
-        $color_labels = [
-            'primary' => esc_html__('Primary', 'fp-experiences'),
-            'secondary' => esc_html__('Secondary', 'fp-experiences'),
-            'accent' => esc_html__('Accent', 'fp-experiences'),
-            'background' => esc_html__('Background', 'fp-experiences'),
-            'surface' => esc_html__('Surface', 'fp-experiences'),
-            'text' => esc_html__('Text', 'fp-experiences'),
-            'muted' => esc_html__('Muted', 'fp-experiences'),
-            'success' => esc_html__('Success', 'fp-experiences'),
-            'warning' => esc_html__('Warning', 'fp-experiences'),
-            'danger' => esc_html__('Danger', 'fp-experiences'),
-        ];
-
-        foreach ($color_labels as $key => $label) {
-            $this->add_control(
-                $key,
-                [
-                    'label' => $label,
-                    'type' => Controls_Manager::COLOR,
-                ]
-            );
-        }
-
-        $this->add_control(
-            'radius',
-            [
-                'label' => esc_html__('Border radius', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '16px',
-            ]
-        );
-
-        $this->add_control(
-            'shadow',
-            [
-                'label' => esc_html__('Shadow', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '0 14px 40px rgba(0,0,0,0.08)',
-            ]
-        );
-
-        $this->add_control(
-            'font',
-            [
-                'label' => esc_html__('Font family', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '"Red Hat Display", sans-serif',
+                'type' => Controls_Manager::RAW_HTML,
+                'raw' => esc_html__('Brand colors use the default FP Experiences palette.', 'fp-experiences'),
+                'content_classes' => 'elementor-panel-alert elementor-panel-alert-info',
             ]
         );
     }
@@ -271,16 +202,7 @@ final class WidgetExperiencePage extends Widget_Base
      */
     private function collect_theme_atts(array $settings): array
     {
-        $keys = ['preset', 'mode', 'primary', 'secondary', 'accent', 'background', 'surface', 'text', 'muted', 'success', 'warning', 'danger', 'radius', 'shadow', 'font'];
-        $atts = [];
-
-        foreach ($keys as $key) {
-            if (! empty($settings[$key])) {
-                $atts[$key] = (string) $settings[$key];
-            }
-        }
-
-        return $atts;
+        return ['preset' => Theme::default_preset()];
     }
 
     /**

--- a/build/fp-experiences/src/Elementor/WidgetList.php
+++ b/build/fp-experiences/src/Elementor/WidgetList.php
@@ -7,6 +7,7 @@ namespace FP_Exp\Elementor;
 use Elementor\Controls_Manager;
 use Elementor\Widget_Base;
 use FP_Exp\Utils\Helpers;
+use FP_Exp\Utils\Theme;
 
 use function absint;
 use function array_filter;
@@ -411,81 +412,11 @@ final class WidgetList extends Widget_Base
     private function add_theme_controls(): void
     {
         $this->add_control(
-            'preset',
+            'branding_notice',
             [
-                'label' => esc_html__('Preset', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    '' => esc_html__('Default', 'fp-experiences'),
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark', 'fp-experiences'),
-                    'natural' => esc_html__('Natural (green)', 'fp-experiences'),
-                    'wine' => esc_html__('Wine / Burgundy', 'fp-experiences'),
-                ],
-            ]
-        );
-
-        $this->add_control(
-            'mode',
-            [
-                'label' => esc_html__('Color mode', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    '' => esc_html__('Inherit', 'fp-experiences'),
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark (.fp-theme-dark)', 'fp-experiences'),
-                    'auto' => esc_html__('Automatic (prefers-color-scheme)', 'fp-experiences'),
-                ],
-            ]
-        );
-
-        $color_labels = [
-            'primary' => esc_html__('Primary', 'fp-experiences'),
-            'secondary' => esc_html__('Secondary', 'fp-experiences'),
-            'accent' => esc_html__('Accent', 'fp-experiences'),
-            'background' => esc_html__('Background', 'fp-experiences'),
-            'surface' => esc_html__('Surface', 'fp-experiences'),
-            'text' => esc_html__('Text', 'fp-experiences'),
-            'muted' => esc_html__('Muted', 'fp-experiences'),
-            'success' => esc_html__('Success', 'fp-experiences'),
-            'warning' => esc_html__('Warning', 'fp-experiences'),
-            'danger' => esc_html__('Danger', 'fp-experiences'),
-        ];
-
-        foreach ($color_labels as $key => $label) {
-            $this->add_control(
-                $key,
-                [
-                    'label' => $label,
-                    'type' => Controls_Manager::COLOR,
-                ]
-            );
-        }
-
-        $this->add_control(
-            'radius',
-            [
-                'label' => esc_html__('Border radius', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '12px',
-            ]
-        );
-
-        $this->add_control(
-            'shadow',
-            [
-                'label' => esc_html__('Shadow', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '0 10px 30px rgba(0,0,0,0.08)',
-            ]
-        );
-
-        $this->add_control(
-            'font',
-            [
-                'label' => esc_html__('Font family', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '"Red Hat Display", sans-serif',
+                'type' => Controls_Manager::RAW_HTML,
+                'raw' => esc_html__('Brand colors use the default FP Experiences palette.', 'fp-experiences'),
+                'content_classes' => 'elementor-panel-alert elementor-panel-alert-info',
             ]
         );
     }
@@ -497,16 +428,7 @@ final class WidgetList extends Widget_Base
      */
     private function collect_theme_atts(array $settings): array
     {
-        $keys = ['preset', 'mode', 'primary', 'secondary', 'accent', 'background', 'surface', 'text', 'muted', 'success', 'warning', 'danger', 'radius', 'shadow', 'font'];
-        $atts = [];
-
-        foreach ($keys as $key) {
-            if (! empty($settings[$key])) {
-                $atts[$key] = (string) $settings[$key];
-            }
-        }
-
-        return $atts;
+        return ['preset' => Theme::default_preset()];
     }
 
     /**

--- a/build/fp-experiences/src/Elementor/WidgetWidget.php
+++ b/build/fp-experiences/src/Elementor/WidgetWidget.php
@@ -6,6 +6,7 @@ namespace FP_Exp\Elementor;
 
 use Elementor\Controls_Manager;
 use Elementor\Widget_Base;
+use FP_Exp\Utils\Theme;
 
 use function do_shortcode;
 use function esc_attr;
@@ -116,81 +117,11 @@ final class WidgetWidget extends Widget_Base
     private function add_theme_controls(): void
     {
         $this->add_control(
-            'preset',
+            'branding_notice',
             [
-                'label' => esc_html__('Preset', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    '' => esc_html__('Default', 'fp-experiences'),
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark', 'fp-experiences'),
-                    'natural' => esc_html__('Natural (green)', 'fp-experiences'),
-                    'wine' => esc_html__('Wine / Burgundy', 'fp-experiences'),
-                ],
-            ]
-        );
-
-        $this->add_control(
-            'mode',
-            [
-                'label' => esc_html__('Color mode', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    '' => esc_html__('Inherit', 'fp-experiences'),
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark (.fp-theme-dark)', 'fp-experiences'),
-                    'auto' => esc_html__('Automatic (prefers-color-scheme)', 'fp-experiences'),
-                ],
-            ]
-        );
-
-        $color_labels = [
-            'primary' => esc_html__('Primary', 'fp-experiences'),
-            'secondary' => esc_html__('Secondary', 'fp-experiences'),
-            'accent' => esc_html__('Accent', 'fp-experiences'),
-            'background' => esc_html__('Background', 'fp-experiences'),
-            'surface' => esc_html__('Surface', 'fp-experiences'),
-            'text' => esc_html__('Text', 'fp-experiences'),
-            'muted' => esc_html__('Muted', 'fp-experiences'),
-            'success' => esc_html__('Success', 'fp-experiences'),
-            'warning' => esc_html__('Warning', 'fp-experiences'),
-            'danger' => esc_html__('Danger', 'fp-experiences'),
-        ];
-
-        foreach ($color_labels as $key => $label) {
-            $this->add_control(
-                $key,
-                [
-                    'label' => $label,
-                    'type' => Controls_Manager::COLOR,
-                ]
-            );
-        }
-
-        $this->add_control(
-            'radius',
-            [
-                'label' => esc_html__('Border radius', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '12px',
-            ]
-        );
-
-        $this->add_control(
-            'shadow',
-            [
-                'label' => esc_html__('Shadow', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '0 10px 30px rgba(0,0,0,0.08)',
-            ]
-        );
-
-        $this->add_control(
-            'font',
-            [
-                'label' => esc_html__('Font family', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '"Red Hat Display", sans-serif',
+                'type' => Controls_Manager::RAW_HTML,
+                'raw' => esc_html__('Brand colors use the default FP Experiences palette.', 'fp-experiences'),
+                'content_classes' => 'elementor-panel-alert elementor-panel-alert-info',
             ]
         );
     }
@@ -202,16 +133,7 @@ final class WidgetWidget extends Widget_Base
      */
     private function collect_theme_atts(array $settings): array
     {
-        $keys = ['preset', 'mode', 'primary', 'secondary', 'accent', 'background', 'surface', 'text', 'muted', 'success', 'warning', 'danger', 'radius', 'shadow', 'font'];
-        $atts = [];
-
-        foreach ($keys as $key) {
-            if (! empty($settings[$key])) {
-                $atts[$key] = (string) $settings[$key];
-            }
-        }
-
-        return $atts;
+        return ['preset' => Theme::default_preset()];
     }
 
     /**

--- a/languages/fp-experiences.pot
+++ b/languages/fp-experiences.pot
@@ -1612,12 +1612,8 @@ msgstr ""
 msgid "Clear caches"
 msgstr ""
 
-#: src/Admin/SettingsPage.php:881
-msgid "Tune the booking UI to match your visual identity. Choose a preset, then refine individual colors, borders, and fonts."
-msgstr ""
-
-#: src/Admin/SettingsPage.php:882
-msgid "Dark mode can be applied automatically or when wrapping the shortcode output with the .fp-theme-dark class."
+#: src/Admin/SettingsPage.php:1115
+msgid "FP Experiences now uses a single default color palette that keeps every experience readable and on brand."
 msgstr ""
 
 #: src/Admin/SettingsPage.php:887
@@ -1662,142 +1658,28 @@ msgstr ""
 msgid "Create an OAuth client in Google Cloud and add the redirect URI below. After saving credentials, connect the account to sync reservations."
 msgstr ""
 
-#: src/Admin/SettingsPage.php:966
-msgid "Custom"
+#: src/Admin/SettingsPage.php:1208
+msgid "Color palette"
 msgstr ""
 
-#: src/Admin/SettingsPage.php:975
-#: src/Elementor/WidgetCalendar.php:106
-#: src/Elementor/WidgetCheckout.php:70
-#: src/Elementor/WidgetExperiencePage.php:190
-#: src/Elementor/WidgetList.php:287
-#: src/Elementor/WidgetWidget.php:121
-msgid "Preset"
+#: src/Admin/SettingsPage.php:1210
+msgid "Brand colors use the default palette and cannot be customized."
 msgstr ""
 
-#: src/Admin/SettingsPage.php:977
-msgid "Start from a curated palette, then adjust specific values as needed."
+#: src/Elementor/WidgetCalendar.php:108
+#: src/Elementor/WidgetCheckout.php:72
+#: src/Elementor/WidgetExperiencePage.php:192
+#: src/Elementor/WidgetList.php:418
+#: src/Elementor/WidgetWidget.php:123
+msgid "Brand colors use the default FP Experiences palette."
 msgstr ""
 
-#: src/Admin/SettingsPage.php:982
-#: src/Elementor/WidgetCalendar.php:121
-#: src/Elementor/WidgetCheckout.php:85
-#: src/Elementor/WidgetExperiencePage.php:205
-#: src/Elementor/WidgetList.php:302
-#: src/Elementor/WidgetWidget.php:136
-msgid "Color mode"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:984
-#: src/Elementor/WidgetCalendar.php:110
-#: src/Elementor/WidgetCalendar.php:125
-#: src/Elementor/WidgetCheckout.php:74
-#: src/Elementor/WidgetCheckout.php:89
-#: src/Elementor/WidgetExperiencePage.php:194
-#: src/Elementor/WidgetExperiencePage.php:209
-#: src/Elementor/WidgetList.php:291
-#: src/Elementor/WidgetList.php:306
-#: src/Elementor/WidgetWidget.php:125
-#: src/Elementor/WidgetWidget.php:140
-#: src/Utils/Theme.php:39
-msgid "Light"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:985
-msgid "Dark (requires .fp-theme-dark wrapper)"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:986
-msgid "Automatic (prefers-color-scheme + .fp-theme-dark)"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:989
-msgid "Primary color"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:990
-msgid "Secondary color"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:991
-msgid "Accent color"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:992
-#: src/Elementor/WidgetCalendar.php:136
-#: src/Elementor/WidgetCheckout.php:100
-#: src/Elementor/WidgetExperiencePage.php:220
-#: src/Elementor/WidgetList.php:317
-#: src/Elementor/WidgetWidget.php:151
-msgid "Background"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:993
-#: src/Elementor/WidgetCalendar.php:137
-#: src/Elementor/WidgetCheckout.php:101
-#: src/Elementor/WidgetExperiencePage.php:221
-#: src/Elementor/WidgetList.php:318
-#: src/Elementor/WidgetWidget.php:152
-msgid "Surface"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:994
-msgid "Text color"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:995
-msgid "Muted text"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:996
-#: src/Elementor/WidgetCalendar.php:140
-#: src/Elementor/WidgetCheckout.php:104
-#: src/Elementor/WidgetExperiencePage.php:224
-#: src/Elementor/WidgetList.php:321
-#: src/Elementor/WidgetWidget.php:155
-msgid "Success"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:997
-#: src/Elementor/WidgetCalendar.php:141
-#: src/Elementor/WidgetCheckout.php:105
-#: src/Elementor/WidgetExperiencePage.php:225
-#: src/Elementor/WidgetList.php:322
-#: src/Elementor/WidgetWidget.php:156
-msgid "Warning"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:998
-#: src/Elementor/WidgetCalendar.php:142
-#: src/Elementor/WidgetCheckout.php:106
-#: src/Elementor/WidgetExperiencePage.php:226
-#: src/Elementor/WidgetList.php:323
-#: src/Elementor/WidgetWidget.php:157
-msgid "Danger"
-msgstr ""
 
 #: src/Admin/SettingsPage.php:999
 #: src/Elementor/WidgetCalendar.php:158
 #: src/Elementor/WidgetCheckout.php:122
 #: src/Elementor/WidgetExperiencePage.php:242
 #: src/Elementor/WidgetList.php:339
-#: src/Elementor/WidgetWidget.php:173
-msgid "Border radius"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:1000
-#: src/Elementor/WidgetCalendar.php:167
-#: src/Elementor/WidgetCheckout.php:131
-#: src/Elementor/WidgetExperiencePage.php:251
-#: src/Elementor/WidgetList.php:348
-#: src/Elementor/WidgetWidget.php:182
-msgid "Shadow"
-msgstr ""
-
-#: src/Admin/SettingsPage.php:1001
-msgid "Preferred font family"
-msgstr ""
-
 #: src/Admin/SettingsPage.php:1014
 #: src/Elementor/WidgetList.php:79
 msgid "Experiences per page"
@@ -2565,41 +2447,8 @@ msgstr ""
 msgid "Months to display"
 msgstr ""
 
-#: src/Elementor/WidgetCalendar.php:109
-#: src/Elementor/WidgetCheckout.php:73
-#: src/Elementor/WidgetExperiencePage.php:101
-#: src/Elementor/WidgetExperiencePage.php:138
-#: src/Elementor/WidgetExperiencePage.php:193
-#: src/Elementor/WidgetList.php:290
-#: src/Elementor/WidgetWidget.php:124
+#: src/Utils/Theme.php:37
 msgid "Default"
-msgstr ""
-
-#: src/Elementor/WidgetCalendar.php:111
-#: src/Elementor/WidgetCheckout.php:75
-#: src/Elementor/WidgetExperiencePage.php:195
-#: src/Elementor/WidgetList.php:292
-#: src/Elementor/WidgetWidget.php:126
-#: src/Utils/Theme.php:43
-msgid "Dark"
-msgstr ""
-
-#: src/Elementor/WidgetCalendar.php:112
-#: src/Elementor/WidgetCheckout.php:76
-#: src/Elementor/WidgetExperiencePage.php:196
-#: src/Elementor/WidgetList.php:293
-#: src/Elementor/WidgetWidget.php:127
-#: src/Utils/Theme.php:53
-msgid "Natural (green)"
-msgstr ""
-
-#: src/Elementor/WidgetCalendar.php:113
-#: src/Elementor/WidgetCheckout.php:77
-#: src/Elementor/WidgetExperiencePage.php:197
-#: src/Elementor/WidgetList.php:294
-#: src/Elementor/WidgetWidget.php:128
-#: src/Utils/Theme.php:62
-msgid "Wine / Burgundy"
 msgstr ""
 
 #: src/Elementor/WidgetCalendar.php:124

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -604,7 +604,7 @@ final class SettingsPage
         register_setting('fp_exp_settings_branding', 'fp_exp_branding', [
             'type' => 'array',
             'sanitize_callback' => [$this, 'sanitize_branding'],
-            'default' => [],
+            'default' => ['preset' => Theme::default_preset()],
         ]);
 
         add_settings_section(
@@ -1112,8 +1112,7 @@ final class SettingsPage
 
     public function render_branding_help(): void
     {
-        echo '<p>' . esc_html__('Tune the booking UI to match your visual identity. Choose a preset, then refine individual colors, borders, and fonts.', 'fp-experiences') . '</p>';
-        echo '<p>' . esc_html__('Dark mode can be applied automatically or when wrapping the shortcode output with the .fp-theme-dark class.', 'fp-experiences') . '</p>';
+        echo '<p>' . esc_html__('FP Experiences now uses a single default color palette that keeps every experience readable and on brand.', 'fp-experiences') . '</p>';
     }
 
     public function render_listing_help(): void
@@ -1196,43 +1195,13 @@ final class SettingsPage
      */
     private function get_branding_fields(): array
     {
-        $presets = Theme::presets();
-        $preset_options = ['' => esc_html__('Custom', 'fp-experiences')];
-        foreach ($presets as $key => $data) {
-            $preset_options[$key] = esc_html($data['label']);
-        }
-
         return [
             [
                 'key' => 'preset',
-                'type' => 'select',
-                'label' => esc_html__('Preset', 'fp-experiences'),
-                'options' => $preset_options,
-                'description' => esc_html__('Start from a curated palette, then adjust specific values as needed.', 'fp-experiences'),
+                'type' => 'fixed',
+                'label' => esc_html__('Color palette', 'fp-experiences'),
+                'description' => esc_html__('Brand colors use the default palette and cannot be customized.', 'fp-experiences'),
             ],
-            [
-                'key' => 'mode',
-                'type' => 'select',
-                'label' => esc_html__('Color mode', 'fp-experiences'),
-                'options' => [
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark (requires .fp-theme-dark wrapper)', 'fp-experiences'),
-                    'auto' => esc_html__('Automatic (prefers-color-scheme + .fp-theme-dark)', 'fp-experiences'),
-                ],
-            ],
-            ['key' => 'primary', 'label' => esc_html__('Primary color', 'fp-experiences'), 'type' => 'color'],
-            ['key' => 'secondary', 'label' => esc_html__('Secondary color', 'fp-experiences'), 'type' => 'color'],
-            ['key' => 'accent', 'label' => esc_html__('Accent color', 'fp-experiences'), 'type' => 'color'],
-            ['key' => 'background', 'label' => esc_html__('Background', 'fp-experiences'), 'type' => 'color'],
-            ['key' => 'surface', 'label' => esc_html__('Surface', 'fp-experiences'), 'type' => 'color'],
-            ['key' => 'text', 'label' => esc_html__('Text color', 'fp-experiences'), 'type' => 'color'],
-            ['key' => 'muted', 'label' => esc_html__('Muted text', 'fp-experiences'), 'type' => 'color'],
-            ['key' => 'success', 'label' => esc_html__('Success', 'fp-experiences'), 'type' => 'color'],
-            ['key' => 'warning', 'label' => esc_html__('Warning', 'fp-experiences'), 'type' => 'color'],
-            ['key' => 'danger', 'label' => esc_html__('Danger', 'fp-experiences'), 'type' => 'color'],
-            ['key' => 'radius', 'label' => esc_html__('Border radius', 'fp-experiences'), 'type' => 'text', 'placeholder' => '12px'],
-            ['key' => 'shadow', 'label' => esc_html__('Shadow', 'fp-experiences'), 'type' => 'text', 'placeholder' => '0 10px 30px rgba(0,0,0,0.08)'],
-            ['key' => 'font', 'label' => esc_html__('Preferred font family', 'fp-experiences'), 'type' => 'text', 'placeholder' => '"Red Hat Display", sans-serif'],
         ];
     }
 
@@ -1637,7 +1606,13 @@ final class SettingsPage
         $key = $field['key'];
         $value = $branding[$key] ?? '';
 
-        if ('select' === $field['type']) {
+        if ('preset' === $key) {
+            $value = Theme::default_preset();
+        }
+
+        if ('fixed' === ($field['type'] ?? '')) {
+            echo '<input type="hidden" name="fp_exp_branding[' . esc_attr($key) . ']" value="' . esc_attr((string) $value) . '" />';
+        } elseif ('select' === $field['type']) {
             echo '<select name="fp_exp_branding[' . esc_attr($key) . ']">';
             foreach ($field['options'] as $option_key => $label) {
                 $selected = ((string) $value === (string) $option_key) ? 'selected' : '';
@@ -1820,9 +1795,9 @@ final class SettingsPage
             'data-pass-message' => esc_attr__('Current palette passes AA contrast checks.', 'fp-experiences'),
             'data-warning-primary' => esc_attr__('Primary color contrast against the background is %s:1. Consider adjusting colors for AA compliance.', 'fp-experiences'),
             'data-warning-text' => esc_attr__('Body text contrast is %s:1. Increase contrast for readability.', 'fp-experiences'),
-            'data-default-primary' => esc_attr($palette['primary'] ?? '#8B1E3F'),
-            'data-default-background' => esc_attr($palette['background'] ?? '#FFFFFF'),
-            'data-default-text' => esc_attr($palette['text'] ?? '#1F1F1F'),
+            'data-default-primary' => esc_attr($palette['primary'] ?? '#0B6EFD'),
+            'data-default-background' => esc_attr($palette['background'] ?? '#F7F8FA'),
+            'data-default-text' => esc_attr($palette['text'] ?? '#0F172A'),
         ];
 
         echo '<div class="' . esc_attr(implode(' ', $classes)) . '"';
@@ -1974,30 +1949,8 @@ final class SettingsPage
 
         if (! empty($value['preset']) && isset($presets[$value['preset']])) {
             $sanitised['preset'] = sanitize_key((string) $value['preset']);
-        }
-
-        $mode = isset($value['mode']) ? sanitize_key((string) $value['mode']) : 'light';
-        if (! in_array($mode, ['light', 'dark', 'auto'], true)) {
-            $mode = 'light';
-        }
-        $sanitised['mode'] = $mode;
-
-        $color_keys = ['primary', 'secondary', 'accent', 'background', 'surface', 'text', 'muted', 'success', 'warning', 'danger'];
-
-        foreach ($color_keys as $key) {
-            if (empty($value[$key])) {
-                continue;
-            }
-            $color = sanitize_hex_color((string) $value[$key]);
-            if ($color) {
-                $sanitised[$key] = $color;
-            }
-        }
-
-        foreach (['radius', 'shadow', 'font'] as $key) {
-            if (isset($value[$key]) && '' !== $value[$key]) {
-                $sanitised[$key] = sanitize_text_field((string) $value[$key]);
-            }
+        } else {
+            $sanitised['preset'] = Theme::default_preset();
         }
 
         return $sanitised;

--- a/src/Elementor/WidgetCalendar.php
+++ b/src/Elementor/WidgetCalendar.php
@@ -6,6 +6,7 @@ namespace FP_Exp\Elementor;
 
 use Elementor\Controls_Manager;
 use Elementor\Widget_Base;
+use FP_Exp\Utils\Theme;
 
 use function do_shortcode;
 use function esc_attr;
@@ -101,81 +102,11 @@ final class WidgetCalendar extends Widget_Base
     private function add_theme_controls(): void
     {
         $this->add_control(
-            'preset',
+            'branding_notice',
             [
-                'label' => esc_html__('Preset', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    '' => esc_html__('Default', 'fp-experiences'),
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark', 'fp-experiences'),
-                    'natural' => esc_html__('Natural (green)', 'fp-experiences'),
-                    'wine' => esc_html__('Wine / Burgundy', 'fp-experiences'),
-                ],
-            ]
-        );
-
-        $this->add_control(
-            'mode',
-            [
-                'label' => esc_html__('Color mode', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    '' => esc_html__('Inherit', 'fp-experiences'),
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark (.fp-theme-dark)', 'fp-experiences'),
-                    'auto' => esc_html__('Automatic (prefers-color-scheme)', 'fp-experiences'),
-                ],
-            ]
-        );
-
-        $color_labels = [
-            'primary' => esc_html__('Primary', 'fp-experiences'),
-            'secondary' => esc_html__('Secondary', 'fp-experiences'),
-            'accent' => esc_html__('Accent', 'fp-experiences'),
-            'background' => esc_html__('Background', 'fp-experiences'),
-            'surface' => esc_html__('Surface', 'fp-experiences'),
-            'text' => esc_html__('Text', 'fp-experiences'),
-            'muted' => esc_html__('Muted', 'fp-experiences'),
-            'success' => esc_html__('Success', 'fp-experiences'),
-            'warning' => esc_html__('Warning', 'fp-experiences'),
-            'danger' => esc_html__('Danger', 'fp-experiences'),
-        ];
-
-        foreach ($color_labels as $key => $label) {
-            $this->add_control(
-                $key,
-                [
-                    'label' => $label,
-                    'type' => Controls_Manager::COLOR,
-                ]
-            );
-        }
-
-        $this->add_control(
-            'radius',
-            [
-                'label' => esc_html__('Border radius', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '12px',
-            ]
-        );
-
-        $this->add_control(
-            'shadow',
-            [
-                'label' => esc_html__('Shadow', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '0 10px 30px rgba(0,0,0,0.08)',
-            ]
-        );
-
-        $this->add_control(
-            'font',
-            [
-                'label' => esc_html__('Font family', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '"Red Hat Display", sans-serif',
+                'type' => Controls_Manager::RAW_HTML,
+                'raw' => esc_html__('Brand colors use the default FP Experiences palette.', 'fp-experiences'),
+                'content_classes' => 'elementor-panel-alert elementor-panel-alert-info',
             ]
         );
     }
@@ -187,16 +118,7 @@ final class WidgetCalendar extends Widget_Base
      */
     private function collect_theme_atts(array $settings): array
     {
-        $keys = ['preset', 'mode', 'primary', 'secondary', 'accent', 'background', 'surface', 'text', 'muted', 'success', 'warning', 'danger', 'radius', 'shadow', 'font'];
-        $atts = [];
-
-        foreach ($keys as $key) {
-            if (! empty($settings[$key])) {
-                $atts[$key] = (string) $settings[$key];
-            }
-        }
-
-        return $atts;
+        return ['preset' => Theme::default_preset()];
     }
 
     /**

--- a/src/Elementor/WidgetCheckout.php
+++ b/src/Elementor/WidgetCheckout.php
@@ -6,6 +6,7 @@ namespace FP_Exp\Elementor;
 
 use Elementor\Controls_Manager;
 use Elementor\Widget_Base;
+use FP_Exp\Utils\Theme;
 
 use function do_shortcode;
 use function esc_attr;
@@ -65,81 +66,11 @@ final class WidgetCheckout extends Widget_Base
     private function add_theme_controls(): void
     {
         $this->add_control(
-            'preset',
+            'branding_notice',
             [
-                'label' => esc_html__('Preset', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    '' => esc_html__('Default', 'fp-experiences'),
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark', 'fp-experiences'),
-                    'natural' => esc_html__('Natural (green)', 'fp-experiences'),
-                    'wine' => esc_html__('Wine / Burgundy', 'fp-experiences'),
-                ],
-            ]
-        );
-
-        $this->add_control(
-            'mode',
-            [
-                'label' => esc_html__('Color mode', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    '' => esc_html__('Inherit', 'fp-experiences'),
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark (.fp-theme-dark)', 'fp-experiences'),
-                    'auto' => esc_html__('Automatic (prefers-color-scheme)', 'fp-experiences'),
-                ],
-            ]
-        );
-
-        $color_labels = [
-            'primary' => esc_html__('Primary', 'fp-experiences'),
-            'secondary' => esc_html__('Secondary', 'fp-experiences'),
-            'accent' => esc_html__('Accent', 'fp-experiences'),
-            'background' => esc_html__('Background', 'fp-experiences'),
-            'surface' => esc_html__('Surface', 'fp-experiences'),
-            'text' => esc_html__('Text', 'fp-experiences'),
-            'muted' => esc_html__('Muted', 'fp-experiences'),
-            'success' => esc_html__('Success', 'fp-experiences'),
-            'warning' => esc_html__('Warning', 'fp-experiences'),
-            'danger' => esc_html__('Danger', 'fp-experiences'),
-        ];
-
-        foreach ($color_labels as $key => $label) {
-            $this->add_control(
-                $key,
-                [
-                    'label' => $label,
-                    'type' => Controls_Manager::COLOR,
-                ]
-            );
-        }
-
-        $this->add_control(
-            'radius',
-            [
-                'label' => esc_html__('Border radius', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '12px',
-            ]
-        );
-
-        $this->add_control(
-            'shadow',
-            [
-                'label' => esc_html__('Shadow', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '0 10px 30px rgba(0,0,0,0.08)',
-            ]
-        );
-
-        $this->add_control(
-            'font',
-            [
-                'label' => esc_html__('Font family', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '"Red Hat Display", sans-serif',
+                'type' => Controls_Manager::RAW_HTML,
+                'raw' => esc_html__('Brand colors use the default FP Experiences palette.', 'fp-experiences'),
+                'content_classes' => 'elementor-panel-alert elementor-panel-alert-info',
             ]
         );
     }
@@ -151,16 +82,7 @@ final class WidgetCheckout extends Widget_Base
      */
     private function collect_theme_atts(array $settings): array
     {
-        $keys = ['preset', 'mode', 'primary', 'secondary', 'accent', 'background', 'surface', 'text', 'muted', 'success', 'warning', 'danger', 'radius', 'shadow', 'font'];
-        $atts = [];
-
-        foreach ($keys as $key) {
-            if (! empty($settings[$key])) {
-                $atts[$key] = (string) $settings[$key];
-            }
-        }
-
-        return $atts;
+        return ['preset' => Theme::default_preset()];
     }
 
     /**

--- a/src/Elementor/WidgetExperiencePage.php
+++ b/src/Elementor/WidgetExperiencePage.php
@@ -6,6 +6,7 @@ namespace FP_Exp\Elementor;
 
 use Elementor\Controls_Manager;
 use Elementor\Widget_Base;
+use FP_Exp\Utils\Theme;
 
 use function array_filter;
 use function array_map;
@@ -185,81 +186,11 @@ final class WidgetExperiencePage extends Widget_Base
     private function add_theme_controls(): void
     {
         $this->add_control(
-            'preset',
+            'branding_notice',
             [
-                'label' => esc_html__('Preset', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    '' => esc_html__('Default', 'fp-experiences'),
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark', 'fp-experiences'),
-                    'natural' => esc_html__('Natural (green)', 'fp-experiences'),
-                    'wine' => esc_html__('Wine / Burgundy', 'fp-experiences'),
-                ],
-            ]
-        );
-
-        $this->add_control(
-            'mode',
-            [
-                'label' => esc_html__('Color mode', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    '' => esc_html__('Inherit', 'fp-experiences'),
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark (.fp-theme-dark)', 'fp-experiences'),
-                    'auto' => esc_html__('Automatic (prefers-color-scheme)', 'fp-experiences'),
-                ],
-            ]
-        );
-
-        $color_labels = [
-            'primary' => esc_html__('Primary', 'fp-experiences'),
-            'secondary' => esc_html__('Secondary', 'fp-experiences'),
-            'accent' => esc_html__('Accent', 'fp-experiences'),
-            'background' => esc_html__('Background', 'fp-experiences'),
-            'surface' => esc_html__('Surface', 'fp-experiences'),
-            'text' => esc_html__('Text', 'fp-experiences'),
-            'muted' => esc_html__('Muted', 'fp-experiences'),
-            'success' => esc_html__('Success', 'fp-experiences'),
-            'warning' => esc_html__('Warning', 'fp-experiences'),
-            'danger' => esc_html__('Danger', 'fp-experiences'),
-        ];
-
-        foreach ($color_labels as $key => $label) {
-            $this->add_control(
-                $key,
-                [
-                    'label' => $label,
-                    'type' => Controls_Manager::COLOR,
-                ]
-            );
-        }
-
-        $this->add_control(
-            'radius',
-            [
-                'label' => esc_html__('Border radius', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '16px',
-            ]
-        );
-
-        $this->add_control(
-            'shadow',
-            [
-                'label' => esc_html__('Shadow', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '0 14px 40px rgba(0,0,0,0.08)',
-            ]
-        );
-
-        $this->add_control(
-            'font',
-            [
-                'label' => esc_html__('Font family', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '"Red Hat Display", sans-serif',
+                'type' => Controls_Manager::RAW_HTML,
+                'raw' => esc_html__('Brand colors use the default FP Experiences palette.', 'fp-experiences'),
+                'content_classes' => 'elementor-panel-alert elementor-panel-alert-info',
             ]
         );
     }
@@ -271,16 +202,7 @@ final class WidgetExperiencePage extends Widget_Base
      */
     private function collect_theme_atts(array $settings): array
     {
-        $keys = ['preset', 'mode', 'primary', 'secondary', 'accent', 'background', 'surface', 'text', 'muted', 'success', 'warning', 'danger', 'radius', 'shadow', 'font'];
-        $atts = [];
-
-        foreach ($keys as $key) {
-            if (! empty($settings[$key])) {
-                $atts[$key] = (string) $settings[$key];
-            }
-        }
-
-        return $atts;
+        return ['preset' => Theme::default_preset()];
     }
 
     /**

--- a/src/Elementor/WidgetList.php
+++ b/src/Elementor/WidgetList.php
@@ -7,6 +7,7 @@ namespace FP_Exp\Elementor;
 use Elementor\Controls_Manager;
 use Elementor\Widget_Base;
 use FP_Exp\Utils\Helpers;
+use FP_Exp\Utils\Theme;
 
 use function absint;
 use function array_filter;
@@ -411,81 +412,11 @@ final class WidgetList extends Widget_Base
     private function add_theme_controls(): void
     {
         $this->add_control(
-            'preset',
+            'branding_notice',
             [
-                'label' => esc_html__('Preset', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    '' => esc_html__('Default', 'fp-experiences'),
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark', 'fp-experiences'),
-                    'natural' => esc_html__('Natural (green)', 'fp-experiences'),
-                    'wine' => esc_html__('Wine / Burgundy', 'fp-experiences'),
-                ],
-            ]
-        );
-
-        $this->add_control(
-            'mode',
-            [
-                'label' => esc_html__('Color mode', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    '' => esc_html__('Inherit', 'fp-experiences'),
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark (.fp-theme-dark)', 'fp-experiences'),
-                    'auto' => esc_html__('Automatic (prefers-color-scheme)', 'fp-experiences'),
-                ],
-            ]
-        );
-
-        $color_labels = [
-            'primary' => esc_html__('Primary', 'fp-experiences'),
-            'secondary' => esc_html__('Secondary', 'fp-experiences'),
-            'accent' => esc_html__('Accent', 'fp-experiences'),
-            'background' => esc_html__('Background', 'fp-experiences'),
-            'surface' => esc_html__('Surface', 'fp-experiences'),
-            'text' => esc_html__('Text', 'fp-experiences'),
-            'muted' => esc_html__('Muted', 'fp-experiences'),
-            'success' => esc_html__('Success', 'fp-experiences'),
-            'warning' => esc_html__('Warning', 'fp-experiences'),
-            'danger' => esc_html__('Danger', 'fp-experiences'),
-        ];
-
-        foreach ($color_labels as $key => $label) {
-            $this->add_control(
-                $key,
-                [
-                    'label' => $label,
-                    'type' => Controls_Manager::COLOR,
-                ]
-            );
-        }
-
-        $this->add_control(
-            'radius',
-            [
-                'label' => esc_html__('Border radius', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '12px',
-            ]
-        );
-
-        $this->add_control(
-            'shadow',
-            [
-                'label' => esc_html__('Shadow', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '0 10px 30px rgba(0,0,0,0.08)',
-            ]
-        );
-
-        $this->add_control(
-            'font',
-            [
-                'label' => esc_html__('Font family', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '"Red Hat Display", sans-serif',
+                'type' => Controls_Manager::RAW_HTML,
+                'raw' => esc_html__('Brand colors use the default FP Experiences palette.', 'fp-experiences'),
+                'content_classes' => 'elementor-panel-alert elementor-panel-alert-info',
             ]
         );
     }
@@ -497,16 +428,7 @@ final class WidgetList extends Widget_Base
      */
     private function collect_theme_atts(array $settings): array
     {
-        $keys = ['preset', 'mode', 'primary', 'secondary', 'accent', 'background', 'surface', 'text', 'muted', 'success', 'warning', 'danger', 'radius', 'shadow', 'font'];
-        $atts = [];
-
-        foreach ($keys as $key) {
-            if (! empty($settings[$key])) {
-                $atts[$key] = (string) $settings[$key];
-            }
-        }
-
-        return $atts;
+        return ['preset' => Theme::default_preset()];
     }
 
     /**

--- a/src/Elementor/WidgetWidget.php
+++ b/src/Elementor/WidgetWidget.php
@@ -6,6 +6,7 @@ namespace FP_Exp\Elementor;
 
 use Elementor\Controls_Manager;
 use Elementor\Widget_Base;
+use FP_Exp\Utils\Theme;
 
 use function do_shortcode;
 use function esc_attr;
@@ -116,81 +117,11 @@ final class WidgetWidget extends Widget_Base
     private function add_theme_controls(): void
     {
         $this->add_control(
-            'preset',
+            'branding_notice',
             [
-                'label' => esc_html__('Preset', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    '' => esc_html__('Default', 'fp-experiences'),
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark', 'fp-experiences'),
-                    'natural' => esc_html__('Natural (green)', 'fp-experiences'),
-                    'wine' => esc_html__('Wine / Burgundy', 'fp-experiences'),
-                ],
-            ]
-        );
-
-        $this->add_control(
-            'mode',
-            [
-                'label' => esc_html__('Color mode', 'fp-experiences'),
-                'type' => Controls_Manager::SELECT,
-                'options' => [
-                    '' => esc_html__('Inherit', 'fp-experiences'),
-                    'light' => esc_html__('Light', 'fp-experiences'),
-                    'dark' => esc_html__('Dark (.fp-theme-dark)', 'fp-experiences'),
-                    'auto' => esc_html__('Automatic (prefers-color-scheme)', 'fp-experiences'),
-                ],
-            ]
-        );
-
-        $color_labels = [
-            'primary' => esc_html__('Primary', 'fp-experiences'),
-            'secondary' => esc_html__('Secondary', 'fp-experiences'),
-            'accent' => esc_html__('Accent', 'fp-experiences'),
-            'background' => esc_html__('Background', 'fp-experiences'),
-            'surface' => esc_html__('Surface', 'fp-experiences'),
-            'text' => esc_html__('Text', 'fp-experiences'),
-            'muted' => esc_html__('Muted', 'fp-experiences'),
-            'success' => esc_html__('Success', 'fp-experiences'),
-            'warning' => esc_html__('Warning', 'fp-experiences'),
-            'danger' => esc_html__('Danger', 'fp-experiences'),
-        ];
-
-        foreach ($color_labels as $key => $label) {
-            $this->add_control(
-                $key,
-                [
-                    'label' => $label,
-                    'type' => Controls_Manager::COLOR,
-                ]
-            );
-        }
-
-        $this->add_control(
-            'radius',
-            [
-                'label' => esc_html__('Border radius', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '12px',
-            ]
-        );
-
-        $this->add_control(
-            'shadow',
-            [
-                'label' => esc_html__('Shadow', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '0 10px 30px rgba(0,0,0,0.08)',
-            ]
-        );
-
-        $this->add_control(
-            'font',
-            [
-                'label' => esc_html__('Font family', 'fp-experiences'),
-                'type' => Controls_Manager::TEXT,
-                'placeholder' => '"Red Hat Display", sans-serif',
+                'type' => Controls_Manager::RAW_HTML,
+                'raw' => esc_html__('Brand colors use the default FP Experiences palette.', 'fp-experiences'),
+                'content_classes' => 'elementor-panel-alert elementor-panel-alert-info',
             ]
         );
     }
@@ -202,16 +133,7 @@ final class WidgetWidget extends Widget_Base
      */
     private function collect_theme_atts(array $settings): array
     {
-        $keys = ['preset', 'mode', 'primary', 'secondary', 'accent', 'background', 'surface', 'text', 'muted', 'success', 'warning', 'danger', 'radius', 'shadow', 'font'];
-        $atts = [];
-
-        foreach ($keys as $key) {
-            if (! empty($settings[$key])) {
-                $atts[$key] = (string) $settings[$key];
-            }
-        }
-
-        return $atts;
+        return ['preset' => Theme::default_preset()];
     }
 
     /**


### PR DESCRIPTION
## Summary
- revert the theme presets to a single default option and keep the palette locked to the light mode values
- update the branding settings UI to persist the fixed preset and refresh Elementor notices to mention the default palette
- regenerate the translation template to drop obsolete color strings and capture the new branding copy

## Testing
- php -l src/Utils/Theme.php
- php -l build/fp-experiences/src/Utils/Theme.php
- php -l src/Admin/SettingsPage.php
- php -l build/fp-experiences/src/Admin/SettingsPage.php
- for file in src/Elementor/WidgetCalendar.php src/Elementor/WidgetCheckout.php src/Elementor/WidgetExperiencePage.php src/Elementor/WidgetList.php src/Elementor/WidgetWidget.php; do php -l $file || exit 1; done
- for file in build/fp-experiences/src/Elementor/WidgetCalendar.php build/fp-experiences/src/Elementor/WidgetCheckout.php build/fp-experiences/src/Elementor/WidgetExperiencePage.php build/fp-experiences/src/Elementor/WidgetList.php build/fp-experiences/src/Elementor/WidgetWidget.php; do php -l $file || exit 1; done

------
https://chatgpt.com/codex/tasks/task_e_68de3e58c064832fb07665bd828da910