### PR TITLE
Add trust badge search UX and metadata keywords

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -450,14 +450,123 @@
 
 .fp-exp-checkbox-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: 8px;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 10px;
 }
+
+.fp-exp-checkbox-grid__search {
+    margin-bottom: 12px;
+}
+
+.fp-exp-checkbox-grid__search-input {
+    width: 100%;
+    max-width: 420px;
+    padding: 6px 10px;
+    border: 1px solid #c3c4c7;
+    border-radius: 6px;
+    font-size: 13px;
+    line-height: 1.4;
+    background-color: #fff;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
 
 .fp-exp-checkbox-grid label {
     display: inline-flex;
+    align-items: stretch;
+    gap: 10px;
+}
+
+.fp-exp-checkbox-grid__item {
+    align-items: stretch;
+}
+
+.fp-exp-checkbox-grid__item.is-disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.fp-exp-checkbox-grid__item.is-disabled input[type="checkbox"] {
+    cursor: not-allowed;
+}
+
+.fp-exp-checkbox-grid__content {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 10px;
+    align-items: flex-start;
+}
+
+.fp-exp-checkbox-grid__icon {
+    display: inline-flex;
+    width: 32px;
+    height: 32px;
+    border-radius: 10px;
     align-items: center;
-    gap: 6px;
+    justify-content: center;
+    background: rgba(15, 23, 42, 0.06);
+    color: var(--fp-exp-color-primary, #8b1e3f);
+}
+
+.fp-exp-checkbox-grid__icon svg {
+    width: 18px;
+    height: 18px;
+}
+
+.fp-exp-checkbox-grid__body {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    align-items: flex-start;
+}
+
+.fp-exp-checkbox-grid__title {
+    font-weight: 600;
+    line-height: 1.2;
+}
+
+.fp-exp-checkbox-grid__tagline {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--fp-exp-color-primary, #8b1e3f);
+    line-height: 1.25;
+}
+
+.fp-exp-checkbox-grid__description {
+    font-size: 11px;
+    line-height: 1.35;
+    color: var(--fp-exp-color-muted, #666);
+    max-width: 220px;
+}
+
+.fp-exp-checkbox-grid__item[hidden] {
+    display: none !important;
+}
+
+.fp-exp-checkbox-grid.is-empty {
+    opacity: 0.5;
+}
+
+.fp-exp-field__description--muted {
+    color: #50575e;
+}
+
+[data-fp-cognitive-bias-empty] {
+    margin-top: 8px;
+    font-size: 12px;
+}
+
+.fp-exp-checkbox-grid.is-max {
+    outline: 2px solid rgba(139, 30, 63, 0.3);
+    border-radius: 12px;
+    padding: 6px;
+}
+
+.fp-exp-field__description--status {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--fp-exp-color-primary, #8b1e3f);
+    margin-top: 6px;
 }
 
 .fp-exp-tab-panel input[type="text"],

--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -2097,18 +2097,65 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.4rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
 }
+
 
 .fp-exp-overview__chip {
     display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.35rem 0.65rem;
-    border-radius: 999px;
+    align-items: flex-start;
+    gap: 0.6rem;
+    padding: 0.65rem 0.85rem;
+    border-radius: 16px;
     background: rgba(15, 23, 42, 0.08);
     color: var(--fp-color-text);
-    font-weight: 600;
+    min-width: 200px;
+    max-width: 280px;
+}
+
+.fp-exp-overview__chip-icon {
+    display: inline-flex;
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    background: rgba(139, 30, 63, 0.12);
+    color: var(--fp-color-primary);
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.fp-exp-overview__chip-icon svg {
+    width: 20px;
+    height: 20px;
+}
+
+.fp-exp-overview__chip-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    align-items: flex-start;
+}
+
+.fp-exp-overview__chip-label {
+    font-weight: 700;
     font-size: 0.85rem;
+    line-height: 1.2;
+}
+
+.fp-exp-overview__chip-tagline {
+    font-size: 0.8rem;
+    line-height: 1.2;
+    font-weight: 600;
+    color: var(--fp-color-primary);
+}
+
+.fp-exp-overview__chip-description {
+    font-size: 0.75rem;
+    line-height: 1.35;
+    color: rgba(15, 23, 42, 0.75);
 }
 
 .fp-exp-overview__languages {

--- a/build/fp-experiences/assets/css/admin.css
+++ b/build/fp-experiences/assets/css/admin.css
@@ -450,14 +450,123 @@
 
 .fp-exp-checkbox-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: 8px;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 10px;
 }
+
+.fp-exp-checkbox-grid__search {
+    margin-bottom: 12px;
+}
+
+.fp-exp-checkbox-grid__search-input {
+    width: 100%;
+    max-width: 420px;
+    padding: 6px 10px;
+    border: 1px solid #c3c4c7;
+    border-radius: 6px;
+    font-size: 13px;
+    line-height: 1.4;
+    background-color: #fff;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
 
 .fp-exp-checkbox-grid label {
     display: inline-flex;
+    align-items: stretch;
+    gap: 10px;
+}
+
+.fp-exp-checkbox-grid__item {
+    align-items: stretch;
+}
+
+.fp-exp-checkbox-grid__item.is-disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.fp-exp-checkbox-grid__item.is-disabled input[type="checkbox"] {
+    cursor: not-allowed;
+}
+
+.fp-exp-checkbox-grid__content {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 10px;
+    align-items: flex-start;
+}
+
+.fp-exp-checkbox-grid__icon {
+    display: inline-flex;
+    width: 32px;
+    height: 32px;
+    border-radius: 10px;
     align-items: center;
-    gap: 6px;
+    justify-content: center;
+    background: rgba(15, 23, 42, 0.06);
+    color: var(--fp-exp-color-primary, #8b1e3f);
+}
+
+.fp-exp-checkbox-grid__icon svg {
+    width: 18px;
+    height: 18px;
+}
+
+.fp-exp-checkbox-grid__body {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    align-items: flex-start;
+}
+
+.fp-exp-checkbox-grid__title {
+    font-weight: 600;
+    line-height: 1.2;
+}
+
+.fp-exp-checkbox-grid__tagline {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--fp-exp-color-primary, #8b1e3f);
+    line-height: 1.25;
+}
+
+.fp-exp-checkbox-grid__description {
+    font-size: 11px;
+    line-height: 1.35;
+    color: var(--fp-exp-color-muted, #666);
+    max-width: 220px;
+}
+
+.fp-exp-checkbox-grid__item[hidden] {
+    display: none !important;
+}
+
+.fp-exp-checkbox-grid.is-empty {
+    opacity: 0.5;
+}
+
+.fp-exp-field__description--muted {
+    color: #50575e;
+}
+
+[data-fp-cognitive-bias-empty] {
+    margin-top: 8px;
+    font-size: 12px;
+}
+
+.fp-exp-checkbox-grid.is-max {
+    outline: 2px solid rgba(139, 30, 63, 0.3);
+    border-radius: 12px;
+    padding: 6px;
+}
+
+.fp-exp-field__description--status {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--fp-exp-color-primary, #8b1e3f);
+    margin-top: 6px;
 }
 
 .fp-exp-tab-panel input[type="text"],

--- a/build/fp-experiences/assets/css/front.css
+++ b/build/fp-experiences/assets/css/front.css
@@ -2097,18 +2097,65 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.4rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
 }
+
 
 .fp-exp-overview__chip {
     display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.35rem 0.65rem;
-    border-radius: 999px;
+    align-items: flex-start;
+    gap: 0.6rem;
+    padding: 0.65rem 0.85rem;
+    border-radius: 16px;
     background: rgba(15, 23, 42, 0.08);
     color: var(--fp-color-text);
-    font-weight: 600;
+    min-width: 200px;
+    max-width: 280px;
+}
+
+.fp-exp-overview__chip-icon {
+    display: inline-flex;
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    background: rgba(139, 30, 63, 0.12);
+    color: var(--fp-color-primary);
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.fp-exp-overview__chip-icon svg {
+    width: 20px;
+    height: 20px;
+}
+
+.fp-exp-overview__chip-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    align-items: flex-start;
+}
+
+.fp-exp-overview__chip-label {
+    font-weight: 700;
     font-size: 0.85rem;
+    line-height: 1.2;
+}
+
+.fp-exp-overview__chip-tagline {
+    font-size: 0.8rem;
+    line-height: 1.2;
+    font-weight: 600;
+    color: var(--fp-color-primary);
+}
+
+.fp-exp-overview__chip-description {
+    font-size: 0.75rem;
+    line-height: 1.35;
+    color: rgba(15, 23, 42, 0.75);
 }
 
 .fp-exp-overview__languages {

--- a/build/fp-experiences/assets/js/admin.js
+++ b/build/fp-experiences/assets/js/admin.js
@@ -482,6 +482,150 @@
         });
     }
 
+    function initCognitiveBiasLimiter(root) {
+        const grids = Array.from(root.querySelectorAll('[data-fp-cognitive-bias]'));
+        if (!grids.length) {
+            return;
+        }
+
+        grids.forEach((grid) => {
+            if (!(grid instanceof HTMLElement)) {
+                return;
+            }
+
+            if (grid.dataset.fpCognitiveBiasInit === '1') {
+                return;
+            }
+
+            const max = parseInt(grid.dataset.max || '0', 10) || 0;
+            if (max <= 0) {
+                return;
+            }
+
+            const field = grid.closest('.fp-exp-field') || root;
+            const status = field ? field.querySelector('[data-fp-cognitive-bias-status]') : null;
+            const searchInput = field ? field.querySelector('[data-fp-cognitive-bias-search]') : null;
+            const emptyState = field ? field.querySelector('[data-fp-cognitive-bias-empty]') : null;
+            const template = status && status.dataset.template
+                ? status.dataset.template
+                : getString('trustBadgesStatus');
+            const maxMessage = status && status.dataset.maxMessage
+                ? status.dataset.maxMessage
+                : getString('trustBadgesMax');
+
+            const checkboxes = Array.from(grid.querySelectorAll('input[type="checkbox"]'));
+            if (!checkboxes.length) {
+                return;
+            }
+
+            const items = checkboxes
+                .map((checkbox) => checkbox.closest('.fp-exp-checkbox-grid__item'))
+                .filter((item) => item instanceof HTMLElement);
+
+            grid.dataset.fpCognitiveBiasInit = '1';
+
+            function renderStatus(count) {
+                if (!status) {
+                    return;
+                }
+
+                let message = template || '';
+                if (message.includes('%1$s')) {
+                    message = message.replace('%1$s', String(count));
+                }
+                if (message.includes('%2$s')) {
+                    message = message.replace('%2$s', String(max));
+                }
+
+                if (!template) {
+                    message = `${count}/${max}`;
+                }
+
+                if (count >= max && maxMessage) {
+                    message = message ? `${message} ${maxMessage}` : maxMessage;
+                }
+
+                status.textContent = message;
+            }
+
+            function updateState() {
+                const selected = checkboxes.filter((checkbox) => checkbox.checked);
+                const count = selected.length;
+                const reached = count >= max;
+
+                checkboxes.forEach((checkbox) => {
+                    const shouldDisable = reached && !checkbox.checked;
+                    checkbox.disabled = shouldDisable;
+                    if (shouldDisable) {
+                        checkbox.setAttribute('aria-disabled', 'true');
+                    } else {
+                        checkbox.removeAttribute('aria-disabled');
+                    }
+
+                    const label = checkbox.closest('label');
+                    if (label) {
+                        label.classList.toggle('is-disabled', shouldDisable);
+                    }
+                });
+
+                grid.classList.toggle('is-max', reached);
+                grid.setAttribute('data-selected-count', String(count));
+                renderStatus(count);
+            }
+
+            function applySearch(rawTerm) {
+                const term = typeof rawTerm === 'string' ? rawTerm.trim().toLowerCase() : '';
+                let visibleCount = 0;
+
+                items.forEach((item) => {
+                    if (!(item instanceof HTMLElement)) {
+                        return;
+                    }
+
+                    const haystack = item.dataset.search || '';
+                    const matches = !term || haystack.includes(term);
+                    item.hidden = !matches;
+
+                    if (matches) {
+                        visibleCount += 1;
+                    }
+                });
+
+                grid.classList.toggle('is-filtered', term.length > 0);
+                grid.classList.toggle('is-empty', visibleCount === 0);
+                grid.setAttribute('data-visible-count', String(visibleCount));
+
+                if (emptyState) {
+                    emptyState.hidden = visibleCount !== 0;
+                }
+            }
+
+            checkboxes.forEach((checkbox) => {
+                checkbox.addEventListener('change', updateState);
+            });
+
+            if (searchInput instanceof HTMLInputElement) {
+                const handleSearch = () => {
+                    applySearch(searchInput.value || '');
+                    updateState();
+                };
+
+                searchInput.addEventListener('input', handleSearch);
+                searchInput.addEventListener('search', handleSearch);
+
+                if (searchInput.value) {
+                    applySearch(searchInput.value);
+                } else {
+                    applySearch('');
+                }
+            } else {
+                applySearch('');
+            }
+
+            updateState();
+        });
+    }
+
     function initRecurrence(root) {
         const toggle = root.querySelector('[data-recurrence-toggle]');
         const settings = root.querySelector('[data-recurrence-settings]');
@@ -768,10 +912,6 @@
                 } catch (error) {
                     setStatus(getString('recurrenceGenerateError') || '', true);
                 }
-            });
-        }
-    }
-
             });
         }
     }
