### PR TITLE
Remove navigation payload from experience shortcode data

### DIFF
--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -2722,38 +2722,6 @@
     margin-top: 0.5rem;
 }
 
-.fp-exp-page__nav {
-    display: block;
-    background: var(--fp-color-surface);
-    padding: 0.5rem;
-    border-radius: var(--fp-exp-radius-base, 12px);
-    overflow-x: auto;
-}
-
-.fp-exp-page__nav-list {
-    display: flex;
-    gap: 0.5rem;
-    padding: 0;
-    margin: 0;
-    list-style: none;
-}
-
-.fp-exp-page__nav-button {
-    border: none;
-    background: transparent;
-    color: var(--fp-color-text);
-    padding: 0.6rem 1.2rem;
-    border-radius: 999px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: background 0.2s ease, color 0.2s ease;
-}
-
-.fp-exp-page__nav-button:hover,
-.fp-exp-page__nav-button:focus-visible {
-    background: rgba(15, 23, 42, 0.08);
-}
-
 .fp-exp-section {
     background: var(--fp-color-surface);
     border-radius: var(--fp-exp-radius-base, 12px);

--- a/build/fp-experiences/assets/css/front.css
+++ b/build/fp-experiences/assets/css/front.css
@@ -2722,38 +2722,6 @@
     margin-top: 0.5rem;
 }
 
-.fp-exp-page__nav {
-    display: block;
-    background: var(--fp-color-surface);
-    padding: 0.5rem;
-    border-radius: var(--fp-exp-radius-base, 12px);
-    overflow-x: auto;
-}
-
-.fp-exp-page__nav-list {
-    display: flex;
-    gap: 0.5rem;
-    padding: 0;
-    margin: 0;
-    list-style: none;
-}
-
-.fp-exp-page__nav-button {
-    border: none;
-    background: transparent;
-    color: var(--fp-color-text);
-    padding: 0.6rem 1.2rem;
-    border-radius: 999px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: background 0.2s ease, color 0.2s ease;
-}
-
-.fp-exp-page__nav-button:hover,
-.fp-exp-page__nav-button:focus-visible {
-    background: rgba(15, 23, 42, 0.08);
-}
-
 .fp-exp-section {
     background: var(--fp-color-surface);
     border-radius: var(--fp-exp-radius-base, 12px);

--- a/build/fp-experiences/src/Shortcodes/ExperienceShortcode.php
+++ b/build/fp-experiences/src/Shortcodes/ExperienceShortcode.php
@@ -286,93 +286,6 @@ final class ExperienceShortcode extends BaseShortcode
             $enabled_sections['overview'] = false;
         }
 
