### PR TITLE
Trim hero media height

### DIFF
--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -1904,27 +1904,48 @@
     background: transparent;
     padding: 0;
     box-shadow: none;
+    border-radius: 0;
+    width: 100vw;
+    margin-inline: calc(50% - 50vw);
 }
 
 .fp-hero-section {
-    display: grid;
-    gap: clamp(1.5rem, 4vw, 2.75rem);
-    align-items: stretch;
-    grid-template-columns: minmax(0, 1fr);
+    position: relative;
+    display: block;
+    padding-block: clamp(2rem, 6vw, 5rem) clamp(2.5rem, 8vw, 6rem);
+    box-sizing: border-box;
+    overflow: hidden;
 }
 
-@media (min-width: 960px) {
-    .fp-hero-section {
-        grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
-    }
+.fp-hero-section::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background:
+        linear-gradient(180deg, rgba(15, 23, 42, 0.12) 0%, rgba(15, 23, 42, 0) 55%),
+        var(--fp-color-surface, #fff);
+    z-index: 0;
+}
+
+.fp-hero-section__inner {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.75rem, 5vw, 3rem);
+    position: relative;
+    z-index: 1;
+    width: min(1200px, 100%);
+    margin: 0 auto;
+    padding-inline: clamp(16px, 6vw, 96px);
+    box-sizing: border-box;
 }
 
 .fp-hero-media {
     position: relative;
     border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
     overflow: hidden;
-    min-height: clamp(240px, 45vw, 520px);
+    min-height: clamp(200px, 32vw, 420px);
     background: rgba(15, 23, 42, 0.1);
+    order: 2;
 }
 
 .fp-hero-media__image {
@@ -1939,7 +1960,7 @@
     width: 100%;
     height: 100%;
     min-height: 220px;
-    border-radius: var(--fp-exp-radius-base, 12px);
+    border-radius: 0;
     overflow: hidden;
 }
 
@@ -1959,10 +1980,61 @@
     background: var(--fp-color-surface);
     border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
     box-shadow: var(--fp-shadow);
-    padding: clamp(1.5rem, 4vw, 2.75rem);
+    padding: clamp(1.75rem, 4vw, 3rem);
     display: flex;
     flex-direction: column;
     gap: 1.25rem;
+    max-width: min(720px, 100%);
+    align-self: flex-start;
+    order: 1;
+}
+
+.fp-exp-gift__body {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1rem, 3vw, 1.5rem);
+    align-items: flex-start;
+}
+
+.fp-exp-gift__content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    max-width: 48ch;
+}
+
+.fp-exp-gift__eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(139, 30, 63, 0.12);
+    color: #8b1e3f;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.fp-exp-gift__title {
+    font-size: clamp(1.5rem, 4vw, 2.25rem);
+    line-height: 1.1;
+    margin: 0;
+}
+
+.fp-exp-gift__description {
+    margin: 0;
+    color: rgba(15, 23, 42, 0.72);
+}
+
+@media (min-width: 768px) {
+    .fp-exp-gift__body {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+        gap: clamp(1.5rem, 4vw, 3rem);
+    }
 }
 
 .fp-hero-body__header {

--- a/build/fp-experiences/assets/css/front.css
+++ b/build/fp-experiences/assets/css/front.css
@@ -1904,27 +1904,48 @@
     background: transparent;
     padding: 0;
     box-shadow: none;
+    border-radius: 0;
+    width: 100vw;
+    margin-inline: calc(50% - 50vw);
 }
 
 .fp-hero-section {
-    display: grid;
-    gap: clamp(1.5rem, 4vw, 2.75rem);
-    align-items: stretch;
-    grid-template-columns: minmax(0, 1fr);
+    position: relative;
+    display: block;
+    padding-block: clamp(2rem, 6vw, 5rem) clamp(2.5rem, 8vw, 6rem);
+    box-sizing: border-box;
+    overflow: hidden;
 }
 