@@ -1292,6 +1432,7 @@
             initMediaControls(root);
             initRecurrence(root);
             initFormValidation(root);
+            initCognitiveBiasLimiter(root);
         }
 
         initCalendarApp();

--- a/build/fp-experiences/src/Shortcodes/ExperienceShortcode.php
+++ b/build/fp-experiences/src/Shortcodes/ExperienceShortcode.php
@@ -251,7 +251,7 @@ final class ExperienceShortcode extends BaseShortcode
         $cognitive_bias_slugs = is_array($cognitive_bias_meta)
             ? array_values(array_filter(array_map('sanitize_key', $cognitive_bias_meta)))
             : [];
-        $cognitive_bias_labels = Helpers::cognitive_bias_labels($cognitive_bias_slugs);
+        $cognitive_bias_badges = Helpers::cognitive_bias_badges($cognitive_bias_slugs);
 
         $badges = $this->build_badges($duration_minutes, $language_badges, $family_friendly);
 
@@ -286,7 +286,7 @@ final class ExperienceShortcode extends BaseShortcode
                 'summary' => $meeting_summary,
             ],
             'family_friendly' => $family_friendly,
-            'cognitive_biases' => $cognitive_bias_labels,
+            'cognitive_biases' => $cognitive_bias_badges,
         ];
 
         $overview_has_content = $this->overview_has_content($overview);