-        $sections_map = [
-            'hero' => [
-                'id' => 'hero',
-                'label' => esc_html__('Intro', 'fp-experiences'),
-            ],
-            'overview' => [
-                'id' => 'overview',
-                'label' => esc_html__('Overview', 'fp-experiences'),
-            ],
-            'gallery' => [
-                'id' => 'gallery',
-                'label' => esc_html__('Gallery', 'fp-experiences'),
-            ],
-            'highlights' => [
-                'id' => 'highlights',
-                'label' => esc_html__('Highlights', 'fp-experiences'),
-            ],
-            'inclusions' => [
-                'id' => 'inclusions',
-                'label' => esc_html__('What\'s included', 'fp-experiences'),
-            ],
-            'meeting' => [
-                'id' => 'meeting',
-                'label' => esc_html__('Meeting point', 'fp-experiences'),
-            ],
-            'extras' => [
-                'id' => 'extras',
-                'label' => esc_html__('Good to know', 'fp-experiences'),
-            ],
-            'faq' => [
-                'id' => 'faq',
-                'label' => esc_html__('FAQ', 'fp-experiences'),
-            ],
-            'reviews' => [
-                'id' => 'reviews',
-                'label' => esc_html__('Reviews', 'fp-experiences'),
-            ],
-        ];
-
-        $navigation = [];
-        foreach (self::ALLOWED_SECTIONS as $section_key) {
-            if (! $enabled_sections[$section_key] || empty($sections_map[$section_key])) {
-                continue;
-            }
-
-            if ('overview' === $section_key && ! $overview_has_content) {
-                continue;
-            }
-
-            if ('gallery' === $section_key) {
-                $valid_gallery = array_filter(
-                    $gallery,
-                    static fn ($image) => is_array($image) && ! empty($image['url'])
-                );
-
-                if (count($valid_gallery) < 2) {
-                    continue;
-                }
-            }
-
-            if ('highlights' === $section_key && empty($highlights)) {
-                continue;
-            }
-
-            if ('inclusions' === $section_key && empty($inclusions) && empty($exclusions)) {
-                continue;
-            }
-
-            if ('meeting' === $section_key && empty($meeting_data['primary'])) {
-                continue;
-            }
-
-            if ('extras' === $section_key && empty($what_to_bring) && empty($notes) && empty($policy)) {
-                continue;
-            }
-
-            if ('faq' === $section_key && empty($faq_items)) {
-                continue;
-            }
-
-            if ('reviews' === $section_key && empty($reviews)) {
-                continue;
-            }
-
-            $navigation[] = $sections_map[$section_key];
-        }
-
         $missing_meta = [];
 
         if ($enabled_sections['highlights'] && empty($highlights)) {
@@ -443,7 +356,6 @@ final class ExperienceShortcode extends BaseShortcode
             'faq' => $faq_items,
             'reviews' => $reviews,
             'sections' => $enabled_sections,
-            'navigation' => $navigation,
             'meeting_points' => $meeting_data,
             'sticky_widget' => $is_sticky_widget,
             'widget_html' => $widget_html,

--- a/build/fp-experiences/templates/front/experience.php
+++ b/build/fp-experiences/templates/front/experience.php
@@ -14,7 +14,6 @@
  * @var array<int, array<string, string>> $faq
  * @var array<int, array<string, mixed>> $reviews
  * @var array<string, bool> $sections
- * @var array<int, array<string, string>> $navigation
  * @var array{primary: ?array<string, mixed>, alternatives: array<int, array<string, mixed>>} $meeting_points
  * @var bool $sticky_widget
  * @var string $widget_html
@@ -72,9 +71,7 @@ if ($layout_gutter > 0) {
 
 $layout_style_attr = empty($layout_style) ? '' : implode(';', $layout_style);
 
-$navigation = isset($navigation) && is_array($navigation) ? $navigation : [];
 $sections = isset($sections) && is_array($sections) ? $sections : [];
-$has_navigation = ! empty($navigation);
 $has_highlights = ! empty($highlights);
 $has_inclusions = ! empty($inclusions) || ! empty($exclusions);
 $has_meeting = isset($meeting_points['primary']) && is_array($meeting_points['primary']);
@@ -489,24 +486,6 @@ $cta_label = esc_html__('Controlla disponibilità', 'fp-experiences');
                         <div class="fp-gift__success" data-fp-gift-success hidden></div>
                     </div>
                 </section>
-            <?php endif; ?>
-
-            <?php if ($has_navigation) : ?>
-                <nav class="fp-exp-page__nav" aria-label="<?php esc_attr_e('Experience sections', 'fp-experiences'); ?>">
-                    <ul class="fp-exp-page__nav-list">
-                        <?php foreach ($navigation as $item) : ?>
-                            <li class="fp-exp-page__nav-item">
-                                <button
-                                    type="button"
-                                    class="fp-exp-page__nav-button"
-                                    data-fp-scroll="<?php echo esc_attr($item['id']); ?>"
-                                >
-                                    <?php echo esc_html($item['label']); ?>
-                                </button>
-                            </li>
-                        <?php endforeach; ?>
-                    </ul>
-                </nav>
             <?php endif; ?>
 
             <?php if (! empty($sections['highlights']) && $has_highlights) : ?>

--- a/src/Shortcodes/ExperienceShortcode.php
+++ b/src/Shortcodes/ExperienceShortcode.php
@@ -286,93 +286,6 @@ final class ExperienceShortcode extends BaseShortcode
             $enabled_sections['overview'] = false;
         }
 
-        $sections_map = [
-            'hero' => [
-                'id' => 'hero',
-                'label' => esc_html__('Intro', 'fp-experiences'),
-            ],
-            'overview' => [
-                'id' => 'overview',
-                'label' => esc_html__('Overview', 'fp-experiences'),
-            ],
-            'gallery' => [
-                'id' => 'gallery',
-                'label' => esc_html__('Gallery', 'fp-experiences'),
-            ],
-            'highlights' => [
-                'id' => 'highlights',
-                'label' => esc_html__('Highlights', 'fp-experiences'),
-            ],
-            'inclusions' => [
-                'id' => 'inclusions',
-                'label' => esc_html__('What\'s included', 'fp-experiences'),
-            ],
-            'meeting' => [
-                'id' => 'meeting',
-                'label' => esc_html__('Meeting point', 'fp-experiences'),
-            ],
-            'extras' => [
-                'id' => 'extras',
-                'label' => esc_html__('Good to know', 'fp-experiences'),
-            ],
-            'faq' => [
-                'id' => 'faq',
-                'label' => esc_html__('FAQ', 'fp-experiences'),
-            ],
-            'reviews' => [
-                'id' => 'reviews',
-                'label' => esc_html__('Reviews', 'fp-experiences'),
-            ],
-        ];
-
-        $navigation = [];
-        foreach (self::ALLOWED_SECTIONS as $section_key) {
-            if (! $enabled_sections[$section_key] || empty($sections_map[$section_key])) {
-                continue;
-            }
-
-            if ('overview' === $section_key && ! $overview_has_content) {
-                continue;
-            }
-
-            if ('gallery' === $section_key) {
-                $valid_gallery = array_filter(
-                    $gallery,
-                    static fn ($image) => is_array($image) && ! empty($image['url'])
-                );
-
-                if (count($valid_gallery) < 2) {
-                    continue;
-                }
-            }
-
-            if ('highlights' === $section_key && empty($highlights)) {
-                continue;
-            }
-
-            if ('inclusions' === $section_key && empty($inclusions) && empty($exclusions)) {
-                continue;
-            }
-
-            if ('meeting' === $section_key && empty($meeting_data['primary'])) {
-                continue;
-            }
-
-            if ('extras' === $section_key && empty($what_to_bring) && empty($notes) && empty($policy)) {
-                continue;
-            }
-
-            if ('faq' === $section_key && empty($faq_items)) {
-                continue;
-            }
-
-            if ('reviews' === $section_key && empty($reviews)) {
-                continue;
-            }
-
-            $navigation[] = $sections_map[$section_key];
-        }
-
         $missing_meta = [];
 
         if ($enabled_sections['highlights'] && empty($highlights)) {
@@ -443,7 +356,6 @@ final class ExperienceShortcode extends BaseShortcode
             'faq' => $faq_items,
             'reviews' => $reviews,
             'sections' => $enabled_sections,
-            'navigation' => $navigation,
             'meeting_points' => $meeting_data,
             'sticky_widget' => $is_sticky_widget,
             'widget_html' => $widget_html,

--- a/templates/front/experience.php
+++ b/templates/front/experience.php
@@ -14,7 +14,6 @@
  * @var array<int, array<string, string>> $faq
  * @var array<int, array<string, mixed>> $reviews
  * @var array<string, bool> $sections
- * @var array<int, array<string, string>> $navigation
  * @var array{primary: ?array<string, mixed>, alternatives: array<int, array<string, mixed>>} $meeting_points
  * @var bool $sticky_widget
  * @var string $widget_html
@@ -72,9 +71,7 @@ if ($layout_gutter > 0) {
 
 $layout_style_attr = empty($layout_style) ? '' : implode(';', $layout_style);
 
-$navigation = isset($navigation) && is_array($navigation) ? $navigation : [];
 $sections = isset($sections) && is_array($sections) ? $sections : [];
-$has_navigation = ! empty($navigation);
 $has_highlights = ! empty($highlights);
 $has_inclusions = ! empty($inclusions) || ! empty($exclusions);
 $has_meeting = isset($meeting_points['primary']) && is_array($meeting_points['primary']);
@@ -489,24 +486,6 @@ $cta_label = esc_html__('Controlla disponibilità', 'fp-experiences');
                         <div class="fp-gift__success" data-fp-gift-success hidden></div>
                     </div>
                 </section>
-            <?php endif; ?>
-
-            <?php if ($has_navigation) : ?>
-                <nav class="fp-exp-page__nav" aria-label="<?php esc_attr_e('Experience sections', 'fp-experiences'); ?>">
-                    <ul class="fp-exp-page__nav-list">
-                        <?php foreach ($navigation as $item) : ?>
-                            <li class="fp-exp-page__nav-item">
-                                <button
-                                    type="button"
-                                    class="fp-exp-page__nav-button"
-                                    data-fp-scroll="<?php echo esc_attr($item['id']); ?>"
-                                >
-                                    <?php echo esc_html($item['label']); ?>
-                                </button>
-                            </li>
-                        <?php endforeach; ?>
-                    </ul>
-                </nav>
             <?php endif; ?>
 
             <?php if (! empty($sections['highlights']) && $has_highlights) : ?>


### PR DESCRIPTION
## Summary
- stop building the navigation dataset in the experience shortcode payload now that the navigation UI was removed
- mirror the same cleanup in the built plugin sources

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68de6b1b75a8832fb3e0df99751be826