-@media (min-width: 960px) {
-    .fp-hero-section {
-        grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
-    }
+.fp-hero-section::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background:
+        linear-gradient(180deg, rgba(15, 23, 42, 0.12) 0%, rgba(15, 23, 42, 0) 55%),
+        var(--fp-color-surface, #fff);
+    z-index: 0;
+}
+
+.fp-hero-section__inner {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.75rem, 5vw, 3rem);
+    position: relative;
+    z-index: 1;
+    width: min(1200px, 100%);
+    margin: 0 auto;
+    padding-inline: clamp(16px, 6vw, 96px);
+    box-sizing: border-box;
 }
 
 .fp-hero-media {
     position: relative;
     border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
     overflow: hidden;
-    min-height: clamp(240px, 45vw, 520px);
+    min-height: clamp(200px, 32vw, 420px);
     background: rgba(15, 23, 42, 0.1);
+    order: 2;
 }
 
 .fp-hero-media__image {
@@ -1939,7 +1960,7 @@
     width: 100%;
     height: 100%;
     min-height: 220px;
-    border-radius: var(--fp-exp-radius-base, 12px);
+    border-radius: 0;
     overflow: hidden;
 }
 
@@ -1959,10 +1980,61 @@
     background: var(--fp-color-surface);
     border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
     box-shadow: var(--fp-shadow);
-    padding: clamp(1.5rem, 4vw, 2.75rem);
+    padding: clamp(1.75rem, 4vw, 3rem);
     display: flex;
     flex-direction: column;
     gap: 1.25rem;