--- a/build/fp-experiences/src/Utils/Helpers.php
+++ b/build/fp-experiences/src/Utils/Helpers.php
@@ -30,7 +30,6 @@ use function is_bool;
 use function is_numeric;
 use function is_readable;
 use function is_string;
-use function is_user_logged_in;
 use function json_decode;
 use function ltrim;
 use function preg_split;
@@ -57,6 +56,40 @@ final class Helpers
      * @var array<string, string>
      */
     private static array $asset_version_cache = [];
+
+    /**
+     * @var array<int, array{id: string, label: string, description: string, tagline: string, icon: string, priority: int, keywords: array<int, string>}>|null
+     */
+    private static ?array $cognitive_bias_choices_cache = null;
+
+    /**
+     * @var array<string, array{id: string, label: string, description: string, tagline: string, icon: string, priority: int, keywords: array<int, string>}>|null
+     */
+    private static ?array $cognitive_bias_choices_index = null;
+
+    /**
+     * @var array<string, string>|null
+     */
+    private static ?array $cognitive_bias_icon_cache = null;
+
+    public const COGNITIVE_BIAS_MAX_SELECTION = 3;
+
+    public static function cognitive_bias_max_selection(): int
+    {
+        $max = apply_filters('fp_exp_cognitive_bias_max_selection', self::COGNITIVE_BIAS_MAX_SELECTION);
+
+        if (! is_numeric($max)) {
+            $max = self::COGNITIVE_BIAS_MAX_SELECTION;
+        }
+
+        $max = (int) $max;
+
+        if ($max <= 0) {
+            $max = self::COGNITIVE_BIAS_MAX_SELECTION;
+        }
+
+        return $max;
+    }
 
     public static function can_manage_fp(): bool
     {
@@ -406,30 +439,209 @@ final class Helpers
     }
 
     /**
-     * @return array<int, array{id: string, label: string}>
+     * @return array<int, array{id: string, label: string, description: string, tagline: string, icon: string, priority: int, keywords: array<int, string>}>
      */
     public static function cognitive_bias_choices(): array
     {
-        $biases = [
-            'anchoring' => __('Bias di ancoraggio', 'fp-experiences'),
-            'authority' => __('Principio di autorità', 'fp-experiences'),
-            'scarcity' => __('Bias di scarsità', 'fp-experiences'),
-            'social-proof' => __('Riprova sociale', 'fp-experiences'),
-            'loss-aversion' => __('Avversione alla perdita', 'fp-experiences'),
-            'commitment' => __('Impegno e coerenza', 'fp-experiences'),
-            'reciprocity' => __('Reciprocità', 'fp-experiences'),
-            'framing' => __('Effetto framing', 'fp-experiences'),
+        if (null !== self::$cognitive_bias_choices_cache) {
+            return self::$cognitive_bias_choices_cache;
+        }
+
+        $icon_registry = self::cognitive_bias_icons();
+
+        $defaults = [
+            [
+                'id' => 'safe-booking',
+                'label' => __('Prenotazione sicura', 'fp-experiences'),
+                'description' => __('Pagamenti crittografati e protezione antifrode per ogni transazione.', 'fp-experiences'),
+                'tagline' => __('Transazioni protette', 'fp-experiences'),
+                'icon' => 'shield',
+                'priority' => 10,
+                'keywords' => [
+                    __('sicurezza', 'fp-experiences'),
+                    __('pagamento sicuro', 'fp-experiences'),
+                    __('antifrode', 'fp-experiences'),
+                ],
+            ],
+            [
+                'id' => 'protected-checkout',
+                'label' => __('Checkout protetto', 'fp-experiences'),
+                'description' => __('Carte e wallet digitali approvati con conferma in tempo reale.', 'fp-experiences'),
+                'tagline' => __('Paghi come preferisci', 'fp-experiences'),
+                'icon' => 'lock',
+                'priority' => 20,
+                'keywords' => [
+                    __('checkout', 'fp-experiences'),
+                    __('pagamenti digitali', 'fp-experiences'),
+                    __('wallet', 'fp-experiences'),
+                ],
+            ],
+            [
+                'id' => 'flexible-cancellation',
+                'label' => __('Cancellazione flessibile', 'fp-experiences'),
+                'description' => __('Puoi modificare o annullare entro i termini indicati senza penali.', 'fp-experiences'),
+                'tagline' => __('Piani che cambiano? Nessun problema', 'fp-experiences'),
+                'icon' => 'calendar',
+                'priority' => 30,
+                'keywords' => [
+                    __('cambio data', 'fp-experiences'),
+                    __('rimborso', 'fp-experiences'),
+                    __('politica flessibile', 'fp-experiences'),
+                ],
+            ],
+            [
+                'id' => 'instant-confirmation',
+                'label' => __('Conferma immediata', 'fp-experiences'),
+                'description' => __('Ricevi subito biglietti e dettagli via e-mail e nell’area riservata.', 'fp-experiences'),
+                'tagline' => __('Ricevi tutto in pochi secondi', 'fp-experiences'),
+                'icon' => 'bolt',
+                'priority' => 40,
+                'keywords' => [
+                    __('e-ticket', 'fp-experiences'),
+                    __('conferma istantanea', 'fp-experiences'),
+                    __('email immediata', 'fp-experiences'),
+                ],
+            ],
+            [
+                'id' => 'best-price',
+                'label' => __('Miglior prezzo garantito', 'fp-experiences'),
+                'description' => __('Se trovi un prezzo più basso ti rimborsiamo la differenza.', 'fp-experiences'),
+                'tagline' => __('Zero sorprese sul prezzo', 'fp-experiences'),
+                'icon' => 'badge',
+                'priority' => 50,
+                'keywords' => [
+                    __('garanzia prezzo', 'fp-experiences'),
+                    __('risparmio', 'fp-experiences'),
+                    __('rimborso differenza', 'fp-experiences'),
+                ],
+            ],
+            [
+                'id' => 'verified-experience',
+                'label' => __('Esperienza verificata', 'fp-experiences'),
+                'description' => __('Operatori certificati e recensioni verificate da viaggiatori reali.', 'fp-experiences'),
+                'tagline' => __('Partner selezionati', 'fp-experiences'),
+                'icon' => 'star',
+                'priority' => 60,
+                'keywords' => [
+                    __('certificata', 'fp-experiences'),
+                    __('recensioni verificate', 'fp-experiences'),
+                    __('qualità garantita', 'fp-experiences'),
+                ],
+            ],
+            [
+                'id' => 'dedicated-support',
+                'label' => __('Supporto dedicato', 'fp-experiences'),
+                'description' => __('Assistenza multicanale prima, durante e dopo l’esperienza.', 'fp-experiences'),
+                'tagline' => __('Siamo con te in ogni fase', 'fp-experiences'),
+                'icon' => 'headset',
+                'priority' => 70,
+                'keywords' => [
+                    __('assistenza', 'fp-experiences'),
+                    __('supporto 24/7', 'fp-experiences'),
+                    __('contatto diretto', 'fp-experiences'),
+                ],
+            ],
+            [
+                'id' => 'gift-option',
+                'label' => __('Perfetta come regalo', 'fp-experiences'),
+                'description' => __('Voucher personalizzabili con messaggi e consegna immediata.', 'fp-experiences'),
+                'tagline' => __('Biglietto regalo digitale', 'fp-experiences'),
+                'icon' => 'gift',
+                'priority' => 80,
+                'keywords' => [
+                    __('idea regalo', 'fp-experiences'),
+                    __('voucher', 'fp-experiences'),
+                    __('buono regalo', 'fp-experiences'),
+                ],
+            ],
         ];
 
-        $choices = [];
-        foreach ($biases as $slug => $label) {
-            $choices[] = [
-                'id' => (string) $slug,
-                'label' => (string) $label,
+        $maybe_filtered = apply_filters('fp_exp_cognitive_bias_choices', $defaults);
+        $maybe_filtered = is_array($maybe_filtered) ? $maybe_filtered : $defaults;
+
+        $normalized = [];
+        foreach ($maybe_filtered as $position => $choice) {
+            if (! is_array($choice)) {
+                continue;
+            }
+
+            $id = isset($choice['id']) ? sanitize_key((string) $choice['id']) : '';
+            $label = isset($choice['label']) ? (string) $choice['label'] : '';
+            $description = isset($choice['description']) ? (string) $choice['description'] : '';
+            $tagline = isset($choice['tagline']) ? (string) $choice['tagline'] : '';
+            $icon = isset($choice['icon']) ? sanitize_key((string) $choice['icon']) : '';
+            if ('' === $icon || ! isset($icon_registry[$icon])) {
+                $icon = 'shield';
+            }
+            $priority = isset($choice['priority']) ? (int) $choice['priority'] : (($position + 1) * 10);
+            $keywords = [];
+
+            if (isset($choice['keywords']) && is_array($choice['keywords'])) {
+                foreach ($choice['keywords'] as $keyword) {
+                    $keyword_value = sanitize_text_field((string) $keyword);
+                    if ('' === $keyword_value) {
+                        continue;
+                    }
+
+                    $keywords[] = $keyword_value;
+                }
+            }
+
+            $keywords = array_values(array_unique($keywords));
+
+            if ('' === $id || '' === $label) {
+                continue;
+            }
+
+            $normalized[$id] = [
+                'id' => $id,
+                'label' => sanitize_text_field($label),
+                'description' => sanitize_text_field($description),
+                'tagline' => sanitize_text_field($tagline),
+                'icon' => $icon,
+                'priority' => $priority,
+                'keywords' => $keywords,
             ];
         }
 
-        return $choices;
+        uasort(
+            $normalized,
+            static function (array $a, array $b): int {
+                if ($a['priority'] === $b['priority']) {
+                    return strcmp($a['label'], $b['label']);
+                }
+
+                return $a['priority'] <=> $b['priority'];
+            }
+        );
+
+        self::$cognitive_bias_choices_index = $normalized;
+        self::$cognitive_bias_choices_cache = array_values($normalized);
+
+        return self::$cognitive_bias_choices_cache;
+    }
+
+    /**
+     * @param array<int, string> $slugs
+     * @return array<int, array{id: string, label: string, description: string, tagline: string, icon: string, priority: int, keywords: array<int, string>}>
+     */
+    public static function cognitive_bias_badges(array $slugs): array
+    {
+        $indexed = self::cognitive_bias_index();
+
+        $normalized_slugs = array_values(array_unique(array_map(
+            static fn ($slug): string => sanitize_key((string) $slug),
+            $slugs
+        )));
+
+        $badges = [];
+        foreach ($normalized_slugs as $slug) {
+            if (isset($indexed[$slug])) {
+                $badges[] = $indexed[$slug];
+            }
+        }
+
+        return array_slice($badges, 0, self::cognitive_bias_max_selection());
     }
 
     /**
@@ -438,21 +650,89 @@ final class Helpers
      */
     public static function cognitive_bias_labels(array $slugs): array
     {
-        $choices = self::cognitive_bias_choices();
-        $map = [];
-        foreach ($choices as $choice) {
-            $map[$choice['id']] = $choice['label'];
+        $badges = self::cognitive_bias_badges($slugs);
+
+        return array_map(
+            static fn (array $badge): string => $badge['label'],
+            $badges
+        );
+    }
+
+    /**
+     * @return array<string, array{id: string, label: string, description: string, tagline: string, icon: string, priority: int, keywords: array<int, string>}>
+     */
+    public static function cognitive_bias_index(): array
+    {
+        if (null === self::$cognitive_bias_choices_index) {
+            self::cognitive_bias_choices();
         }
 
-        $labels = [];
-        foreach ($slugs as $slug) {
-            $key = sanitize_key((string) $slug);
-            if (isset($map[$key])) {
-                $labels[] = $map[$key];
+        return self::$cognitive_bias_choices_index ?? [];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function cognitive_bias_icons(): array
+    {
+        if (null !== self::$cognitive_bias_icon_cache) {
+            return self::$cognitive_bias_icon_cache;
+        }
+
+        $defaults = [
+            'shield' => '<svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 2 4 5v6c0 5.55 3.84 10.74 8 12 4.16-1.26 8-6.45 8-12V5Zm0 15c-2.21-.93-4-4-4-6.74V7.36l4-1.45 4 1.45v2.9C16 13 14.21 16.07 12 17Z"/></svg>',
+            'lock' => '<svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path fill="currentColor" d="M17 8h-1V6a4 4 0 0 0-8 0v2H7a3 3 0 0 0-3 3v8a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3v-8a3 3 0 0 0-3-3Zm-5 9.5A1.5 1.5 0 1 1 13.5 16 1.5 1.5 0 0 1 12 17.5Zm3-9.5H9V6a3 3 0 0 1 6 0Z"/></svg>',
+            'calendar' => '<svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path fill="currentColor" d="M19 3h-1V1h-2v2H8V1H6v2H5a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3V6a3 3 0 0 0-3-3Zm1 17a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V10h16Zm0-12H4V6a1 1 0 0 1 1-1h1v2h2V5h8v2h2V5h1a1 1 0 0 1 1 1Z"/></svg>',
+            'bolt' => '<svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path fill="currentColor" d="M15.14 3 5 13.65h6l-2.14 7.35L19 9.35h-6Z"/></svg>',
+            'badge' => '<svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path fill="currentColor" d="M19 2H5v20l7-3 7 3Zm-3.21 7.79-4 4a1 1 0 0 1-1.42 0l-2-2 1.42-1.41L11 11.59l3.29-3.3Z"/></svg>',
+            'star' => '<svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 2 9.18 8.26 2 9.27l5.45 4.86L5.82 21 12 17.27 18.18 21l-1.63-6.87L22 9.27l-7.18-1.01Z"/></svg>',
+            'headset' => '<svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 2a9 9 0 0 0-9 9v6a3 3 0 0 0 3 3h2v-8H6v-1a6 6 0 0 1 12 0v1h-2v8h2a3 3 0 0 0 3-3v-6a9 9 0 0 0-9-9Zm-1 18h2v2h-2Z"/></svg>',
+            'gift' => '<svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path fill="currentColor" d="M20 7h-1.17A3 3 0 0 0 20 5a3 3 0 0 0-5-2.24L12 5.2 9 2.76A3 3 0 0 0 4 5a3 3 0 0 0 1.17 2H4a2 2 0 0 0-2 2v3a1 1 0 0 0 1 1h1v7a2 2 0 0 0 2 2h4a1 1 0 0 0 1-1v-8h2v8a1 1 0 0 0 1 1h4a2 2 0 0 0 2-2v-7h1a1 1 0 0 0 1-1V9a2 2 0 0 0-2-2ZM6 5a1 1 0 0 1 1.62-.78L11 6H7a1 1 0 0 1-1-1Zm3 15H6v-6h3Zm9 0h-3v-6h3Zm2-8H4V9h16Z"/></svg>',
+        ];
+
+        $registry = apply_filters('fp_exp_cognitive_bias_icon_registry', $defaults);
+        $registry = is_array($registry) ? $registry : $defaults;
+
+        $normalized = [];
+
+        foreach ($registry as $icon => $svg) {
+            $key = sanitize_key((string) $icon);
+            if ('' === $key) {
+                continue;
             }
+
+            if (! is_string($svg)) {
+                continue;
+            }
+
+            $markup = trim($svg);
+            if ('' === $markup) {
+                continue;
+            }
+
+            $normalized[$key] = $markup;
         }
 
-        return $labels;
+        if (! isset($normalized['shield'])) {
+            $normalized['shield'] = $defaults['shield'];
+        }
+
+        self::$cognitive_bias_icon_cache = $normalized;
+
+        return self::$cognitive_bias_icon_cache;
+    }
+
+    public static function cognitive_bias_icon_svg(string $icon): string
+    {
+        $icon = sanitize_key($icon);
+
+        $icons = self::cognitive_bias_icons();
+
+        if (! isset($icons[$icon])) {
+            $icon = 'shield';
+        }
+
+        return $icons[$icon];
     }
 
     public static function rtb_mode(): string
@@ -478,13 +758,29 @@ final class Helpers
 
     public static function verify_rest_nonce(WP_REST_Request $request, string $action, array $param_keys = ['nonce', '_wpnonce']): bool
     {
-        $nonce = self::extract_rest_nonce($request, $param_keys);
+        $header_nonce = $request->get_header('x-wp-nonce');
 
-        if (! $nonce) {
-            return false;
+        if (is_string($header_nonce) && $header_nonce) {
+            $header_nonce = sanitize_text_field($header_nonce);
+            if (wp_verify_nonce($header_nonce, $action)) {
+                return true;
+            }
         }
 
-        return (bool) wp_verify_nonce($nonce, $action);
+        foreach ($param_keys as $key) {
+            $value = $request->get_param($key);
+            if (! is_string($value) || '' === $value) {
+                continue;
+            }
+
+            $value = sanitize_text_field($value);
+
+            if (wp_verify_nonce($value, $action)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public static function verify_public_rest_request(WP_REST_Request $request): bool
@@ -501,24 +797,7 @@ final class Helpers
             }
         }
 
-        return is_user_logged_in();
-    }
-
-    private static function extract_rest_nonce(WP_REST_Request $request, array $param_keys): string
-    {
-        $header = $request->get_header('x-wp-nonce');
-        if (is_string($header) && $header) {
-            return sanitize_text_field($header);
-        }
-
-        foreach ($param_keys as $key) {
-            $value = $request->get_param($key);
-            if (is_string($value) && $value) {
-                return sanitize_text_field($value);
-            }
-        }
-
-        return '';
+        return false;
     }
 
     public static function rtb_hold_timeout(): int

--- a/build/fp-experiences/templates/front/experience.php
+++ b/build/fp-experiences/templates/front/experience.php
@@ -112,7 +112,32 @@ $overview_themes = isset($overview['themes']) && is_array($overview['themes']) ?
 $overview_languages = isset($overview['language_badges']) && is_array($overview['language_badges']) ? $overview['language_badges'] : [];
 $overview_language_terms = isset($overview['language_terms']) && is_array($overview['language_terms']) ? $overview['language_terms'] : [];
 $overview_biases = isset($overview['cognitive_biases']) && is_array($overview['cognitive_biases'])
-    ? array_values(array_filter(array_map('strval', $overview['cognitive_biases'])))
+    ? array_values(array_filter(array_map(
+        static function ($bias) {
+            if (! is_array($bias)) {
+                $bias = [
+                    'label' => (string) $bias,
+                ];
+            }
+
+            $label = isset($bias['label']) ? (string) $bias['label'] : '';
+            if ('' === $label) {
+                return null;
+            }
+
+            $tagline = isset($bias['tagline']) ? (string) $bias['tagline'] : '';
+            $description = isset($bias['description']) ? (string) $bias['description'] : '';
+            $icon = isset($bias['icon']) ? (string) $bias['icon'] : '';
+
+            return [
+                'label' => $label,
+                'tagline' => $tagline,
+                'description' => $description,
+                'icon' => $icon,
+            ];
+        },
+        $overview['cognitive_biases']
+    )))
     : [];
 $overview_duration_label = isset($overview['duration_label']) ? (string) $overview['duration_label'] : '';
 $overview_duration_terms = isset($overview['duration_terms']) && is_array($overview['duration_terms']) ? $overview['duration_terms'] : [];
@@ -289,12 +314,40 @@ $cta_label = esc_html__('Controlla disponibilità', 'fp-experiences');
 
                         <?php if (! empty($overview_biases)) : ?>
                             <div class="fp-exp-overview__item">
-                                <span class="fp-exp-overview__label"><?php esc_html_e('Bias cognitivi', 'fp-experiences'); ?></span>
-                                <div class="fp-exp-overview__chips">
-                                    <?php foreach ($overview_biases as $bias) : ?>
-                                        <span class="fp-exp-overview__chip"><?php echo esc_html($bias); ?></span>
+                                <span class="fp-exp-overview__label"><?php esc_html_e('Badge di fiducia', 'fp-experiences'); ?></span>
+                                <ul class="fp-exp-overview__chips" role="list">
+                                    <?php foreach ($overview_biases as $bias) :
+                                        $label = isset($bias['label']) ? (string) $bias['label'] : '';
+                                        if ('' === $label) {
+                                            continue;
+                                        }
+
+                                        $tagline = isset($bias['tagline']) ? (string) $bias['tagline'] : '';
+                                        $description = isset($bias['description']) ? (string) $bias['description'] : '';
+                                        $icon_name = isset($bias['icon']) ? (string) $bias['icon'] : '';
+                                        $icon_svg = \FP_Exp\Utils\Helpers::cognitive_bias_icon_svg($icon_name);
+                                        $chip_label_parts = array_values(array_filter([$label, $tagline, $description]));
+                                        $chip_label_text = ! empty($chip_label_parts)
+                                            ? implode(' – ', array_unique($chip_label_parts))
+                                            : '';
+                                        ?>
+                                        <li
+                                            class="fp-exp-overview__chip"
+                                            <?php if ('' !== $chip_label_text) : ?>title="<?php echo esc_attr($chip_label_text); ?>" aria-label="<?php echo esc_attr($chip_label_text); ?>"<?php endif; ?>
+                                        >
+                                            <span class="fp-exp-overview__chip-icon" aria-hidden="true"><?php echo $icon_svg; ?></span>
+                                            <span class="fp-exp-overview__chip-body">
+                                                <span class="fp-exp-overview__chip-label"><?php echo esc_html($label); ?></span>
+                                                <?php if ('' !== $tagline) : ?>
+                                                    <span class="fp-exp-overview__chip-tagline"><?php echo esc_html($tagline); ?></span>
+                                                <?php endif; ?>
+                                                <?php if ('' !== $description) : ?>
+                                                    <span class="fp-exp-overview__chip-description"><?php echo esc_html($description); ?></span>
+                                                <?php endif; ?>
+                                            </span>
+                                        </li>
                                     <?php endforeach; ?>
-                                </div>
+                                </ul>
                             </div>
                         <?php endif; ?>
 

--- a/src/Shortcodes/ExperienceShortcode.php
+++ b/src/Shortcodes/ExperienceShortcode.php
@@ -251,7 +251,7 @@ final class ExperienceShortcode extends BaseShortcode
         $cognitive_bias_slugs = is_array($cognitive_bias_meta)
             ? array_values(array_filter(array_map('sanitize_key', $cognitive_bias_meta)))
             : [];
-        $cognitive_bias_labels = Helpers::cognitive_bias_labels($cognitive_bias_slugs);
+        $cognitive_bias_badges = Helpers::cognitive_bias_badges($cognitive_bias_slugs);
 
         $badges = $this->build_badges($duration_minutes, $language_badges, $family_friendly);
 
@@ -286,7 +286,7 @@ final class ExperienceShortcode extends BaseShortcode
                 'summary' => $meeting_summary,
             ],
             'family_friendly' => $family_friendly,
-            'cognitive_biases' => $cognitive_bias_labels,
+            'cognitive_biases' => $cognitive_bias_badges,
         ];
 
         $overview_has_content = $this->overview_has_content($overview);

--- a/src/Utils/Helpers.php
+++ b/src/Utils/Helpers.php
@@ -57,6 +57,40 @@ final class Helpers
      */
     private static array $asset_version_cache = [];
 
+    /**
+     * @var array<int, array{id: string, label: string, description: string, tagline: string, icon: string, priority: int, keywords: array<int, string>}>|null
+     */
+    private static ?array $cognitive_bias_choices_cache = null;
+
+    /**
+     * @var array<string, array{id: string, label: string, description: string, tagline: string, icon: string, priority: int, keywords: array<int, string>}>|null
+     */
+    private static ?array $cognitive_bias_choices_index = null;
+
+    /**
+     * @var array<string, string>|null
+     */
+    private static ?array $cognitive_bias_icon_cache = null;
+
+    public const COGNITIVE_BIAS_MAX_SELECTION = 3;
+
+    public static function cognitive_bias_max_selection(): int
+    {
+        $max = apply_filters('fp_exp_cognitive_bias_max_selection', self::COGNITIVE_BIAS_MAX_SELECTION);
+
+        if (! is_numeric($max)) {
+            $max = self::COGNITIVE_BIAS_MAX_SELECTION;
+        }
+
+        $max = (int) $max;
+
+        if ($max <= 0) {
+            $max = self::COGNITIVE_BIAS_MAX_SELECTION;
+        }
+
+        return $max;
+    }
+
     public static function can_manage_fp(): bool
     {
         return current_user_can('fp_exp_manage')
@@ -405,30 +439,209 @@ final class Helpers
     }
 
     /**
-     * @return array<int, array{id: string, label: string}>
+     * @return array<int, array{id: string, label: string, description: string, tagline: string, icon: string, priority: int, keywords: array<int, string>}>
      */
     public static function cognitive_bias_choices(): array
     {
-        $biases = [
-            'anchoring' => __('Bias di ancoraggio', 'fp-experiences'),
-            'authority' => __('Principio di autorità', 'fp-experiences'),
-            'scarcity' => __('Bias di scarsità', 'fp-experiences'),
-            'social-proof' => __('Riprova sociale', 'fp-experiences'),
-            'loss-aversion' => __('Avversione alla perdita', 'fp-experiences'),
-            'commitment' => __('Impegno e coerenza', 'fp-experiences'),
-            'reciprocity' => __('Reciprocità', 'fp-experiences'),
-            'framing' => __('Effetto framing', 'fp-experiences'),
+        if (null !== self::$cognitive_bias_choices_cache) {
+            return self::$cognitive_bias_choices_cache;
+        }
+
+        $icon_registry = self::cognitive_bias_icons();
+
+        $defaults = [
+            [
+                'id' => 'safe-booking',
+                'label' => __('Prenotazione sicura', 'fp-experiences'),
+                'description' => __('Pagamenti crittografati e protezione antifrode per ogni transazione.', 'fp-experiences'),
+                'tagline' => __('Transazioni protette', 'fp-experiences'),
+                'icon' => 'shield',
+                'priority' => 10,
+                'keywords' => [
+                    __('sicurezza', 'fp-experiences'),
+                    __('pagamento sicuro', 'fp-experiences'),
+                    __('antifrode', 'fp-experiences'),
+                ],
+            ],
+            [
+                'id' => 'protected-checkout',
+                'label' => __('Checkout protetto', 'fp-experiences'),
+                'description' => __('Carte e wallet digitali approvati con conferma in tempo reale.', 'fp-experiences'),
+                'tagline' => __('Paghi come preferisci', 'fp-experiences'),
+                'icon' => 'lock',
+                'priority' => 20,
+                'keywords' => [
+                    __('checkout', 'fp-experiences'),
+                    __('pagamenti digitali', 'fp-experiences'),
+                    __('wallet', 'fp-experiences'),
+                ],
+            ],
+            [
+                'id' => 'flexible-cancellation',
+                'label' => __('Cancellazione flessibile', 'fp-experiences'),
+                'description' => __('Puoi modificare o annullare entro i termini indicati senza penali.', 'fp-experiences'),
+                'tagline' => __('Piani che cambiano? Nessun problema', 'fp-experiences'),
+                'icon' => 'calendar',
+                'priority' => 30,
+                'keywords' => [
+                    __('cambio data', 'fp-experiences'),
+                    __('rimborso', 'fp-experiences'),
+                    __('politica flessibile', 'fp-experiences'),
+                ],
+            ],
+            [
+                'id' => 'instant-confirmation',
+                'label' => __('Conferma immediata', 'fp-experiences'),
+                'description' => __('Ricevi subito biglietti e dettagli via e-mail e nell’area riservata.', 'fp-experiences'),
+                'tagline' => __('Ricevi tutto in pochi secondi', 'fp-experiences'),
+                'icon' => 'bolt',
+                'priority' => 40,
+                'keywords' => [
+                    __('e-ticket', 'fp-experiences'),
+                    __('conferma istantanea', 'fp-experiences'),
+                    __('email immediata', 'fp-experiences'),
+                ],
+            ],
+            [
+                'id' => 'best-price',
+                'label' => __('Miglior prezzo garantito', 'fp-experiences'),
+                'description' => __('Se trovi un prezzo più basso ti rimborsiamo la differenza.', 'fp-experiences'),
+                'tagline' => __('Zero sorprese sul prezzo', 'fp-experiences'),
+                'icon' => 'badge',
+                'priority' => 50,
+                'keywords' => [
+                    __('garanzia prezzo', 'fp-experiences'),
+                    __('risparmio', 'fp-experiences'),
+                    __('rimborso differenza', 'fp-experiences'),
+                ],
+            ],
+            [
+                'id' => 'verified-experience',
+                'label' => __('Esperienza verificata', 'fp-experiences'),
+                'description' => __('Operatori certificati e recensioni verificate da viaggiatori reali.', 'fp-experiences'),
+                'tagline' => __('Partner selezionati', 'fp-experiences'),
+                'icon' => 'star',
+                'priority' => 60,
+                'keywords' => [
+                    __('certificata', 'fp-experiences'),
+                    __('recensioni verificate', 'fp-experiences'),
+                    __('qualità garantita', 'fp-experiences'),
+                ],
+            ],
+            [
+                'id' => 'dedicated-support',
+                'label' => __('Supporto dedicato', 'fp-experiences'),
+                'description' => __('Assistenza multicanale prima, durante e dopo l’esperienza.', 'fp-experiences'),
+                'tagline' => __('Siamo con te in ogni fase', 'fp-experiences'),
+                'icon' => 'headset',
+                'priority' => 70,
+                'keywords' => [
+                    __('assistenza', 'fp-experiences'),
+                    __('supporto 24/7', 'fp-experiences'),
+                    __('contatto diretto', 'fp-experiences'),
+                ],
+            ],
+            [
+                'id' => 'gift-option',
+                'label' => __('Perfetta come regalo', 'fp-experiences'),
+                'description' => __('Voucher personalizzabili con messaggi e consegna immediata.', 'fp-experiences'),
+                'tagline' => __('Biglietto regalo digitale', 'fp-experiences'),
+                'icon' => 'gift',
+                'priority' => 80,
+                'keywords' => [
+                    __('idea regalo', 'fp-experiences'),
+                    __('voucher', 'fp-experiences'),
+                    __('buono regalo', 'fp-experiences'),
+                ],
+            ],
         ];
 
-        $choices = [];
-        foreach ($biases as $slug => $label) {
-            $choices[] = [
-                'id' => (string) $slug,
-                'label' => (string) $label,
+        $maybe_filtered = apply_filters('fp_exp_cognitive_bias_choices', $defaults);
+        $maybe_filtered = is_array($maybe_filtered) ? $maybe_filtered : $defaults;
+
+        $normalized = [];
+        foreach ($maybe_filtered as $position => $choice) {
+            if (! is_array($choice)) {
+                continue;
+            }
+
+            $id = isset($choice['id']) ? sanitize_key((string) $choice['id']) : '';
+            $label = isset($choice['label']) ? (string) $choice['label'] : '';
+            $description = isset($choice['description']) ? (string) $choice['description'] : '';
+            $tagline = isset($choice['tagline']) ? (string) $choice['tagline'] : '';
+            $icon = isset($choice['icon']) ? sanitize_key((string) $choice['icon']) : '';
+            if ('' === $icon || ! isset($icon_registry[$icon])) {
+                $icon = 'shield';
+            }
+            $priority = isset($choice['priority']) ? (int) $choice['priority'] : (($position + 1) * 10);
+            $keywords = [];
+
+            if (isset($choice['keywords']) && is_array($choice['keywords'])) {
+                foreach ($choice['keywords'] as $keyword) {
+                    $keyword_value = sanitize_text_field((string) $keyword);
+                    if ('' === $keyword_value) {
+                        continue;
+                    }
+
+                    $keywords[] = $keyword_value;
+                }
+            }
+
+            $keywords = array_values(array_unique($keywords));
+
+            if ('' === $id || '' === $label) {
+                continue;
+            }
+
+            $normalized[$id] = [
+                'id' => $id,
+                'label' => sanitize_text_field($label),
+                'description' => sanitize_text_field($description),
+                'tagline' => sanitize_text_field($tagline),
+                'icon' => $icon,
+                'priority' => $priority,
+                'keywords' => $keywords,
             ];
         }
 
-        return $choices;
+        uasort(
+            $normalized,
+            static function (array $a, array $b): int {
+                if ($a['priority'] === $b['priority']) {
+                    return strcmp($a['label'], $b['label']);
+                }
+
+                return $a['priority'] <=> $b['priority'];
+            }
+        );
+
+        self::$cognitive_bias_choices_index = $normalized;
+        self::$cognitive_bias_choices_cache = array_values($normalized);
+
+        return self::$cognitive_bias_choices_cache;
+    }
+
+    /**
+     * @param array<int, string> $slugs
+     * @return array<int, array{id: string, label: string, description: string, tagline: string, icon: string, priority: int, keywords: array<int, string>}>
+     */
+    public static function cognitive_bias_badges(array $slugs): array
+    {
+        $indexed = self::cognitive_bias_index();
+
+        $normalized_slugs = array_values(array_unique(array_map(
+            static fn ($slug): string => sanitize_key((string) $slug),
+            $slugs
+        )));
+
+        $badges = [];
+        foreach ($normalized_slugs as $slug) {
+            if (isset($indexed[$slug])) {
+                $badges[] = $indexed[$slug];
+            }
+        }
+
+        return array_slice($badges, 0, self::cognitive_bias_max_selection());
     }
 
     /**
@@ -437,21 +650,89 @@ final class Helpers
      */
     public static function cognitive_bias_labels(array $slugs): array
     {
-        $choices = self::cognitive_bias_choices();
-        $map = [];
-        foreach ($choices as $choice) {
-            $map[$choice['id']] = $choice['label'];
+        $badges = self::cognitive_bias_badges($slugs);
+
+        return array_map(
+            static fn (array $badge): string => $badge['label'],
+            $badges
+        );
+    }
+
+    /**
+     * @return array<string, array{id: string, label: string, description: string, tagline: string, icon: string, priority: int, keywords: array<int, string>}>
+     */
+    public static function cognitive_bias_index(): array
+    {
+        if (null === self::$cognitive_bias_choices_index) {
+            self::cognitive_bias_choices();
         }
 
-        $labels = [];
-        foreach ($slugs as $slug) {
-            $key = sanitize_key((string) $slug);
-            if (isset($map[$key])) {
-                $labels[] = $map[$key];
+        return self::$cognitive_bias_choices_index ?? [];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function cognitive_bias_icons(): array
+    {
+        if (null !== self::$cognitive_bias_icon_cache) {
+            return self::$cognitive_bias_icon_cache;
+        }
+
+        $defaults = [
+            'shield' => '<svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 2 4 5v6c0 5.55 3.84 10.74 8 12 4.16-1.26 8-6.45 8-12V5Zm0 15c-2.21-.93-4-4-4-6.74V7.36l4-1.45 4 1.45v2.9C16 13 14.21 16.07 12 17Z"/></svg>',
+            'lock' => '<svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path fill="currentColor" d="M17 8h-1V6a4 4 0 0 0-8 0v2H7a3 3 0 0 0-3 3v8a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3v-8a3 3 0 0 0-3-3Zm-5 9.5A1.5 1.5 0 1 1 13.5 16 1.5 1.5 0 0 1 12 17.5Zm3-9.5H9V6a3 3 0 0 1 6 0Z"/></svg>',
+            'calendar' => '<svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path fill="currentColor" d="M19 3h-1V1h-2v2H8V1H6v2H5a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3V6a3 3 0 0 0-3-3Zm1 17a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V10h16Zm0-12H4V6a1 1 0 0 1 1-1h1v2h2V5h8v2h2V5h1a1 1 0 0 1 1 1Z"/></svg>',
+            'bolt' => '<svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path fill="currentColor" d="M15.14 3 5 13.65h6l-2.14 7.35L19 9.35h-6Z"/></svg>',
+            'badge' => '<svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path fill="currentColor" d="M19 2H5v20l7-3 7 3Zm-3.21 7.79-4 4a1 1 0 0 1-1.42 0l-2-2 1.42-1.41L11 11.59l3.29-3.3Z"/></svg>',
+            'star' => '<svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 2 9.18 8.26 2 9.27l5.45 4.86L5.82 21 12 17.27 18.18 21l-1.63-6.87L22 9.27l-7.18-1.01Z"/></svg>',
+            'headset' => '<svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 2a9 9 0 0 0-9 9v6a3 3 0 0 0 3 3h2v-8H6v-1a6 6 0 0 1 12 0v1h-2v8h2a3 3 0 0 0 3-3v-6a9 9 0 0 0-9-9Zm-1 18h2v2h-2Z"/></svg>',
+            'gift' => '<svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path fill="currentColor" d="M20 7h-1.17A3 3 0 0 0 20 5a3 3 0 0 0-5-2.24L12 5.2 9 2.76A3 3 0 0 0 4 5a3 3 0 0 0 1.17 2H4a2 2 0 0 0-2 2v3a1 1 0 0 0 1 1h1v7a2 2 0 0 0 2 2h4a1 1 0 0 0 1-1v-8h2v8a1 1 0 0 0 1 1h4a2 2 0 0 0 2-2v-7h1a1 1 0 0 0 1-1V9a2 2 0 0 0-2-2ZM6 5a1 1 0 0 1 1.62-.78L11 6H7a1 1 0 0 1-1-1Zm3 15H6v-6h3Zm9 0h-3v-6h3Zm2-8H4V9h16Z"/></svg>',
+        ];
+
+        $registry = apply_filters('fp_exp_cognitive_bias_icon_registry', $defaults);
+        $registry = is_array($registry) ? $registry : $defaults;
+
+        $normalized = [];
+
+        foreach ($registry as $icon => $svg) {
+            $key = sanitize_key((string) $icon);
+            if ('' === $key) {
+                continue;
             }
+
+            if (! is_string($svg)) {
+                continue;
+            }
+
+            $markup = trim($svg);
+            if ('' === $markup) {
+                continue;
+            }
+
+            $normalized[$key] = $markup;
         }
 
-        return $labels;
+        if (! isset($normalized['shield'])) {
+            $normalized['shield'] = $defaults['shield'];
+        }
+
+        self::$cognitive_bias_icon_cache = $normalized;
+
+        return self::$cognitive_bias_icon_cache;
+    }
+
+    public static function cognitive_bias_icon_svg(string $icon): string
+    {
+        $icon = sanitize_key($icon);
+
+        $icons = self::cognitive_bias_icons();
+
+        if (! isset($icons[$icon])) {
+            $icon = 'shield';
+        }
+
+        return $icons[$icon];
     }
 
     public static function rtb_mode(): string

--- a/templates/front/experience.php
+++ b/templates/front/experience.php
@@ -112,7 +112,32 @@ $overview_themes = isset($overview['themes']) && is_array($overview['themes']) ?
 $overview_languages = isset($overview['language_badges']) && is_array($overview['language_badges']) ? $overview['language_badges'] : [];
 $overview_language_terms = isset($overview['language_terms']) && is_array($overview['language_terms']) ? $overview['language_terms'] : [];
 $overview_biases = isset($overview['cognitive_biases']) && is_array($overview['cognitive_biases'])
-    ? array_values(array_filter(array_map('strval', $overview['cognitive_biases'])))
+    ? array_values(array_filter(array_map(
+        static function ($bias) {
+            if (! is_array($bias)) {
+                $bias = [
+                    'label' => (string) $bias,
+                ];
+            }
+
+            $label = isset($bias['label']) ? (string) $bias['label'] : '';
+            if ('' === $label) {
+                return null;
+            }
+
+            $tagline = isset($bias['tagline']) ? (string) $bias['tagline'] : '';
+            $description = isset($bias['description']) ? (string) $bias['description'] : '';
+            $icon = isset($bias['icon']) ? (string) $bias['icon'] : '';
+
+            return [
+                'label' => $label,
+                'tagline' => $tagline,
+                'description' => $description,
+                'icon' => $icon,
+            ];
+        },
+        $overview['cognitive_biases']
+    )))
     : [];
 $overview_duration_label = isset($overview['duration_label']) ? (string) $overview['duration_label'] : '';
 $overview_duration_terms = isset($overview['duration_terms']) && is_array($overview['duration_terms']) ? $overview['duration_terms'] : [];
@@ -289,12 +314,40 @@ $cta_label = esc_html__('Controlla disponibilità', 'fp-experiences');
 
                         <?php if (! empty($overview_biases)) : ?>
                             <div class="fp-exp-overview__item">
-                                <span class="fp-exp-overview__label"><?php esc_html_e('Bias cognitivi', 'fp-experiences'); ?></span>
-                                <div class="fp-exp-overview__chips">
-                                    <?php foreach ($overview_biases as $bias) : ?>
-                                        <span class="fp-exp-overview__chip"><?php echo esc_html($bias); ?></span>
+                                <span class="fp-exp-overview__label"><?php esc_html_e('Badge di fiducia', 'fp-experiences'); ?></span>
+                                <ul class="fp-exp-overview__chips" role="list">
+                                    <?php foreach ($overview_biases as $bias) :
+                                        $label = isset($bias['label']) ? (string) $bias['label'] : '';
+                                        if ('' === $label) {
+                                            continue;
+                                        }
+
+                                        $tagline = isset($bias['tagline']) ? (string) $bias['tagline'] : '';
+                                        $description = isset($bias['description']) ? (string) $bias['description'] : '';
+                                        $icon_name = isset($bias['icon']) ? (string) $bias['icon'] : '';
+                                        $icon_svg = \FP_Exp\Utils\Helpers::cognitive_bias_icon_svg($icon_name);
+                                        $chip_label_parts = array_values(array_filter([$label, $tagline, $description]));
+                                        $chip_label_text = ! empty($chip_label_parts)
+                                            ? implode(' – ', array_unique($chip_label_parts))
+                                            : '';
+                                        ?>
+                                        <li
+                                            class="fp-exp-overview__chip"
+                                            <?php if ('' !== $chip_label_text) : ?>title="<?php echo esc_attr($chip_label_text); ?>" aria-label="<?php echo esc_attr($chip_label_text); ?>"<?php endif; ?>
+                                        >
+                                            <span class="fp-exp-overview__chip-icon" aria-hidden="true"><?php echo $icon_svg; ?></span>
+                                            <span class="fp-exp-overview__chip-body">
+                                                <span class="fp-exp-overview__chip-label"><?php echo esc_html($label); ?></span>
+                                                <?php if ('' !== $tagline) : ?>
+                                                    <span class="fp-exp-overview__chip-tagline"><?php echo esc_html($tagline); ?></span>
+                                                <?php endif; ?>
+                                                <?php if ('' !== $description) : ?>
+                                                    <span class="fp-exp-overview__chip-description"><?php echo esc_html($description); ?></span>
+                                                <?php endif; ?>
+                                            </span>
+                                        </li>
                                     <?php endforeach; ?>
-                                </div>
+                                </ul>
                             </div>
                         <?php endif; ?>
 


### PR DESCRIPTION
## Summary
- add keyword metadata to each trust badge so filters and extensions can reason about persuasive themes more easily
- introduce an admin search field with live filtering, empty-state messaging, and matching styles to speed up badge selection
- render the public trust badges as a semantic list and mirror all helper, style, and script updates in the distributed build assets

## Testing
- php -l src/Utils/Helpers.php
- php -l src/Admin/ExperienceMetaBoxes.php
- php -l templates/front/experience.php
- php -l build/fp-experiences/src/Utils/Helpers.php
- php -l build/fp-experiences/src/Admin/ExperienceMetaBoxes.php
- php -l build/fp-experiences/templates/front/experience.php


------
https://chatgpt.com/codex/tasks/task_e_68de46f397f4832fb4cf7a35605b738d