+    max-width: min(720px, 100%);
+    align-self: flex-start;
+    order: 1;
+}
+
+.fp-exp-gift__body {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1rem, 3vw, 1.5rem);
+    align-items: flex-start;
+}
+
+.fp-exp-gift__content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    max-width: 48ch;
+}
+
+.fp-exp-gift__eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(139, 30, 63, 0.12);
+    color: #8b1e3f;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.fp-exp-gift__title {
+    font-size: clamp(1.5rem, 4vw, 2.25rem);
+    line-height: 1.1;
+    margin: 0;
+}
+
+.fp-exp-gift__description {
+    margin: 0;
+    color: rgba(15, 23, 42, 0.72);
+}
+
+@media (min-width: 768px) {
+    .fp-exp-gift__body {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+        gap: clamp(1.5rem, 4vw, 3rem);
+    }
 }
 
 .fp-hero-body__header {

--- a/build/fp-experiences/templates/front/experience.php
+++ b/build/fp-experiences/templates/front/experience.php
@@ -180,70 +180,80 @@ $cta_label = esc_html__('Controlla disponibilità', 'fp-experiences');
         <main class="fp-main">
             <?php if (! empty($sections['hero'])) : ?>
                 <section class="fp-section fp-hero-section" id="fp-exp-section-hero" data-fp-section="hero">
-                    <div class="fp-hero-media" aria-hidden="<?php echo null === $primary_image ? 'true' : 'false'; ?>">
-                        <?php if ($primary_image) : ?>
-                            <img
-                                class="fp-hero-media__image"
-                                src="<?php echo esc_url($primary_image['url']); ?>"
-                                <?php if (! empty($primary_image['srcset'])) : ?>srcset="<?php echo esc_attr($primary_image['srcset']); ?>"<?php endif; ?>
-                                sizes="100vw"
-                                <?php if (! empty($primary_image['width'])) : ?>width="<?php echo esc_attr((string) $primary_image['width']); ?>"<?php endif; ?>
-                                <?php if (! empty($primary_image['height'])) : ?>height="<?php echo esc_attr((string) $primary_image['height']); ?>"<?php endif; ?>
-                                alt="<?php echo esc_attr($experience['title']); ?>"
-                                loading="eager"
-                                decoding="async"
-                                fetchpriority="high"
-                            />
-                        <?php else : ?>
-                            <div class="fp-hero fp-exp-gallery fp-exp-gallery--placeholder">
-                                <span aria-hidden="true"></span>
-                            </div>
-                        <?php endif; ?>
-                    </div>
-                    <div class="fp-hero-body">
-                        <div class="fp-hero-body__header">
-                            <div class="fp-eyebrow">
-                                <span class="fp-badge">FP Experiences</span>
-                            </div>
-                            <h1 class="fp-title"><?php echo esc_html($experience['title']); ?></h1>
+                    <div class="fp-hero-section__inner">
+                        <div class="fp-hero-media" aria-hidden="<?php echo null === $primary_image ? 'true' : 'false'; ?>">
+                            <?php if ($primary_image) : ?>
+                                <img
+                                    class="fp-hero-media__image"
+                                    src="<?php echo esc_url($primary_image['url']); ?>"
+                                    <?php if (! empty($primary_image['srcset'])) : ?>srcset="<?php echo esc_attr($primary_image['srcset']); ?>"<?php endif; ?>
+                                    sizes="100vw"
+                                    <?php if (! empty($primary_image['width'])) : ?>width="<?php echo esc_attr((string) $primary_image['width']); ?>"<?php endif; ?>
+                                    <?php if (! empty($primary_image['height'])) : ?>height="<?php echo esc_attr((string) $primary_image['height']); ?>"<?php endif; ?>
+                                    alt="<?php echo esc_attr($experience['title']); ?>"
+                                    loading="eager"
+                                    decoding="async"
+                                    fetchpriority="high"
+                                />
+                            <?php else : ?>
+                                <div class="fp-hero fp-exp-gallery fp-exp-gallery--placeholder">
+                                    <span aria-hidden="true"></span>
+                                </div>
+                            <?php endif; ?>
                         </div>
-                        <?php if (! empty($experience['summary'])) : ?>
-                            <p class="fp-summary"><?php echo esc_html($experience['summary']); ?></p>
-                        <?php endif; ?>
-                        <?php if (! empty($hero_highlights)) : ?>
-                            <ul class="fp-hero-highlights" role="list">
-                                <?php foreach ($hero_highlights as $highlight) : ?>
-                                    <li class="fp-hero-highlights__item"><?php echo esc_html($highlight); ?></li>
-                                <?php endforeach; ?>
-                            </ul>
-                        <?php endif; ?>
-                        <?php if (! empty($hero_fact_badges)) : ?>
-                            <ul class="fp-hero-facts" role="list">
-                                <?php foreach ($hero_fact_badges as $badge) : ?>
-                                    <li class="fp-hero-facts__item">
-                                            <span class="fp-hero-facts__icon" aria-hidden="true">
-                                                <?php if ('clock' === ($badge['icon'] ?? '')) : ?>
-                                                    <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm1 10.59 2.12 2.12-1.41 1.41-2.83-2.83V7h2.12Z"/></svg>
-                                                <?php else : ?>
-                                                    <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M12 12.88 9.17 10H5a3 3 0 0 0-3 3v7h6v-4h2v4h6v-7a3 3 0 0 0-3-3h-1.17Zm9-2.88a4 4 0 1 0-4-4 4 4 0 0 0 4 4Z"/></svg>
-                                                <?php endif; ?>
-                                            </span>
-                                            <span class="fp-hero-facts__text"><?php echo esc_html((string) ($badge['label'] ?? '')); ?></span>
-                                    </li>
-                                <?php endforeach; ?>
-                            </ul>
-                        <?php endif; ?>
-                        <?php if ($gift_enabled) : ?>
-                            <div class="fp-hero-gift-link">
-                                <a
-                                    href="#fp-exp-gift"
-                                    class="fp-exp-button fp-exp-button--secondary"
-                                    data-fp-gift-toggle
-                                >
-                                    <?php esc_html_e('Gift this experience', 'fp-experiences'); ?>
-                                </a>
+                        <div class="fp-hero-body">
+                            <div class="fp-hero-body__header">
+                                <div class="fp-eyebrow">
+                                    <span class="fp-badge">FP Experiences</span>
+                                </div>
+                                <h1 class="fp-title"><?php echo esc_html($experience['title']); ?></h1>
                             </div>
-                        <?php endif; ?>
+                            <?php if (! empty($experience['summary'])) : ?>
+                                <p class="fp-summary"><?php echo esc_html($experience['summary']); ?></p>
+                            <?php endif; ?>
+                            <?php if (! empty($hero_highlights)) : ?>
+                                <ul class="fp-hero-highlights" role="list">
+                                    <?php foreach ($hero_highlights as $highlight) : ?>
+                                        <li class="fp-hero-highlights__item"><?php echo esc_html($highlight); ?></li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            <?php endif; ?>
+                            <?php if (! empty($hero_fact_badges)) : ?>
+                                <ul class="fp-hero-facts" role="list">
+                                    <?php foreach ($hero_fact_badges as $badge) : ?>
+                                        <li class="fp-hero-facts__item">
+                                                <span class="fp-hero-facts__icon" aria-hidden="true">
+                                                    <?php if ('clock' === ($badge['icon'] ?? '')) : ?>
+                                                        <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm1 10.59 2.12 2.12-1.41 1.41-2.83-2.83V7h2.12Z"/></svg>
+                                                    <?php else : ?>
+                                                        <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M12 12.88 9.17 10H5a3 3 0 0 0-3 3v7h6v-4h2v4h6v-7a3 3 0 0 0-3-3h-1.17Zm9-2.88a4 4 0 1 0-4-4 4 4 0 0 0 4 4Z"/></svg>
+                                                    <?php endif; ?>
+                                                </span>
+                                                <span class="fp-hero-facts__text"><?php echo esc_html((string) ($badge['label'] ?? '')); ?></span>
+                                        </li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                </section>
+            <?php endif; ?>
+
+            <?php if ($gift_enabled) : ?>
+                <section class="fp-exp-section fp-exp-gift" id="fp-exp-hero-gift" data-fp-section="hero-gift">
+                    <div class="fp-exp-gift__body">
+                        <div class="fp-exp-gift__content">
+                            <span class="fp-exp-gift__eyebrow"><?php esc_html_e('Regali', 'fp-experiences'); ?></span>
+                            <h2 class="fp-exp-gift__title fp-exp-section__title"><?php esc_html_e('Gift this experience', 'fp-experiences'); ?></h2>
+                            <p class="fp-exp-gift__description"><?php esc_html_e('Acquista un voucher e invialo con un messaggio personalizzato in pochi clic.', 'fp-experiences'); ?></p>
+                        </div>
+                        <a
+                            href="#fp-exp-gift"
+                            class="fp-exp-button fp-exp-button--secondary"
+                            data-fp-gift-toggle
+                        >
+                            <?php esc_html_e('Gift this experience', 'fp-experiences'); ?>
+                        </a>
                     </div>
                 </section>
             <?php endif; ?>

--- a/templates/front/experience.php
+++ b/templates/front/experience.php
@@ -180,70 +180,80 @@ $cta_label = esc_html__('Controlla disponibilità', 'fp-experiences');
         <main class="fp-main">
             <?php if (! empty($sections['hero'])) : ?>
                 <section class="fp-section fp-hero-section" id="fp-exp-section-hero" data-fp-section="hero">
-                    <div class="fp-hero-media" aria-hidden="<?php echo null === $primary_image ? 'true' : 'false'; ?>">
-                        <?php if ($primary_image) : ?>
-                            <img
-                                class="fp-hero-media__image"
-                                src="<?php echo esc_url($primary_image['url']); ?>"
-                                <?php if (! empty($primary_image['srcset'])) : ?>srcset="<?php echo esc_attr($primary_image['srcset']); ?>"<?php endif; ?>
-                                sizes="100vw"
-                                <?php if (! empty($primary_image['width'])) : ?>width="<?php echo esc_attr((string) $primary_image['width']); ?>"<?php endif; ?>
-                                <?php if (! empty($primary_image['height'])) : ?>height="<?php echo esc_attr((string) $primary_image['height']); ?>"<?php endif; ?>
-                                alt="<?php echo esc_attr($experience['title']); ?>"
-                                loading="eager"
-                                decoding="async"
-                                fetchpriority="high"
-                            />
-                        <?php else : ?>
-                            <div class="fp-hero fp-exp-gallery fp-exp-gallery--placeholder">
-                                <span aria-hidden="true"></span>
-                            </div>
-                        <?php endif; ?>
-                    </div>
-                    <div class="fp-hero-body">
-                        <div class="fp-hero-body__header">
-                            <div class="fp-eyebrow">
-                                <span class="fp-badge">FP Experiences</span>
-                            </div>
-                            <h1 class="fp-title"><?php echo esc_html($experience['title']); ?></h1>
+                    <div class="fp-hero-section__inner">
+                        <div class="fp-hero-media" aria-hidden="<?php echo null === $primary_image ? 'true' : 'false'; ?>">
+                            <?php if ($primary_image) : ?>
+                                <img
+                                    class="fp-hero-media__image"
+                                    src="<?php echo esc_url($primary_image['url']); ?>"
+                                    <?php if (! empty($primary_image['srcset'])) : ?>srcset="<?php echo esc_attr($primary_image['srcset']); ?>"<?php endif; ?>
+                                    sizes="100vw"
+                                    <?php if (! empty($primary_image['width'])) : ?>width="<?php echo esc_attr((string) $primary_image['width']); ?>"<?php endif; ?>
+                                    <?php if (! empty($primary_image['height'])) : ?>height="<?php echo esc_attr((string) $primary_image['height']); ?>"<?php endif; ?>
+                                    alt="<?php echo esc_attr($experience['title']); ?>"
+                                    loading="eager"
+                                    decoding="async"
+                                    fetchpriority="high"
+                                />
+                            <?php else : ?>
+                                <div class="fp-hero fp-exp-gallery fp-exp-gallery--placeholder">
+                                    <span aria-hidden="true"></span>
+                                </div>
+                            <?php endif; ?>
                         </div>
-                        <?php if (! empty($experience['summary'])) : ?>
-                            <p class="fp-summary"><?php echo esc_html($experience['summary']); ?></p>
-                        <?php endif; ?>
-                        <?php if (! empty($hero_highlights)) : ?>
-                            <ul class="fp-hero-highlights" role="list">
-                                <?php foreach ($hero_highlights as $highlight) : ?>
-                                    <li class="fp-hero-highlights__item"><?php echo esc_html($highlight); ?></li>
-                                <?php endforeach; ?>
-                            </ul>
-                        <?php endif; ?>
-                        <?php if (! empty($hero_fact_badges)) : ?>
-                            <ul class="fp-hero-facts" role="list">
-                                <?php foreach ($hero_fact_badges as $badge) : ?>
-                                    <li class="fp-hero-facts__item">
-                                            <span class="fp-hero-facts__icon" aria-hidden="true">
-                                                <?php if ('clock' === ($badge['icon'] ?? '')) : ?>
-                                                    <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm1 10.59 2.12 2.12-1.41 1.41-2.83-2.83V7h2.12Z"/></svg>
-                                                <?php else : ?>
-                                                    <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M12 12.88 9.17 10H5a3 3 0 0 0-3 3v7h6v-4h2v4h6v-7a3 3 0 0 0-3-3h-1.17Zm9-2.88a4 4 0 1 0-4-4 4 4 0 0 0 4 4Z"/></svg>
-                                                <?php endif; ?>
-                                            </span>
-                                            <span class="fp-hero-facts__text"><?php echo esc_html((string) ($badge['label'] ?? '')); ?></span>
-                                    </li>
-                                <?php endforeach; ?>
-                            </ul>
-                        <?php endif; ?>
-                        <?php if ($gift_enabled) : ?>
-                            <div class="fp-hero-gift-link">
-                                <a
-                                    href="#fp-exp-gift"
-                                    class="fp-exp-button fp-exp-button--secondary"
-                                    data-fp-gift-toggle
-                                >
-                                    <?php esc_html_e('Gift this experience', 'fp-experiences'); ?>
-                                </a>
+                        <div class="fp-hero-body">
+                            <div class="fp-hero-body__header">
+                                <div class="fp-eyebrow">
+                                    <span class="fp-badge">FP Experiences</span>
+                                </div>
+                                <h1 class="fp-title"><?php echo esc_html($experience['title']); ?></h1>
                             </div>
-                        <?php endif; ?>
+                            <?php if (! empty($experience['summary'])) : ?>
+                                <p class="fp-summary"><?php echo esc_html($experience['summary']); ?></p>
+                            <?php endif; ?>
+                            <?php if (! empty($hero_highlights)) : ?>
+                                <ul class="fp-hero-highlights" role="list">
+                                    <?php foreach ($hero_highlights as $highlight) : ?>
+                                        <li class="fp-hero-highlights__item"><?php echo esc_html($highlight); ?></li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            <?php endif; ?>
+                            <?php if (! empty($hero_fact_badges)) : ?>
+                                <ul class="fp-hero-facts" role="list">
+                                    <?php foreach ($hero_fact_badges as $badge) : ?>
+                                        <li class="fp-hero-facts__item">
+                                                <span class="fp-hero-facts__icon" aria-hidden="true">
+                                                    <?php if ('clock' === ($badge['icon'] ?? '')) : ?>
+                                                        <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm1 10.59 2.12 2.12-1.41 1.41-2.83-2.83V7h2.12Z"/></svg>
+                                                    <?php else : ?>
+                                                        <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M12 12.88 9.17 10H5a3 3 0 0 0-3 3v7h6v-4h2v4h6v-7a3 3 0 0 0-3-3h-1.17Zm9-2.88a4 4 0 1 0-4-4 4 4 0 0 0 4 4Z"/></svg>
+                                                    <?php endif; ?>
+                                                </span>
+                                                <span class="fp-hero-facts__text"><?php echo esc_html((string) ($badge['label'] ?? '')); ?></span>
+                                        </li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                </section>
+            <?php endif; ?>
+
+            <?php if ($gift_enabled) : ?>
+                <section class="fp-exp-section fp-exp-gift" id="fp-exp-hero-gift" data-fp-section="hero-gift">
+                    <div class="fp-exp-gift__body">
+                        <div class="fp-exp-gift__content">
+                            <span class="fp-exp-gift__eyebrow"><?php esc_html_e('Regali', 'fp-experiences'); ?></span>
+                            <h2 class="fp-exp-gift__title fp-exp-section__title"><?php esc_html_e('Gift this experience', 'fp-experiences'); ?></h2>
+                            <p class="fp-exp-gift__description"><?php esc_html_e('Acquista un voucher e invialo con un messaggio personalizzato in pochi clic.', 'fp-experiences'); ?></p>
+                        </div>
+                        <a
+                            href="#fp-exp-gift"
+                            class="fp-exp-button fp-exp-button--secondary"
+                            data-fp-gift-toggle
+                        >
+                            <?php esc_html_e('Gift this experience', 'fp-experiences'); ?>
+                        </a>
                     </div>
                 </section>
             <?php endif; ?>


### PR DESCRIPTION
## Summary
- lower the hero media container's height clamp so the image appears shorter
- mirror the updated hero dimensions in the compiled front-end stylesheet

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de5c2a6308832f9634b28a345445ff