### PR TITLE
Refine experience detail sections with structured layouts

### DIFF
--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -1886,7 +1886,7 @@
     gap: var(--fp-exp-spacing);
 }
 
-.fp-main > section {
+.fp-main > section:not(.fp-exp-section) {
     background: var(--fp-color-surface);
     border-radius: var(--fp-btn-radius, 12px);
     padding: clamp(16px, 2vw, 24px);
@@ -1900,150 +1900,70 @@
     max-width: none;
 }
 
-.fp-main > .fp-hero-section {
-    background: transparent;
-    padding: 0;
-    box-shadow: none;
-    border-radius: 0;
-    width: 100vw;
-    margin-inline: calc(50% - 50vw);
-}
 
-.fp-hero-section {
-    position: relative;
-    display: block;
-    padding-block: clamp(2rem, 6vw, 5rem) clamp(2.5rem, 8vw, 6rem);
-    box-sizing: border-box;
-    overflow: hidden;
-}
-
-.fp-hero-section::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background:
-        linear-gradient(180deg, rgba(15, 23, 42, 0.12) 0%, rgba(15, 23, 42, 0) 55%),
-        var(--fp-color-surface, #fff);
-    z-index: 0;
-}
-
-.fp-hero-section__inner {
-    display: flex;
-    flex-direction: column;
-    gap: clamp(1.75rem, 5vw, 3rem);
-    position: relative;
-    z-index: 1;
-    width: min(1200px, 100%);
-    margin: 0 auto;
-    padding-inline: clamp(16px, 6vw, 96px);
-    box-sizing: border-box;
-}
-
-.fp-hero-media {
-    position: relative;
+.fp-exp-section {
+    background: var(--fp-color-surface);
     border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
-    overflow: hidden;
-    min-height: clamp(200px, 32vw, 420px);
-    background: rgba(15, 23, 42, 0.1);
-    order: 2;
+    padding: clamp(1.5rem, 4vw, 3rem);
+    box-shadow: var(--fp-shadow);
 }
 
-.fp-hero-media__image {
+.fp-exp-hero {
+    padding: clamp(2.5rem, 6vw, 4rem);
+}
+
+.fp-exp-hero__layout {
+    display: grid;
+    gap: clamp(1.75rem, 5vw, 3rem);
+}
+
+.fp-exp-hero__primary {
+    display: grid;
+    gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.fp-exp-hero__media {
+    position: relative;
+    border-radius: clamp(1.25rem, 3vw, 2rem);
+    overflow: hidden;
+    background: rgba(15, 23, 42, 0.08);
+    aspect-ratio: 4 / 3;
+}
+
+.fp-exp-hero__media--placeholder {
+    display: grid;
+    place-items: center;
+    color: rgba(15, 23, 42, 0.4);
+}
+
+.fp-exp-hero__media--placeholder span {
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    background: currentColor;
+    opacity: 0.15;
+}
+
+.fp-exp-hero__image {
+    display: block;
     width: 100%;
     height: 100%;
     object-fit: cover;
-    display: block;
 }
 
-.fp-exp-gallery--placeholder {
-    position: relative;
-    width: 100%;
-    height: 100%;
-    min-height: 220px;
-    border-radius: 0;
-    overflow: hidden;
-}
-
-.fp-exp-gallery--placeholder span {
-    position: absolute;
-    inset: 0;
-    background: repeating-linear-gradient(
-        135deg,
-        rgba(255, 255, 255, 0.1) 0,
-        rgba(255, 255, 255, 0.1) 12px,
-        rgba(255, 255, 255, 0.2) 12px,
-        rgba(255, 255, 255, 0.2) 24px
-    );
-}
-
-.fp-hero-body {
-    background: var(--fp-color-surface);
-    border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
-    box-shadow: var(--fp-shadow);
-    padding: clamp(1.75rem, 4vw, 3rem);
+.fp-exp-hero__content {
     display: flex;
     flex-direction: column;
-    gap: 1.25rem;
-    max-width: min(720px, 100%);
-    align-self: flex-start;
-    order: 1;
+    gap: clamp(1.5rem, 3vw, 2.25rem);
 }
 
-.fp-exp-gift__body {
+.fp-exp-hero__header {
     display: flex;
     flex-direction: column;
-    gap: clamp(1rem, 3vw, 1.5rem);
-    align-items: flex-start;
+    gap: 0.75rem;
 }
 
-.fp-exp-gift__content {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    max-width: 48ch;
-}
-
-.fp-exp-gift__eyebrow {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.35rem 0.75rem;
-    border-radius: 999px;
-    background: rgba(139, 30, 63, 0.12);
-    color: #8b1e3f;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-}
-
-.fp-exp-gift__title {
-    font-size: clamp(1.5rem, 4vw, 2.25rem);
-    line-height: 1.1;
-    margin: 0;
-}
-
-.fp-exp-gift__description {
-    margin: 0;
-    color: rgba(15, 23, 42, 0.72);
-}
-
-@media (min-width: 768px) {
-    .fp-exp-gift__body {
-        flex-direction: row;
-        align-items: center;
-        justify-content: space-between;
-        gap: clamp(1.5rem, 4vw, 3rem);
-    }
-}
-
-.fp-hero-body__header {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-.fp-badge {
+.fp-exp-hero__eyebrow {
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
@@ -2053,79 +1973,139 @@
     color: var(--fp-color-primary);
     font-weight: 600;
     font-size: 0.75rem;
-    letter-spacing: 0.1em;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
 }
 
-.fp-eyebrow {
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.12em;
-    color: var(--fp-color-muted);
-}
-
-.fp-title {
+.fp-exp-hero__title {
     margin: 0;
-    font-size: clamp(28px, 3vw, 40px);
+    font-size: clamp(2.1rem, 2.6vw + 1rem, 3.35rem);
     line-height: 1.1;
-    color: var(--fp-color-text);
 }
 
-
-.fp-hero-highlights {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
+.fp-exp-hero__summary {
     margin: 0;
-    padding: 0;
-    list-style: none;
+    font-size: clamp(1.05rem, 0.6vw + 0.95rem, 1.3rem);
+    line-height: 1.6;
+    color: var(--fp-color-text-muted, rgba(15, 23, 42, 0.78));
 }
 
-.fp-hero-highlights__item {
-    padding: 0.35rem 0.75rem;
-    border-radius: 999px;
-    background: rgba(139, 30, 63, 0.12);
-    color: var(--fp-color-primary);
-    font-weight: 600;
-}
-
-.fp-hero-facts {
-    display: flex;
-    flex-wrap: wrap;
+.fp-exp-hero__highlights {
+    display: grid;
     gap: 0.75rem;
     margin: 0;
     padding: 0;
     list-style: none;
 }
 
-.fp-hero-facts__item {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.9rem;
-    border-radius: 999px;
+.fp-exp-hero__highlight {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.65rem;
+    padding: 0.75rem 1rem;
+    border-radius: clamp(0.9rem, 2vw, 1.25rem);
     background: rgba(15, 23, 42, 0.06);
-    color: var(--fp-color-text);
-}
-
-.fp-hero-facts__icon {
-    display: inline-flex;
-    width: 1.25rem;
-    height: 1.25rem;
-    align-items: center;
-    justify-content: center;
-    color: var(--fp-color-primary);
-}
-
-.fp-hero-facts__text {
     font-weight: 600;
 }
 
+.fp-exp-hero__highlight-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.1rem;
+    height: 1.1rem;
+    color: var(--fp-color-primary);
+    flex-shrink: 0;
+}
+
+.fp-exp-hero__highlight-text {
+    line-height: 1.5;
+}
+
+.fp-exp-hero__sidebar {
+    display: flex;
+    align-items: stretch;
+}
+
+.fp-exp-hero__card {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.25rem, 3vw, 1.75rem);
+    padding: clamp(1.75rem, 4vw, 2.5rem);
+    border-radius: clamp(1.25rem, 3vw, 1.75rem);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    background: linear-gradient(135deg, rgba(139, 30, 63, 0.08), rgba(15, 23, 42, 0.02));
+    box-shadow: 0 30px 70px -40px rgba(15, 23, 42, 0.45);
+}
+
+.fp-exp-hero__price {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.75rem 1.1rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.75);
+    color: var(--fp-color-primary);
+    font-weight: 600;
+}
+
+.fp-exp-hero__price-label {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.fp-exp-hero__price-value {
+    font-size: clamp(1.45rem, 1vw + 1.2rem, 2rem);
+}
+
+.fp-exp-hero__actions {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.fp-exp-hero__facts {
+    display: grid;
+    gap: 0.85rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.fp-exp-hero__fact {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.65rem 0.85rem;
+    border-radius: clamp(0.85rem, 2vw, 1.1rem);
+    background: rgba(255, 255, 255, 0.65);
+    color: var(--fp-color-text);
+    backdrop-filter: blur(6px);
+}
+
+.fp-exp-hero__fact-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.4rem;
+    height: 1.4rem;
+    color: var(--fp-color-primary);
+    flex-shrink: 0;
+}
+
+.fp-exp-hero__fact-text {
+    font-weight: 600;
+    line-height: 1.4;
+}
+
+
+
 .fp-exp-overview {
-    background: var(--fp-color-surface);
-    border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
-    box-shadow: var(--fp-shadow);
-    padding: clamp(1.75rem, 4vw, 2.75rem);
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.5rem, 3vw, 2.25rem);
 }
 
 .fp-exp-overview__grid {
@@ -2172,6 +2152,14 @@
     list-style: none;
     margin: 0;
     padding: 0;
+}
+
+.fp-exp-overview__summary {
+    margin: 0;
+    color: var(--fp-color-text);
+    font-size: 1.05rem;
+    line-height: 1.6;
+    max-width: 58ch;
 }
 
 
@@ -2733,6 +2721,21 @@
     scroll-margin-top: 96px;
 }
 
+.fp-exp-section__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-bottom: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.fp-exp-section__eyebrow {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--fp-color-muted);
+    font-weight: 600;
+}
+
 .fp-exp-section__title {
     margin: 0 0 1rem;
     font-size: clamp(1.5rem, 3vw, 2rem);
@@ -2744,19 +2747,21 @@
     color: var(--fp-color-muted);
 }
 
-.fp-exp-columns {
+.fp-exp-section__summary {
+    margin: 0;
+    color: var(--fp-color-text-muted, rgba(15, 23, 42, 0.72));
+    line-height: 1.6;
+    max-width: 60ch;
+}
+
+.fp-exp-section__body {
     display: grid;
-    gap: 1.5rem;
+    gap: clamp(1.25rem, 3vw, 2rem);
 }
 
-.fp-exp-columns--stack {
-    gap: clamp(1rem, 3vw, 2rem);
-}
-
-.fp-exp-column__title {
-    margin: 0 0 0.75rem;
-    font-size: 1.125rem;
-    color: var(--fp-color-text);
+.fp-exp-section__body--flush {
+    gap: clamp(1rem, 2vw, 1.5rem);
+    padding: 0;
 }
 
 .fp-exp-list {
@@ -2774,24 +2779,156 @@
     line-height: 1.5;
 }
 
-.fp-exp-icon--check,
-.fp-exp-icon--cross {
-    width: 1rem;
-    height: 1rem;
-    margin-top: 0.25rem;
+.fp-exp-highlights__list {
+    display: grid;
+    gap: clamp(1rem, 2.5vw, 1.5rem);
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    list-style: none;
+    margin: 0;
+    padding: 0;
 }
 
-.fp-exp-icon--check {
-    color: var(--fp-exp-color-success, #1B998B);
+.fp-exp-highlights__item {
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+    padding: 1rem 1.25rem;
+    border-radius: 18px;
+    background: rgba(15, 23, 42, 0.05);
+    line-height: 1.5;
 }
 
-.fp-exp-icon--cross {
-    color: var(--fp-exp-color-danger, #C44536);
+.fp-exp-highlights__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--fp-color-primary) 15%, #fff);
+    color: var(--fp-color-primary);
+    flex-shrink: 0;
 }
 
-.fp-exp-paragraph {
+.fp-exp-highlights__icon svg {
+    width: 18px;
+    height: 18px;
+}
+
+.fp-exp-highlights__text {
+    font-weight: 600;
+    color: var(--fp-color-text);
+}
+
+.fp-exp-inclusions__grid {
+    display: grid;
+    gap: clamp(1.5rem, 3vw, 2rem);
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.fp-exp-inclusions__column {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: clamp(1.25rem, 3vw, 1.75rem);
+    border-radius: 20px;
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    background: rgba(15, 23, 42, 0.02);
+}
+
+.fp-exp-inclusions__title {
+    margin: 0;
+    font-size: 1.125rem;
+    color: var(--fp-color-text);
+}
+
+.fp-exp-inclusions__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.85rem;
+}
+
+.fp-exp-inclusions__item {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    line-height: 1.6;
+}
+
+.fp-exp-inclusions__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 999px;
+    flex-shrink: 0;
+}
+
+.fp-exp-inclusions__icon svg {
+    width: 16px;
+    height: 16px;
+}
+
+.fp-exp-inclusions__icon--check {
+    background: rgba(27, 153, 139, 0.18);
+    color: #1B998B;
+}
+
+.fp-exp-inclusions__icon--cross {
+    background: rgba(196, 69, 54, 0.18);
+    color: #C44536;
+}
+
+.fp-exp-inclusions__text {
+    color: var(--fp-color-text);
+}
+
+.fp-exp-essentials__grid {
+    display: grid;
+    gap: clamp(1.5rem, 3vw, 2rem);
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.fp-exp-essentials__card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: clamp(1.25rem, 3vw, 1.75rem);
+    border-radius: 20px;
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    background: rgba(15, 23, 42, 0.02);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.fp-exp-essentials__title {
+    margin: 0;
+    font-size: 1.125rem;
+    color: var(--fp-color-text);
+}
+
+.fp-exp-essentials__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.fp-exp-essentials__item {
+    line-height: 1.6;
+}
+
+.fp-exp-essentials__copy {
     margin: 0;
     line-height: 1.6;
+    color: var(--fp-color-text);
+}
+
+.fp-exp-essentials__copy--rich .fp-exp-richtext {
+    margin: 0;
 }
 
 .fp-exp-richtext {
@@ -3016,12 +3153,17 @@
         align-self: start;
     }
 
-    .fp-hero-section {
-        grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+    .fp-exp-hero__layout {
+        grid-template-columns: minmax(0, 1.25fr) minmax(0, 0.85fr);
+        align-items: start;
+    }
+
+    .fp-exp-hero__primary {
+        grid-template-columns: minmax(0, 1fr) minmax(0, 0.95fr);
         align-items: stretch;
     }
 
-    .fp-hero-media__primary {
+    .fp-exp-hero__media {
         min-height: 100%;
     }
 
@@ -3057,13 +3199,22 @@
         --fp-exp-spacing: clamp(24px, 2vw, 32px);
     }
 
-    .fp-main > section {
+    .fp-main > section:not(.fp-exp-section) {
         padding: clamp(24px, 2.5vw, 36px);
     }
 
-    .fp-hero {
-        grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
-        grid-auto-rows: 220px;
+    .fp-exp-hero__layout {
+        grid-template-columns: minmax(0, 1.35fr) minmax(0, 0.9fr);
+    }
+
+    .fp-exp-hero__primary {
+        grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+        gap: clamp(1.75rem, 3vw, 2.75rem);
+    }
+
+    .fp-exp-hero__media {
+        aspect-ratio: auto;
+        min-height: 460px;
     }
 }
 

--- a/build/fp-experiences/assets/css/front.css
+++ b/build/fp-experiences/assets/css/front.css
@@ -1886,7 +1886,7 @@
     gap: var(--fp-exp-spacing);
 }
 
-.fp-main > section {
+.fp-main > section:not(.fp-exp-section) {
     background: var(--fp-color-surface);
     border-radius: var(--fp-btn-radius, 12px);
     padding: clamp(16px, 2vw, 24px);
@@ -1900,150 +1900,70 @@
     max-width: none;
 }
 
-.fp-main > .fp-hero-section {
-    background: transparent;
-    padding: 0;
-    box-shadow: none;
-    border-radius: 0;
-    width: 100vw;
-    margin-inline: calc(50% - 50vw);
-}
 
-.fp-hero-section {
-    position: relative;
-    display: block;
-    padding-block: clamp(2rem, 6vw, 5rem) clamp(2.5rem, 8vw, 6rem);
-    box-sizing: border-box;
-    overflow: hidden;
-}
-
-.fp-hero-section::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background:
-        linear-gradient(180deg, rgba(15, 23, 42, 0.12) 0%, rgba(15, 23, 42, 0) 55%),
-        var(--fp-color-surface, #fff);
-    z-index: 0;
-}
-
-.fp-hero-section__inner {
-    display: flex;
-    flex-direction: column;
-    gap: clamp(1.75rem, 5vw, 3rem);
-    position: relative;
-    z-index: 1;
-    width: min(1200px, 100%);
-    margin: 0 auto;
-    padding-inline: clamp(16px, 6vw, 96px);
-    box-sizing: border-box;
-}
-
-.fp-hero-media {
-    position: relative;
+.fp-exp-section {
+    background: var(--fp-color-surface);
     border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
-    overflow: hidden;
-    min-height: clamp(200px, 32vw, 420px);
-    background: rgba(15, 23, 42, 0.1);
-    order: 2;
+    padding: clamp(1.5rem, 4vw, 3rem);
+    box-shadow: var(--fp-shadow);
 }
 
-.fp-hero-media__image {
+.fp-exp-hero {
+    padding: clamp(2.5rem, 6vw, 4rem);
+}
+
+.fp-exp-hero__layout {
+    display: grid;
+    gap: clamp(1.75rem, 5vw, 3rem);
+}
+
+.fp-exp-hero__primary {
+    display: grid;
+    gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.fp-exp-hero__media {
+    position: relative;
+    border-radius: clamp(1.25rem, 3vw, 2rem);
+    overflow: hidden;
+    background: rgba(15, 23, 42, 0.08);
+    aspect-ratio: 4 / 3;
+}
+
+.fp-exp-hero__media--placeholder {
+    display: grid;
+    place-items: center;
+    color: rgba(15, 23, 42, 0.4);
+}
+
+.fp-exp-hero__media--placeholder span {
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    background: currentColor;
+    opacity: 0.15;
+}
+
+.fp-exp-hero__image {
+    display: block;
     width: 100%;
     height: 100%;
     object-fit: cover;
-    display: block;
 }
 
-.fp-exp-gallery--placeholder {
-    position: relative;
-    width: 100%;
-    height: 100%;
-    min-height: 220px;
-    border-radius: 0;
-    overflow: hidden;
-}
-
-.fp-exp-gallery--placeholder span {
-    position: absolute;
-    inset: 0;
-    background: repeating-linear-gradient(
-        135deg,
-        rgba(255, 255, 255, 0.1) 0,
-        rgba(255, 255, 255, 0.1) 12px,
-        rgba(255, 255, 255, 0.2) 12px,
-        rgba(255, 255, 255, 0.2) 24px
-    );
-}
-
-.fp-hero-body {
-    background: var(--fp-color-surface);
-    border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
-    box-shadow: var(--fp-shadow);
-    padding: clamp(1.75rem, 4vw, 3rem);
+.fp-exp-hero__content {
     display: flex;
     flex-direction: column;
-    gap: 1.25rem;
-    max-width: min(720px, 100%);
-    align-self: flex-start;
-    order: 1;
+    gap: clamp(1.5rem, 3vw, 2.25rem);
 }
 
-.fp-exp-gift__body {
+.fp-exp-hero__header {
     display: flex;
     flex-direction: column;
-    gap: clamp(1rem, 3vw, 1.5rem);
-    align-items: flex-start;
+    gap: 0.75rem;
 }
 
-.fp-exp-gift__content {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    max-width: 48ch;
-}
-
-.fp-exp-gift__eyebrow {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.35rem 0.75rem;
-    border-radius: 999px;
-    background: rgba(139, 30, 63, 0.12);
-    color: #8b1e3f;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-}
-
-.fp-exp-gift__title {
-    font-size: clamp(1.5rem, 4vw, 2.25rem);
-    line-height: 1.1;
-    margin: 0;
-}
-
-.fp-exp-gift__description {
-    margin: 0;
-    color: rgba(15, 23, 42, 0.72);
-}
-
-@media (min-width: 768px) {
-    .fp-exp-gift__body {
-        flex-direction: row;
-        align-items: center;
-        justify-content: space-between;
-        gap: clamp(1.5rem, 4vw, 3rem);
-    }
-}
-
-.fp-hero-body__header {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-.fp-badge {
+.fp-exp-hero__eyebrow {
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
@@ -2053,79 +1973,139 @@
     color: var(--fp-color-primary);
     font-weight: 600;
     font-size: 0.75rem;
-    letter-spacing: 0.1em;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
 }
 
-.fp-eyebrow {
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.12em;
-    color: var(--fp-color-muted);
-}
-
-.fp-title {
+.fp-exp-hero__title {
     margin: 0;
-    font-size: clamp(28px, 3vw, 40px);
+    font-size: clamp(2.1rem, 2.6vw + 1rem, 3.35rem);
     line-height: 1.1;
-    color: var(--fp-color-text);
 }
 
-
-.fp-hero-highlights {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
+.fp-exp-hero__summary {
     margin: 0;
-    padding: 0;
-    list-style: none;
+    font-size: clamp(1.05rem, 0.6vw + 0.95rem, 1.3rem);
+    line-height: 1.6;
+    color: var(--fp-color-text-muted, rgba(15, 23, 42, 0.78));
 }
 
-.fp-hero-highlights__item {
-    padding: 0.35rem 0.75rem;
-    border-radius: 999px;
-    background: rgba(139, 30, 63, 0.12);
-    color: var(--fp-color-primary);
-    font-weight: 600;
-}
-
-.fp-hero-facts {
-    display: flex;
-    flex-wrap: wrap;
+.fp-exp-hero__highlights {
+    display: grid;
     gap: 0.75rem;
     margin: 0;
     padding: 0;
     list-style: none;
 }
 
-.fp-hero-facts__item {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.9rem;
-    border-radius: 999px;
+.fp-exp-hero__highlight {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.65rem;
+    padding: 0.75rem 1rem;
+    border-radius: clamp(0.9rem, 2vw, 1.25rem);
     background: rgba(15, 23, 42, 0.06);
-    color: var(--fp-color-text);
-}
-
-.fp-hero-facts__icon {
-    display: inline-flex;
-    width: 1.25rem;
-    height: 1.25rem;
-    align-items: center;
-    justify-content: center;
-    color: var(--fp-color-primary);
-}
-
-.fp-hero-facts__text {
     font-weight: 600;
 }
 
+.fp-exp-hero__highlight-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.1rem;
+    height: 1.1rem;
+    color: var(--fp-color-primary);
+    flex-shrink: 0;
+}
+
+.fp-exp-hero__highlight-text {
+    line-height: 1.5;
+}
+
+.fp-exp-hero__sidebar {
+    display: flex;
+    align-items: stretch;
+}
+
+.fp-exp-hero__card {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.25rem, 3vw, 1.75rem);
+    padding: clamp(1.75rem, 4vw, 2.5rem);
+    border-radius: clamp(1.25rem, 3vw, 1.75rem);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    background: linear-gradient(135deg, rgba(139, 30, 63, 0.08), rgba(15, 23, 42, 0.02));
+    box-shadow: 0 30px 70px -40px rgba(15, 23, 42, 0.45);
+}
+
+.fp-exp-hero__price {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.75rem 1.1rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.75);
+    color: var(--fp-color-primary);
+    font-weight: 600;
+}
+
+.fp-exp-hero__price-label {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.fp-exp-hero__price-value {
+    font-size: clamp(1.45rem, 1vw + 1.2rem, 2rem);
+}
+
+.fp-exp-hero__actions {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.fp-exp-hero__facts {
+    display: grid;
+    gap: 0.85rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.fp-exp-hero__fact {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.65rem 0.85rem;
+    border-radius: clamp(0.85rem, 2vw, 1.1rem);
+    background: rgba(255, 255, 255, 0.65);
+    color: var(--fp-color-text);
+    backdrop-filter: blur(6px);
+}
+
+.fp-exp-hero__fact-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.4rem;
+    height: 1.4rem;
+    color: var(--fp-color-primary);
+    flex-shrink: 0;
+}
+
+.fp-exp-hero__fact-text {
+    font-weight: 600;
+    line-height: 1.4;
+}
+
+
+
 .fp-exp-overview {
-    background: var(--fp-color-surface);
-    border-radius: var(--fp-exp-radius-large, calc(var(--fp-exp-radius-base, 12px) * 1.4));
-    box-shadow: var(--fp-shadow);
-    padding: clamp(1.75rem, 4vw, 2.75rem);
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.5rem, 3vw, 2.25rem);
 }
 
 .fp-exp-overview__grid {
@@ -2172,6 +2152,14 @@
     list-style: none;
     margin: 0;
     padding: 0;
+}
+
+.fp-exp-overview__summary {
+    margin: 0;
+    color: var(--fp-color-text);
+    font-size: 1.05rem;
+    line-height: 1.6;
+    max-width: 58ch;
 }
 
 
@@ -2733,6 +2721,21 @@
     scroll-margin-top: 96px;
 }
 
+.fp-exp-section__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-bottom: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.fp-exp-section__eyebrow {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--fp-color-muted);
+    font-weight: 600;
+}
+
 .fp-exp-section__title {
     margin: 0 0 1rem;
     font-size: clamp(1.5rem, 3vw, 2rem);
@@ -2744,19 +2747,21 @@
     color: var(--fp-color-muted);
 }
 
-.fp-exp-columns {
+.fp-exp-section__summary {
+    margin: 0;
+    color: var(--fp-color-text-muted, rgba(15, 23, 42, 0.72));
+    line-height: 1.6;
+    max-width: 60ch;
+}
+
+.fp-exp-section__body {
     display: grid;
-    gap: 1.5rem;
+    gap: clamp(1.25rem, 3vw, 2rem);
 }
 
-.fp-exp-columns--stack {
-    gap: clamp(1rem, 3vw, 2rem);
-}
-
-.fp-exp-column__title {
-    margin: 0 0 0.75rem;
-    font-size: 1.125rem;
-    color: var(--fp-color-text);
+.fp-exp-section__body--flush {
+    gap: clamp(1rem, 2vw, 1.5rem);
+    padding: 0;
 }
 
 .fp-exp-list {
@@ -2774,24 +2779,156 @@
     line-height: 1.5;
 }
 
-.fp-exp-icon--check,
-.fp-exp-icon--cross {
-    width: 1rem;
-    height: 1rem;
-    margin-top: 0.25rem;
+.fp-exp-highlights__list {
+    display: grid;
+    gap: clamp(1rem, 2.5vw, 1.5rem);
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    list-style: none;
+    margin: 0;
+    padding: 0;
 }
 
-.fp-exp-icon--check {
-    color: var(--fp-exp-color-success, #1B998B);
+.fp-exp-highlights__item {
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+    padding: 1rem 1.25rem;
+    border-radius: 18px;
+    background: rgba(15, 23, 42, 0.05);
+    line-height: 1.5;
 }
 
-.fp-exp-icon--cross {
-    color: var(--fp-exp-color-danger, #C44536);
+.fp-exp-highlights__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--fp-color-primary) 15%, #fff);
+    color: var(--fp-color-primary);
+    flex-shrink: 0;
 }
 
-.fp-exp-paragraph {
+.fp-exp-highlights__icon svg {
+    width: 18px;
+    height: 18px;
+}
+
+.fp-exp-highlights__text {
+    font-weight: 600;
+    color: var(--fp-color-text);
+}
+
+.fp-exp-inclusions__grid {
+    display: grid;
+    gap: clamp(1.5rem, 3vw, 2rem);
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.fp-exp-inclusions__column {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: clamp(1.25rem, 3vw, 1.75rem);
+    border-radius: 20px;
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    background: rgba(15, 23, 42, 0.02);
+}
+
+.fp-exp-inclusions__title {
+    margin: 0;
+    font-size: 1.125rem;
+    color: var(--fp-color-text);
+}
+
+.fp-exp-inclusions__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.85rem;
+}
+
+.fp-exp-inclusions__item {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    line-height: 1.6;
+}
+
+.fp-exp-inclusions__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 999px;
+    flex-shrink: 0;
+}
+
+.fp-exp-inclusions__icon svg {
+    width: 16px;
+    height: 16px;
+}
+
+.fp-exp-inclusions__icon--check {
+    background: rgba(27, 153, 139, 0.18);
+    color: #1B998B;
+}
+
+.fp-exp-inclusions__icon--cross {
+    background: rgba(196, 69, 54, 0.18);
+    color: #C44536;
+}
+
+.fp-exp-inclusions__text {
+    color: var(--fp-color-text);
+}
+
+.fp-exp-essentials__grid {
+    display: grid;
+    gap: clamp(1.5rem, 3vw, 2rem);
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.fp-exp-essentials__card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: clamp(1.25rem, 3vw, 1.75rem);
+    border-radius: 20px;
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    background: rgba(15, 23, 42, 0.02);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.fp-exp-essentials__title {
+    margin: 0;
+    font-size: 1.125rem;
+    color: var(--fp-color-text);
+}
+
+.fp-exp-essentials__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.fp-exp-essentials__item {
+    line-height: 1.6;
+}
+
+.fp-exp-essentials__copy {
     margin: 0;
     line-height: 1.6;
+    color: var(--fp-color-text);
+}
+
+.fp-exp-essentials__copy--rich .fp-exp-richtext {
+    margin: 0;
 }
 
 .fp-exp-richtext {
@@ -3016,12 +3153,17 @@
         align-self: start;
     }
 
-    .fp-hero-section {
-        grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+    .fp-exp-hero__layout {
+        grid-template-columns: minmax(0, 1.25fr) minmax(0, 0.85fr);
+        align-items: start;
+    }
+
+    .fp-exp-hero__primary {
+        grid-template-columns: minmax(0, 1fr) minmax(0, 0.95fr);
         align-items: stretch;
     }
 
-    .fp-hero-media__primary {
+    .fp-exp-hero__media {
         min-height: 100%;
     }
 
@@ -3057,13 +3199,22 @@
         --fp-exp-spacing: clamp(24px, 2vw, 32px);
     }
 
-    .fp-main > section {
+    .fp-main > section:not(.fp-exp-section) {
         padding: clamp(24px, 2.5vw, 36px);
     }
 
-    .fp-hero {
-        grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
-        grid-auto-rows: 220px;
+    .fp-exp-hero__layout {
+        grid-template-columns: minmax(0, 1.35fr) minmax(0, 0.9fr);
+    }
+
+    .fp-exp-hero__primary {
+        grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+        gap: clamp(1.75rem, 3vw, 2.75rem);
+    }
+
+    .fp-exp-hero__media {
+        aspect-ratio: auto;
+        min-height: 460px;
     }
 }
 

--- a/build/fp-experiences/templates/front/experience.php
+++ b/build/fp-experiences/templates/front/experience.php
@@ -194,65 +194,104 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
         </script>
     <?php endif; ?>
 
-    <div class="fp-grid" data-fp-page>
-        <main class="fp-main">
+    <div class="fp-grid fp-exp-page__layout" data-fp-page>
+        <main class="fp-main fp-exp-page__main">
             <?php if (! empty($sections['hero'])) : ?>
-                <section class="fp-section fp-hero-section" id="fp-exp-section-hero" data-fp-section="hero">
-                    <div class="fp-hero-section__inner">
-                        <div class="fp-hero-media" aria-hidden="<?php echo null === $primary_image ? 'true' : 'false'; ?>">
+                <section class="fp-exp-section fp-exp-hero" id="fp-exp-section-hero" data-fp-section="hero">
+                    <div class="fp-exp-hero__layout">
+                        <div class="fp-exp-hero__primary">
                             <?php if ($primary_image) : ?>
-                                <img
-                                    class="fp-hero-media__image"
-                                    src="<?php echo esc_url($primary_image['url']); ?>"
-                                    <?php if (! empty($primary_image['srcset'])) : ?>srcset="<?php echo esc_attr($primary_image['srcset']); ?>"<?php endif; ?>
-                                    sizes="100vw"
-                                    <?php if (! empty($primary_image['width'])) : ?>width="<?php echo esc_attr((string) $primary_image['width']); ?>"<?php endif; ?>
-                                    <?php if (! empty($primary_image['height'])) : ?>height="<?php echo esc_attr((string) $primary_image['height']); ?>"<?php endif; ?>
-                                    alt="<?php echo esc_attr($experience['title']); ?>"
-                                    loading="eager"
-                                    decoding="async"
-                                    fetchpriority="high"
-                                />
+                                <figure class="fp-exp-hero__media">
+                                    <img
+                                        class="fp-exp-hero__image"
+                                        src="<?php echo esc_url($primary_image['url']); ?>"
+                                        <?php if (! empty($primary_image['srcset'])) : ?>srcset="<?php echo esc_attr($primary_image['srcset']); ?>"<?php endif; ?>
+                                        sizes="(min-width: 1280px) 640px, (min-width: 768px) 60vw, 100vw"
+                                        <?php if (! empty($primary_image['width'])) : ?>width="<?php echo esc_attr((string) $primary_image['width']); ?>"<?php endif; ?>
+                                        <?php if (! empty($primary_image['height'])) : ?>height="<?php echo esc_attr((string) $primary_image['height']); ?>"<?php endif; ?>
+                                        alt="<?php echo esc_attr($experience['title']); ?>"
+                                        loading="eager"
+                                        decoding="async"
+                                        fetchpriority="high"
+                                    />
+                                </figure>
                             <?php else : ?>
-                                <div class="fp-hero fp-exp-gallery fp-exp-gallery--placeholder">
-                                    <span aria-hidden="true"></span>
+                                <div class="fp-exp-hero__media fp-exp-hero__media--placeholder" aria-hidden="true">
+                                    <span></span>
                                 </div>
                             <?php endif; ?>
-                        </div>
-                        <div class="fp-hero-body">
-                            <div class="fp-hero-body__header">
-                                <div class="fp-eyebrow">
-                                    <span class="fp-badge">FP Experiences</span>
-                                </div>
-                                <h1 class="fp-title"><?php echo esc_html($experience['title']); ?></h1>
+
+                            <div class="fp-exp-hero__content">
+                                <header class="fp-exp-hero__header">
+                                    <span class="fp-exp-hero__eyebrow">FP Experiences</span>
+                                    <h1 class="fp-exp-hero__title"><?php echo esc_html($experience['title']); ?></h1>
+                                    <?php if ('' !== $hero_summary) : ?>
+                                        <p class="fp-exp-hero__summary"><?php echo esc_html($hero_summary); ?></p>
+                                    <?php endif; ?>
+                                </header>
+
+                                <?php if (! empty($hero_highlights)) : ?>
+                                    <ul class="fp-exp-hero__highlights" role="list">
+                                        <?php foreach ($hero_highlights as $highlight) : ?>
+                                            <li class="fp-exp-hero__highlight">
+                                                <span class="fp-exp-hero__highlight-icon" aria-hidden="true">
+                                                    <svg viewBox="0 0 24 24"><path fill="currentColor" d="M9.75 18.25 3.5 12l1.41-1.41 4.84 4.84 9.34-9.34L20.5 7.5Z"/></svg>
+                                                </span>
+                                                <span class="fp-exp-hero__highlight-text"><?php echo esc_html($highlight); ?></span>
+                                            </li>
+                                        <?php endforeach; ?>
+                                    </ul>
+                                <?php endif; ?>
                             </div>
-                            <?php if ('' !== $hero_summary) : ?>
-                                <p class="fp-summary"><?php echo esc_html($hero_summary); ?></p>
-                            <?php endif; ?>
-                            <?php if (! empty($hero_highlights)) : ?>
-                                <ul class="fp-hero-highlights" role="list">
-                                    <?php foreach ($hero_highlights as $highlight) : ?>
-                                        <li class="fp-hero-highlights__item"><?php echo esc_html($highlight); ?></li>
-                                    <?php endforeach; ?>
-                                </ul>
-                            <?php endif; ?>
-                            <?php if (! empty($hero_fact_badges)) : ?>
-                                <ul class="fp-hero-facts" role="list">
-                                    <?php foreach ($hero_fact_badges as $badge) : ?>
-                                        <li class="fp-hero-facts__item">
-                                                <span class="fp-hero-facts__icon" aria-hidden="true">
+                        </div>
+
+                        <aside class="fp-exp-hero__sidebar">
+                            <div class="fp-exp-hero__card">
+                                <?php if ('' !== $sticky_price_display) : ?>
+                                    <div class="fp-exp-hero__price" data-fp-scroll-target="calendar">
+                                        <span class="fp-exp-hero__price-label"><?php esc_html_e('From', 'fp-experiences'); ?></span>
+                                        <span class="fp-exp-hero__price-value"><?php echo esc_html($sticky_price_display); ?></span>
+                                    </div>
+                                <?php endif; ?>
+
+                                <div class="fp-exp-hero__actions">
+                                    <button
+                                        type="button"
+                                        class="fp-exp-button fp-exp-button--primary"
+                                        data-fp-scroll="calendar"
+                                        data-fp-cta="hero"
+                                    >
+                                        <?php echo $cta_label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                                    </button>
+                                    <?php if ($show_gallery) : ?>
+                                        <button
+                                            type="button"
+                                            class="fp-exp-button fp-exp-button--secondary"
+                                            data-fp-scroll="gallery"
+                                        >
+                                            <?php esc_html_e('View gallery', 'fp-experiences'); ?>
+                                        </button>
+                                    <?php endif; ?>
+                                </div>
+
+                                <?php if (! empty($hero_fact_badges)) : ?>
+                                    <ul class="fp-exp-hero__facts" role="list">
+                                        <?php foreach ($hero_fact_badges as $badge) : ?>
+                                            <li class="fp-exp-hero__fact">
+                                                <span class="fp-exp-hero__fact-icon" aria-hidden="true">
                                                     <?php if ('clock' === ($badge['icon'] ?? '')) : ?>
                                                         <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm1 10.59 2.12 2.12-1.41 1.41-2.83-2.83V7h2.12Z"/></svg>
                                                     <?php else : ?>
                                                         <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M12 12.88 9.17 10H5a3 3 0 0 0-3 3v7h6v-4h2v4h6v-7a3 3 0 0 0-3-3h-1.17Zm9-2.88a4 4 0 1 0-4-4 4 4 0 0 0 4 4Z"/></svg>
                                                     <?php endif; ?>
                                                 </span>
-                                                <span class="fp-hero-facts__text"><?php echo esc_html((string) ($badge['label'] ?? '')); ?></span>
-                                        </li>
-                                    <?php endforeach; ?>
-                                </ul>
-                            <?php endif; ?>
-                        </div>
+                                                <span class="fp-exp-hero__fact-text"><?php echo esc_html((string) ($badge['label'] ?? '')); ?></span>
+                                            </li>
+                                        <?php endforeach; ?>
+                                    </ul>
+                                <?php endif; ?>
+                            </div>
+                        </aside>
                     </div>
                 </section>
             <?php endif; ?>
@@ -278,6 +317,16 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
 
             <?php if ($has_overview) : ?>
                 <section class="fp-exp-section fp-exp-overview" id="fp-exp-section-overview" data-fp-section="overview">
+                    <header class="fp-exp-section__header fp-exp-overview__header">
+                        <span class="fp-exp-section__eyebrow"><?php esc_html_e('Overview', 'fp-experiences'); ?></span>
+                        <h2 class="fp-exp-section__title"><?php esc_html_e('Key details at a glance', 'fp-experiences'); ?></h2>
+                        <?php if ('' !== $overview_short_description) : ?>
+                            <p class="fp-exp-overview__summary"><?php echo esc_html($overview_short_description); ?></p>
+                        <?php elseif ('' !== $hero_summary) : ?>
+                            <p class="fp-exp-overview__summary"><?php echo esc_html($hero_summary); ?></p>
+                        <?php endif; ?>
+                    </header>
+
                     <div class="fp-exp-overview__grid">
                         <?php if (! empty($overview_themes)) : ?>
                             <div class="fp-exp-overview__item">
@@ -287,13 +336,6 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
                                         <span class="fp-exp-overview__chip"><?php echo esc_html((string) $theme); ?></span>
                                     <?php endforeach; ?>
                                 </div>
-                            </div>
-                        <?php endif; ?>
-
-                        <?php if ('' !== $overview_short_description) : ?>
-                            <div class="fp-exp-overview__item">
-                                <span class="fp-exp-overview__label"><?php esc_html_e('Descrizione breve', 'fp-experiences'); ?></span>
-                                <span class="fp-exp-overview__value"><?php echo esc_html($overview_short_description); ?></span>
                             </div>
                         <?php endif; ?>
 
@@ -394,6 +436,10 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
 
             <?php if ($show_gallery) : ?>
                 <section class="fp-exp-section fp-exp-gallery" id="fp-exp-section-gallery" data-fp-section="gallery">
+                    <header class="fp-exp-section__header">
+                        <span class="fp-exp-section__eyebrow"><?php esc_html_e('Gallery', 'fp-experiences'); ?></span>
+                        <h2 class="fp-exp-section__title"><?php esc_html_e('A glimpse of the experience', 'fp-experiences'); ?></h2>
+                    </header>
                     <div class="fp-exp-gallery__track" role="list">
                         <?php foreach ($gallery_items as $index => $image) :
                             $url = isset($image['url']) ? (string) $image['url'] : '';
@@ -434,7 +480,7 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
 
             <?php if ($gift_enabled) : ?>
                 <section
-                    class="fp-section fp-gift"
+                    class="fp-exp-section fp-gift"
                     id="fp-exp-gift"
                     data-fp-gift
                     data-fp-gift-config="<?php echo esc_attr(wp_json_encode($gift_config)); ?>"
@@ -509,113 +555,142 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
             <?php endif; ?>
 
             <?php if (! empty($sections['highlights']) && $has_highlights) : ?>
-                <section class="fp-exp-section" id="fp-exp-section-highlights" data-fp-section="highlights">
-                    <h2 class="fp-exp-section__title"><?php esc_html_e('Highlights', 'fp-experiences'); ?></h2>
-                    <ul class="fp-exp-list" role="list">
-                        <?php foreach ($highlights as $highlight) : ?>
-                            <li class="fp-exp-list__item"><?php echo esc_html($highlight); ?></li>
-                        <?php endforeach; ?>
-                    </ul>
+                <section class="fp-exp-section fp-exp-highlights" id="fp-exp-section-highlights" data-fp-section="highlights">
+                    <header class="fp-exp-section__header">
+                        <span class="fp-exp-section__eyebrow"><?php esc_html_e('Highlights', 'fp-experiences'); ?></span>
+                        <h2 class="fp-exp-section__title"><?php esc_html_e('What makes this experience special', 'fp-experiences'); ?></h2>
+                    </header>
+                    <div class="fp-exp-section__body">
+                        <ul class="fp-exp-highlights__list" role="list">
+                            <?php foreach ($highlights as $highlight) : ?>
+                                <li class="fp-exp-highlights__item">
+                                    <span class="fp-exp-highlights__icon" aria-hidden="true">
+                                        <svg viewBox="0 0 24 24"><path fill="currentColor" d="M9.75 18.25 3.5 12l1.41-1.41 4.84 4.84 9.34-9.34L20.5 7.5Z"/></svg>
+                                    </span>
+                                    <span class="fp-exp-highlights__text"><?php echo esc_html($highlight); ?></span>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
                 </section>
             <?php endif; ?>
 
             <?php if (! empty($sections['inclusions']) && $has_inclusions) : ?>
-                <section class="fp-exp-section" id="fp-exp-section-inclusions" data-fp-section="inclusions">
-                    <div class="fp-exp-section__header">
+                <section class="fp-exp-section fp-exp-inclusions" id="fp-exp-section-inclusions" data-fp-section="inclusions">
+                    <header class="fp-exp-section__header">
                         <h2 class="fp-exp-section__title"><?php esc_html_e('What\'s included', 'fp-experiences'); ?></h2>
                         <?php if (! empty($exclusions)) : ?>
-                            <p class="fp-exp-section__subtitle"><?php esc_html_e('and what\'s not', 'fp-experiences'); ?></p>
+                            <p class="fp-exp-section__summary"><?php esc_html_e('What to expect on the day and what comes at an extra cost.', 'fp-experiences'); ?></p>
                         <?php endif; ?>
-                    </div>
-                    <div class="fp-exp-columns">
-                        <?php if (! empty($inclusions)) : ?>
-                            <div class="fp-exp-column">
-                                <h3 class="fp-exp-column__title"><?php esc_html_e('Included', 'fp-experiences'); ?></h3>
-                                <ul class="fp-exp-list" role="list">
-                                    <?php foreach ($inclusions as $item) : ?>
-                                        <li class="fp-exp-list__item">
-                                            <span class="fp-exp-icon fp-exp-icon--check" aria-hidden="true">
-                                                <svg viewBox="0 0 24 24"><path fill="currentColor" d="M9.75 18.25 3.5 12l1.41-1.41 4.84 4.84 9.34-9.34L20.5 7.5Z"/></svg>
-                                            </span>
-                                            <span><?php echo esc_html($item); ?></span>
-                                        </li>
-                                    <?php endforeach; ?>
-                                </ul>
-                            </div>
-                        <?php endif; ?>
-                        <?php if (! empty($exclusions)) : ?>
-                            <div class="fp-exp-column">
-                                <h3 class="fp-exp-column__title"><?php esc_html_e('Not included', 'fp-experiences'); ?></h3>
-                                <ul class="fp-exp-list" role="list">
-                                    <?php foreach ($exclusions as $item) : ?>
-                                        <li class="fp-exp-list__item">
-                                            <span class="fp-exp-icon fp-exp-icon--cross" aria-hidden="true">
-                                                <svg viewBox="0 0 24 24"><path fill="currentColor" d="m18.3 5.71 1.42 1.42-5.3 5.29 5.3 5.29-1.42 1.42-5.29-5.3-5.29 5.3-1.42-1.42 5.3-5.29-5.3-5.29 1.42-1.42 5.29 5.3Z"/></svg>
-                                            </span>
-                                            <span><?php echo esc_html($item); ?></span>
-                                        </li>
-                                    <?php endforeach; ?>
-                                </ul>
-                            </div>
-                        <?php endif; ?>
+                    </header>
+                    <div class="fp-exp-section__body">
+                        <div class="fp-exp-inclusions__grid">
+                            <?php if (! empty($inclusions)) : ?>
+                                <div class="fp-exp-inclusions__column">
+                                    <h3 class="fp-exp-inclusions__title"><?php esc_html_e('Included', 'fp-experiences'); ?></h3>
+                                    <ul class="fp-exp-inclusions__list" role="list">
+                                        <?php foreach ($inclusions as $item) : ?>
+                                            <li class="fp-exp-inclusions__item">
+                                                <span class="fp-exp-inclusions__icon fp-exp-inclusions__icon--check" aria-hidden="true">
+                                                    <svg viewBox="0 0 24 24"><path fill="currentColor" d="M9.75 18.25 3.5 12l1.41-1.41 4.84 4.84 9.34-9.34L20.5 7.5Z"/></svg>
+                                                </span>
+                                                <span class="fp-exp-inclusions__text"><?php echo esc_html($item); ?></span>
+                                            </li>
+                                        <?php endforeach; ?>
+                                    </ul>
+                                </div>
+                            <?php endif; ?>
+                            <?php if (! empty($exclusions)) : ?>
+                                <div class="fp-exp-inclusions__column">
+                                    <h3 class="fp-exp-inclusions__title"><?php esc_html_e('Not included', 'fp-experiences'); ?></h3>
+                                    <ul class="fp-exp-inclusions__list" role="list">
+                                        <?php foreach ($exclusions as $item) : ?>
+                                            <li class="fp-exp-inclusions__item">
+                                                <span class="fp-exp-inclusions__icon fp-exp-inclusions__icon--cross" aria-hidden="true">
+                                                    <svg viewBox="0 0 24 24"><path fill="currentColor" d="m18.3 5.71 1.42 1.42-5.3 5.29 5.3 5.29-1.42 1.42-5.29-5.3-5.29 5.3-1.42-1.42 5.3-5.29-5.3-5.29 1.42-1.42 5.29 5.3Z"/></svg>
+                                                </span>
+                                                <span class="fp-exp-inclusions__text"><?php echo esc_html($item); ?></span>
+                                            </li>
+                                        <?php endforeach; ?>
+                                    </ul>
+                                </div>
+                            <?php endif; ?>
+                        </div>
                     </div>
                 </section>
             <?php endif; ?>
 
             <?php if (! empty($sections['meeting']) && $has_meeting) : ?>
-                <section class="fp-exp-section" id="fp-exp-section-meeting" data-fp-section="meeting">
-                    <h2 class="fp-exp-section__title"><?php esc_html_e('Meeting point', 'fp-experiences'); ?></h2>
-                    <?php
-                    $primary = $meeting_points['primary'];
-                    $alternatives = $meeting_points['alternatives'];
-                    include __DIR__ . '/meeting-points.php';
-                    ?>
+                <section class="fp-exp-section fp-exp-meeting" id="fp-exp-section-meeting" data-fp-section="meeting">
+                    <header class="fp-exp-section__header">
+                        <h2 class="fp-exp-section__title"><?php esc_html_e('Meeting point', 'fp-experiences'); ?></h2>
+                        <?php if ('' !== $overview_meeting_summary) : ?>
+                            <p class="fp-exp-section__summary"><?php echo esc_html($overview_meeting_summary); ?></p>
+                        <?php endif; ?>
+                    </header>
+                    <div class="fp-exp-section__body fp-exp-section__body--flush">
+                        <?php
+                        $primary = $meeting_points['primary'];
+                        $alternatives = $meeting_points['alternatives'];
+                        include __DIR__ . '/meeting-points.php';
+                        ?>
+                    </div>
                 </section>
             <?php endif; ?>
 
             <?php if (! empty($sections['extras']) && $has_extras) : ?>
-                <section class="fp-exp-section" id="fp-exp-section-extras" data-fp-section="extras">
-                    <h2 class="fp-exp-section__title"><?php esc_html_e('Good to know', 'fp-experiences'); ?></h2>
-                    <div class="fp-exp-columns fp-exp-columns--stack">
-                        <?php if (! empty($what_to_bring)) : ?>
-                            <div class="fp-exp-column">
-                                <h3 class="fp-exp-column__title"><?php esc_html_e('What to bring', 'fp-experiences'); ?></h3>
-                                <ul class="fp-exp-list" role="list">
-                                    <?php foreach ($what_to_bring as $item) : ?>
-                                        <li class="fp-exp-list__item"><?php echo esc_html($item); ?></li>
-                                    <?php endforeach; ?>
-                                </ul>
-                            </div>
-                        <?php endif; ?>
-
-                        <?php if (! empty($notes)) : ?>
-                            <div class="fp-exp-column">
-                                <h3 class="fp-exp-column__title"><?php esc_html_e('Notes', 'fp-experiences'); ?></h3>
-                                <?php if (is_array($notes)) : ?>
-                                    <ul class="fp-exp-list" role="list">
-                                        <?php foreach ($notes as $note) : ?>
-                                            <li class="fp-exp-list__item"><?php echo esc_html($note); ?></li>
+                <section class="fp-exp-section fp-exp-essentials" id="fp-exp-section-extras" data-fp-section="extras">
+                    <header class="fp-exp-section__header">
+                        <h2 class="fp-exp-section__title"><?php esc_html_e('Good to know', 'fp-experiences'); ?></h2>
+                        <p class="fp-exp-section__summary"><?php esc_html_e('Handy tips to plan ahead, plus important notes and policies.', 'fp-experiences'); ?></p>
+                    </header>
+                    <div class="fp-exp-section__body">
+                        <div class="fp-exp-essentials__grid">
+                            <?php if (! empty($what_to_bring)) : ?>
+                                <article class="fp-exp-essentials__card">
+                                    <h3 class="fp-exp-essentials__title"><?php esc_html_e('What to bring', 'fp-experiences'); ?></h3>
+                                    <ul class="fp-exp-essentials__list" role="list">
+                                        <?php foreach ($what_to_bring as $item) : ?>
+                                            <li class="fp-exp-essentials__item"><?php echo esc_html($item); ?></li>
                                         <?php endforeach; ?>
                                     </ul>
-                                <?php else : ?>
-                                    <p class="fp-exp-paragraph"><?php echo esc_html($notes); ?></p>
-                                <?php endif; ?>
-                            </div>
-                        <?php endif; ?>
+                                </article>
+                            <?php endif; ?>
 
-                        <?php if (! empty($policy)) : ?>
-                            <div class="fp-exp-column">
-                                <h3 class="fp-exp-column__title"><?php esc_html_e('Cancellation policy', 'fp-experiences'); ?></h3>
-                                <div class="fp-exp-richtext"><?php echo wp_kses_post($policy); ?></div>
-                            </div>
-                        <?php endif; ?>
+                            <?php if (! empty($notes)) : ?>
+                                <article class="fp-exp-essentials__card">
+                                    <h3 class="fp-exp-essentials__title"><?php esc_html_e('Notes', 'fp-experiences'); ?></h3>
+                                    <?php if (is_array($notes)) : ?>
+                                        <ul class="fp-exp-essentials__list" role="list">
+                                            <?php foreach ($notes as $note) : ?>
+                                                <li class="fp-exp-essentials__item"><?php echo esc_html($note); ?></li>
+                                            <?php endforeach; ?>
+                                        </ul>
+                                    <?php else : ?>
+                                        <p class="fp-exp-essentials__copy"><?php echo esc_html($notes); ?></p>
+                                    <?php endif; ?>
+                                </article>
+                            <?php endif; ?>
+
+                            <?php if (! empty($policy)) : ?>
+                                <article class="fp-exp-essentials__card">
+                                    <h3 class="fp-exp-essentials__title"><?php esc_html_e('Cancellation policy', 'fp-experiences'); ?></h3>
+                                    <div class="fp-exp-essentials__copy fp-exp-essentials__copy--rich">
+                                        <div class="fp-exp-richtext"><?php echo wp_kses_post($policy); ?></div>
+                                    </div>
+                                </article>
+                            <?php endif; ?>
+                        </div>
                     </div>
                 </section>
             <?php endif; ?>
 
             <?php if (! empty($sections['faq']) && $has_faq) : ?>
                 <section class="fp-exp-section" id="fp-exp-section-faq" data-fp-section="faq">
-                    <h2 class="fp-exp-section__title"><?php esc_html_e('Frequently asked questions', 'fp-experiences'); ?></h2>
+                    <header class="fp-exp-section__header">
+                        <span class="fp-exp-section__eyebrow"><?php esc_html_e('FAQ', 'fp-experiences'); ?></span>
+                        <h2 class="fp-exp-section__title"><?php esc_html_e('Frequently asked questions', 'fp-experiences'); ?></h2>
+                    </header>
                     <div class="fp-exp-accordion" data-fp-accordion>
                         <?php foreach ($faq as $index => $item) :
                             $button_id = $scope_class . '-faq-' . $index;
@@ -654,7 +729,10 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
 
             <?php if (! empty($sections['reviews']) && $has_reviews) : ?>
                 <section class="fp-exp-section" id="fp-exp-section-reviews" data-fp-section="reviews">
-                    <h2 class="fp-exp-section__title"><?php esc_html_e('Traveler reviews', 'fp-experiences'); ?></h2>
+                    <header class="fp-exp-section__header">
+                        <span class="fp-exp-section__eyebrow"><?php esc_html_e('Reviews', 'fp-experiences'); ?></span>
+                        <h2 class="fp-exp-section__title"><?php esc_html_e('Traveler reviews', 'fp-experiences'); ?></h2>
+                    </header>
                     <ul class="fp-exp-reviews" role="list">
                         <?php foreach ($reviews as $review) : ?>
                             <li class="fp-exp-review" data-fp-review>
@@ -692,7 +770,7 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
 
         <?php if ('none' !== $sidebar_position && ! empty($widget_html)) : ?>
             <aside
-                class="fp-aside"
+                class="fp-aside fp-exp-page__aside"
                 id="fp-exp-widget"
                 data-fp-sticky-container
                 aria-label="<?php esc_attr_e('Riepilogo prenotazione', 'fp-experiences'); ?>"

--- a/docs/DEEP-AUDIT.md
+++ b/docs/DEEP-AUDIT.md
@@ -1,7 +1,7 @@
 # Deep Audit Log
 
 ## D6 — Experience Page Layout Refresh
-- Updated the experience template wrapper to use the new `fp-hero-section` class and kept the semantic main/aside structure.
+- Updated the experience template wrapper to use the streamlined `fp-exp-section` hero layout while keeping the semantic main/aside structure.
 - Refined front-end CSS tokens and layout rules to deliver the two-column grid, sticky widget, and GetYourGuide-inspired styling.
 - Extended `[fp_exp_page]` so editors can control container mode, max-width, gutter, and sidebar placement via shortcode attributes or the new defaults stored in `fp_exp_experience_layout`.
 - Added a General settings panel (“Experience Page Layout”) with sanitisation to capture those defaults for non-technical users.

--- a/templates/front/experience.php
+++ b/templates/front/experience.php
@@ -194,65 +194,104 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
         </script>
     <?php endif; ?>
 
-    <div class="fp-grid" data-fp-page>
-        <main class="fp-main">
+    <div class="fp-grid fp-exp-page__layout" data-fp-page>
+        <main class="fp-main fp-exp-page__main">
             <?php if (! empty($sections['hero'])) : ?>
-                <section class="fp-section fp-hero-section" id="fp-exp-section-hero" data-fp-section="hero">
-                    <div class="fp-hero-section__inner">
-                        <div class="fp-hero-media" aria-hidden="<?php echo null === $primary_image ? 'true' : 'false'; ?>">
+                <section class="fp-exp-section fp-exp-hero" id="fp-exp-section-hero" data-fp-section="hero">
+                    <div class="fp-exp-hero__layout">
+                        <div class="fp-exp-hero__primary">
                             <?php if ($primary_image) : ?>
-                                <img
-                                    class="fp-hero-media__image"
-                                    src="<?php echo esc_url($primary_image['url']); ?>"
-                                    <?php if (! empty($primary_image['srcset'])) : ?>srcset="<?php echo esc_attr($primary_image['srcset']); ?>"<?php endif; ?>
-                                    sizes="100vw"
-                                    <?php if (! empty($primary_image['width'])) : ?>width="<?php echo esc_attr((string) $primary_image['width']); ?>"<?php endif; ?>
-                                    <?php if (! empty($primary_image['height'])) : ?>height="<?php echo esc_attr((string) $primary_image['height']); ?>"<?php endif; ?>
-                                    alt="<?php echo esc_attr($experience['title']); ?>"
-                                    loading="eager"
-                                    decoding="async"
-                                    fetchpriority="high"
-                                />
+                                <figure class="fp-exp-hero__media">
+                                    <img
+                                        class="fp-exp-hero__image"
+                                        src="<?php echo esc_url($primary_image['url']); ?>"
+                                        <?php if (! empty($primary_image['srcset'])) : ?>srcset="<?php echo esc_attr($primary_image['srcset']); ?>"<?php endif; ?>
+                                        sizes="(min-width: 1280px) 640px, (min-width: 768px) 60vw, 100vw"
+                                        <?php if (! empty($primary_image['width'])) : ?>width="<?php echo esc_attr((string) $primary_image['width']); ?>"<?php endif; ?>
+                                        <?php if (! empty($primary_image['height'])) : ?>height="<?php echo esc_attr((string) $primary_image['height']); ?>"<?php endif; ?>
+                                        alt="<?php echo esc_attr($experience['title']); ?>"
+                                        loading="eager"
+                                        decoding="async"
+                                        fetchpriority="high"
+                                    />
+                                </figure>
                             <?php else : ?>
-                                <div class="fp-hero fp-exp-gallery fp-exp-gallery--placeholder">
-                                    <span aria-hidden="true"></span>
+                                <div class="fp-exp-hero__media fp-exp-hero__media--placeholder" aria-hidden="true">
+                                    <span></span>
                                 </div>
                             <?php endif; ?>
-                        </div>
-                        <div class="fp-hero-body">
-                            <div class="fp-hero-body__header">
-                                <div class="fp-eyebrow">
-                                    <span class="fp-badge">FP Experiences</span>
-                                </div>
-                                <h1 class="fp-title"><?php echo esc_html($experience['title']); ?></h1>
+
+                            <div class="fp-exp-hero__content">
+                                <header class="fp-exp-hero__header">
+                                    <span class="fp-exp-hero__eyebrow">FP Experiences</span>
+                                    <h1 class="fp-exp-hero__title"><?php echo esc_html($experience['title']); ?></h1>
+                                    <?php if ('' !== $hero_summary) : ?>
+                                        <p class="fp-exp-hero__summary"><?php echo esc_html($hero_summary); ?></p>
+                                    <?php endif; ?>
+                                </header>
+
+                                <?php if (! empty($hero_highlights)) : ?>
+                                    <ul class="fp-exp-hero__highlights" role="list">
+                                        <?php foreach ($hero_highlights as $highlight) : ?>
+                                            <li class="fp-exp-hero__highlight">
+                                                <span class="fp-exp-hero__highlight-icon" aria-hidden="true">
+                                                    <svg viewBox="0 0 24 24"><path fill="currentColor" d="M9.75 18.25 3.5 12l1.41-1.41 4.84 4.84 9.34-9.34L20.5 7.5Z"/></svg>
+                                                </span>
+                                                <span class="fp-exp-hero__highlight-text"><?php echo esc_html($highlight); ?></span>
+                                            </li>
+                                        <?php endforeach; ?>
+                                    </ul>
+                                <?php endif; ?>
                             </div>
-                            <?php if ('' !== $hero_summary) : ?>
-                                <p class="fp-summary"><?php echo esc_html($hero_summary); ?></p>
-                            <?php endif; ?>
-                            <?php if (! empty($hero_highlights)) : ?>
-                                <ul class="fp-hero-highlights" role="list">
-                                    <?php foreach ($hero_highlights as $highlight) : ?>
-                                        <li class="fp-hero-highlights__item"><?php echo esc_html($highlight); ?></li>
-                                    <?php endforeach; ?>
-                                </ul>
-                            <?php endif; ?>
-                            <?php if (! empty($hero_fact_badges)) : ?>
-                                <ul class="fp-hero-facts" role="list">
-                                    <?php foreach ($hero_fact_badges as $badge) : ?>
-                                        <li class="fp-hero-facts__item">
-                                                <span class="fp-hero-facts__icon" aria-hidden="true">
+                        </div>
+
+                        <aside class="fp-exp-hero__sidebar">
+                            <div class="fp-exp-hero__card">
+                                <?php if ('' !== $sticky_price_display) : ?>
+                                    <div class="fp-exp-hero__price" data-fp-scroll-target="calendar">
+                                        <span class="fp-exp-hero__price-label"><?php esc_html_e('From', 'fp-experiences'); ?></span>
+                                        <span class="fp-exp-hero__price-value"><?php echo esc_html($sticky_price_display); ?></span>
+                                    </div>
+                                <?php endif; ?>
+
+                                <div class="fp-exp-hero__actions">
+                                    <button
+                                        type="button"
+                                        class="fp-exp-button fp-exp-button--primary"
+                                        data-fp-scroll="calendar"
+                                        data-fp-cta="hero"
+                                    >
+                                        <?php echo $cta_label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                                    </button>
+                                    <?php if ($show_gallery) : ?>
+                                        <button
+                                            type="button"
+                                            class="fp-exp-button fp-exp-button--secondary"
+                                            data-fp-scroll="gallery"
+                                        >
+                                            <?php esc_html_e('View gallery', 'fp-experiences'); ?>
+                                        </button>
+                                    <?php endif; ?>
+                                </div>
+
+                                <?php if (! empty($hero_fact_badges)) : ?>
+                                    <ul class="fp-exp-hero__facts" role="list">
+                                        <?php foreach ($hero_fact_badges as $badge) : ?>
+                                            <li class="fp-exp-hero__fact">
+                                                <span class="fp-exp-hero__fact-icon" aria-hidden="true">
                                                     <?php if ('clock' === ($badge['icon'] ?? '')) : ?>
                                                         <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm1 10.59 2.12 2.12-1.41 1.41-2.83-2.83V7h2.12Z"/></svg>
                                                     <?php else : ?>
                                                         <svg viewBox="0 0 24 24" role="img" aria-hidden="true"><path fill="currentColor" d="M12 12.88 9.17 10H5a3 3 0 0 0-3 3v7h6v-4h2v4h6v-7a3 3 0 0 0-3-3h-1.17Zm9-2.88a4 4 0 1 0-4-4 4 4 0 0 0 4 4Z"/></svg>
                                                     <?php endif; ?>
                                                 </span>
-                                                <span class="fp-hero-facts__text"><?php echo esc_html((string) ($badge['label'] ?? '')); ?></span>
-                                        </li>
-                                    <?php endforeach; ?>
-                                </ul>
-                            <?php endif; ?>
-                        </div>
+                                                <span class="fp-exp-hero__fact-text"><?php echo esc_html((string) ($badge['label'] ?? '')); ?></span>
+                                            </li>
+                                        <?php endforeach; ?>
+                                    </ul>
+                                <?php endif; ?>
+                            </div>
+                        </aside>
                     </div>
                 </section>
             <?php endif; ?>
@@ -278,6 +317,16 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
 
             <?php if ($has_overview) : ?>
                 <section class="fp-exp-section fp-exp-overview" id="fp-exp-section-overview" data-fp-section="overview">
+                    <header class="fp-exp-section__header fp-exp-overview__header">
+                        <span class="fp-exp-section__eyebrow"><?php esc_html_e('Overview', 'fp-experiences'); ?></span>
+                        <h2 class="fp-exp-section__title"><?php esc_html_e('Key details at a glance', 'fp-experiences'); ?></h2>
+                        <?php if ('' !== $overview_short_description) : ?>
+                            <p class="fp-exp-overview__summary"><?php echo esc_html($overview_short_description); ?></p>
+                        <?php elseif ('' !== $hero_summary) : ?>
+                            <p class="fp-exp-overview__summary"><?php echo esc_html($hero_summary); ?></p>
+                        <?php endif; ?>
+                    </header>
+
                     <div class="fp-exp-overview__grid">
                         <?php if (! empty($overview_themes)) : ?>
                             <div class="fp-exp-overview__item">
@@ -287,13 +336,6 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
                                         <span class="fp-exp-overview__chip"><?php echo esc_html((string) $theme); ?></span>
                                     <?php endforeach; ?>
                                 </div>
-                            </div>
-                        <?php endif; ?>
-
-                        <?php if ('' !== $overview_short_description) : ?>
-                            <div class="fp-exp-overview__item">
-                                <span class="fp-exp-overview__label"><?php esc_html_e('Descrizione breve', 'fp-experiences'); ?></span>
-                                <span class="fp-exp-overview__value"><?php echo esc_html($overview_short_description); ?></span>
                             </div>
                         <?php endif; ?>
 
@@ -394,6 +436,10 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
 
             <?php if ($show_gallery) : ?>
                 <section class="fp-exp-section fp-exp-gallery" id="fp-exp-section-gallery" data-fp-section="gallery">
+                    <header class="fp-exp-section__header">
+                        <span class="fp-exp-section__eyebrow"><?php esc_html_e('Gallery', 'fp-experiences'); ?></span>
+                        <h2 class="fp-exp-section__title"><?php esc_html_e('A glimpse of the experience', 'fp-experiences'); ?></h2>
+                    </header>
                     <div class="fp-exp-gallery__track" role="list">
                         <?php foreach ($gallery_items as $index => $image) :
                             $url = isset($image['url']) ? (string) $image['url'] : '';
@@ -434,7 +480,7 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
 
             <?php if ($gift_enabled) : ?>
                 <section
-                    class="fp-section fp-gift"
+                    class="fp-exp-section fp-gift"
                     id="fp-exp-gift"
                     data-fp-gift
                     data-fp-gift-config="<?php echo esc_attr(wp_json_encode($gift_config)); ?>"
@@ -509,113 +555,142 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
             <?php endif; ?>
 
             <?php if (! empty($sections['highlights']) && $has_highlights) : ?>
-                <section class="fp-exp-section" id="fp-exp-section-highlights" data-fp-section="highlights">
-                    <h2 class="fp-exp-section__title"><?php esc_html_e('Highlights', 'fp-experiences'); ?></h2>
-                    <ul class="fp-exp-list" role="list">
-                        <?php foreach ($highlights as $highlight) : ?>
-                            <li class="fp-exp-list__item"><?php echo esc_html($highlight); ?></li>
-                        <?php endforeach; ?>
-                    </ul>
+                <section class="fp-exp-section fp-exp-highlights" id="fp-exp-section-highlights" data-fp-section="highlights">
+                    <header class="fp-exp-section__header">
+                        <span class="fp-exp-section__eyebrow"><?php esc_html_e('Highlights', 'fp-experiences'); ?></span>
+                        <h2 class="fp-exp-section__title"><?php esc_html_e('What makes this experience special', 'fp-experiences'); ?></h2>
+                    </header>
+                    <div class="fp-exp-section__body">
+                        <ul class="fp-exp-highlights__list" role="list">
+                            <?php foreach ($highlights as $highlight) : ?>
+                                <li class="fp-exp-highlights__item">
+                                    <span class="fp-exp-highlights__icon" aria-hidden="true">
+                                        <svg viewBox="0 0 24 24"><path fill="currentColor" d="M9.75 18.25 3.5 12l1.41-1.41 4.84 4.84 9.34-9.34L20.5 7.5Z"/></svg>
+                                    </span>
+                                    <span class="fp-exp-highlights__text"><?php echo esc_html($highlight); ?></span>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
                 </section>
             <?php endif; ?>
 
             <?php if (! empty($sections['inclusions']) && $has_inclusions) : ?>
-                <section class="fp-exp-section" id="fp-exp-section-inclusions" data-fp-section="inclusions">
-                    <div class="fp-exp-section__header">
+                <section class="fp-exp-section fp-exp-inclusions" id="fp-exp-section-inclusions" data-fp-section="inclusions">
+                    <header class="fp-exp-section__header">
                         <h2 class="fp-exp-section__title"><?php esc_html_e('What\'s included', 'fp-experiences'); ?></h2>
                         <?php if (! empty($exclusions)) : ?>
-                            <p class="fp-exp-section__subtitle"><?php esc_html_e('and what\'s not', 'fp-experiences'); ?></p>
+                            <p class="fp-exp-section__summary"><?php esc_html_e('What to expect on the day and what comes at an extra cost.', 'fp-experiences'); ?></p>
                         <?php endif; ?>
-                    </div>
-                    <div class="fp-exp-columns">
-                        <?php if (! empty($inclusions)) : ?>
-                            <div class="fp-exp-column">
-                                <h3 class="fp-exp-column__title"><?php esc_html_e('Included', 'fp-experiences'); ?></h3>
-                                <ul class="fp-exp-list" role="list">
-                                    <?php foreach ($inclusions as $item) : ?>
-                                        <li class="fp-exp-list__item">
-                                            <span class="fp-exp-icon fp-exp-icon--check" aria-hidden="true">
-                                                <svg viewBox="0 0 24 24"><path fill="currentColor" d="M9.75 18.25 3.5 12l1.41-1.41 4.84 4.84 9.34-9.34L20.5 7.5Z"/></svg>
-                                            </span>
-                                            <span><?php echo esc_html($item); ?></span>
-                                        </li>
-                                    <?php endforeach; ?>
-                                </ul>
-                            </div>
-                        <?php endif; ?>
-                        <?php if (! empty($exclusions)) : ?>
-                            <div class="fp-exp-column">
-                                <h3 class="fp-exp-column__title"><?php esc_html_e('Not included', 'fp-experiences'); ?></h3>
-                                <ul class="fp-exp-list" role="list">
-                                    <?php foreach ($exclusions as $item) : ?>
-                                        <li class="fp-exp-list__item">
-                                            <span class="fp-exp-icon fp-exp-icon--cross" aria-hidden="true">
-                                                <svg viewBox="0 0 24 24"><path fill="currentColor" d="m18.3 5.71 1.42 1.42-5.3 5.29 5.3 5.29-1.42 1.42-5.29-5.3-5.29 5.3-1.42-1.42 5.3-5.29-5.3-5.29 1.42-1.42 5.29 5.3Z"/></svg>
-                                            </span>
-                                            <span><?php echo esc_html($item); ?></span>
-                                        </li>
-                                    <?php endforeach; ?>
-                                </ul>
-                            </div>
-                        <?php endif; ?>
+                    </header>
+                    <div class="fp-exp-section__body">
+                        <div class="fp-exp-inclusions__grid">
+                            <?php if (! empty($inclusions)) : ?>
+                                <div class="fp-exp-inclusions__column">
+                                    <h3 class="fp-exp-inclusions__title"><?php esc_html_e('Included', 'fp-experiences'); ?></h3>
+                                    <ul class="fp-exp-inclusions__list" role="list">
+                                        <?php foreach ($inclusions as $item) : ?>
+                                            <li class="fp-exp-inclusions__item">
+                                                <span class="fp-exp-inclusions__icon fp-exp-inclusions__icon--check" aria-hidden="true">
+                                                    <svg viewBox="0 0 24 24"><path fill="currentColor" d="M9.75 18.25 3.5 12l1.41-1.41 4.84 4.84 9.34-9.34L20.5 7.5Z"/></svg>
+                                                </span>
+                                                <span class="fp-exp-inclusions__text"><?php echo esc_html($item); ?></span>
+                                            </li>
+                                        <?php endforeach; ?>
+                                    </ul>
+                                </div>
+                            <?php endif; ?>
+                            <?php if (! empty($exclusions)) : ?>
+                                <div class="fp-exp-inclusions__column">
+                                    <h3 class="fp-exp-inclusions__title"><?php esc_html_e('Not included', 'fp-experiences'); ?></h3>
+                                    <ul class="fp-exp-inclusions__list" role="list">
+                                        <?php foreach ($exclusions as $item) : ?>
+                                            <li class="fp-exp-inclusions__item">
+                                                <span class="fp-exp-inclusions__icon fp-exp-inclusions__icon--cross" aria-hidden="true">
+                                                    <svg viewBox="0 0 24 24"><path fill="currentColor" d="m18.3 5.71 1.42 1.42-5.3 5.29 5.3 5.29-1.42 1.42-5.29-5.3-5.29 5.3-1.42-1.42 5.3-5.29-5.3-5.29 1.42-1.42 5.29 5.3Z"/></svg>
+                                                </span>
+                                                <span class="fp-exp-inclusions__text"><?php echo esc_html($item); ?></span>
+                                            </li>
+                                        <?php endforeach; ?>
+                                    </ul>
+                                </div>
+                            <?php endif; ?>
+                        </div>
                     </div>
                 </section>
             <?php endif; ?>
 
             <?php if (! empty($sections['meeting']) && $has_meeting) : ?>
-                <section class="fp-exp-section" id="fp-exp-section-meeting" data-fp-section="meeting">
-                    <h2 class="fp-exp-section__title"><?php esc_html_e('Meeting point', 'fp-experiences'); ?></h2>
-                    <?php
-                    $primary = $meeting_points['primary'];
-                    $alternatives = $meeting_points['alternatives'];
-                    include __DIR__ . '/meeting-points.php';
-                    ?>
+                <section class="fp-exp-section fp-exp-meeting" id="fp-exp-section-meeting" data-fp-section="meeting">
+                    <header class="fp-exp-section__header">
+                        <h2 class="fp-exp-section__title"><?php esc_html_e('Meeting point', 'fp-experiences'); ?></h2>
+                        <?php if ('' !== $overview_meeting_summary) : ?>
+                            <p class="fp-exp-section__summary"><?php echo esc_html($overview_meeting_summary); ?></p>
+                        <?php endif; ?>
+                    </header>
+                    <div class="fp-exp-section__body fp-exp-section__body--flush">
+                        <?php
+                        $primary = $meeting_points['primary'];
+                        $alternatives = $meeting_points['alternatives'];
+                        include __DIR__ . '/meeting-points.php';
+                        ?>
+                    </div>
                 </section>
             <?php endif; ?>
 
             <?php if (! empty($sections['extras']) && $has_extras) : ?>
-                <section class="fp-exp-section" id="fp-exp-section-extras" data-fp-section="extras">
-                    <h2 class="fp-exp-section__title"><?php esc_html_e('Good to know', 'fp-experiences'); ?></h2>
-                    <div class="fp-exp-columns fp-exp-columns--stack">
-                        <?php if (! empty($what_to_bring)) : ?>
-                            <div class="fp-exp-column">
-                                <h3 class="fp-exp-column__title"><?php esc_html_e('What to bring', 'fp-experiences'); ?></h3>
-                                <ul class="fp-exp-list" role="list">
-                                    <?php foreach ($what_to_bring as $item) : ?>
-                                        <li class="fp-exp-list__item"><?php echo esc_html($item); ?></li>
-                                    <?php endforeach; ?>
-                                </ul>
-                            </div>
-                        <?php endif; ?>
-
-                        <?php if (! empty($notes)) : ?>
-                            <div class="fp-exp-column">
-                                <h3 class="fp-exp-column__title"><?php esc_html_e('Notes', 'fp-experiences'); ?></h3>
-                                <?php if (is_array($notes)) : ?>
-                                    <ul class="fp-exp-list" role="list">
-                                        <?php foreach ($notes as $note) : ?>
-                                            <li class="fp-exp-list__item"><?php echo esc_html($note); ?></li>
+                <section class="fp-exp-section fp-exp-essentials" id="fp-exp-section-extras" data-fp-section="extras">
+                    <header class="fp-exp-section__header">
+                        <h2 class="fp-exp-section__title"><?php esc_html_e('Good to know', 'fp-experiences'); ?></h2>
+                        <p class="fp-exp-section__summary"><?php esc_html_e('Handy tips to plan ahead, plus important notes and policies.', 'fp-experiences'); ?></p>
+                    </header>
+                    <div class="fp-exp-section__body">
+                        <div class="fp-exp-essentials__grid">
+                            <?php if (! empty($what_to_bring)) : ?>
+                                <article class="fp-exp-essentials__card">
+                                    <h3 class="fp-exp-essentials__title"><?php esc_html_e('What to bring', 'fp-experiences'); ?></h3>
+                                    <ul class="fp-exp-essentials__list" role="list">
+                                        <?php foreach ($what_to_bring as $item) : ?>
+                                            <li class="fp-exp-essentials__item"><?php echo esc_html($item); ?></li>
                                         <?php endforeach; ?>
                                     </ul>
-                                <?php else : ?>
-                                    <p class="fp-exp-paragraph"><?php echo esc_html($notes); ?></p>
-                                <?php endif; ?>
-                            </div>
-                        <?php endif; ?>
+                                </article>
+                            <?php endif; ?>
 
-                        <?php if (! empty($policy)) : ?>
-                            <div class="fp-exp-column">
-                                <h3 class="fp-exp-column__title"><?php esc_html_e('Cancellation policy', 'fp-experiences'); ?></h3>
-                                <div class="fp-exp-richtext"><?php echo wp_kses_post($policy); ?></div>
-                            </div>
-                        <?php endif; ?>
+                            <?php if (! empty($notes)) : ?>
+                                <article class="fp-exp-essentials__card">
+                                    <h3 class="fp-exp-essentials__title"><?php esc_html_e('Notes', 'fp-experiences'); ?></h3>
+                                    <?php if (is_array($notes)) : ?>
+                                        <ul class="fp-exp-essentials__list" role="list">
+                                            <?php foreach ($notes as $note) : ?>
+                                                <li class="fp-exp-essentials__item"><?php echo esc_html($note); ?></li>
+                                            <?php endforeach; ?>
+                                        </ul>
+                                    <?php else : ?>
+                                        <p class="fp-exp-essentials__copy"><?php echo esc_html($notes); ?></p>
+                                    <?php endif; ?>
+                                </article>
+                            <?php endif; ?>
+
+                            <?php if (! empty($policy)) : ?>
+                                <article class="fp-exp-essentials__card">
+                                    <h3 class="fp-exp-essentials__title"><?php esc_html_e('Cancellation policy', 'fp-experiences'); ?></h3>
+                                    <div class="fp-exp-essentials__copy fp-exp-essentials__copy--rich">
+                                        <div class="fp-exp-richtext"><?php echo wp_kses_post($policy); ?></div>
+                                    </div>
+                                </article>
+                            <?php endif; ?>
+                        </div>
                     </div>
                 </section>
             <?php endif; ?>
 
             <?php if (! empty($sections['faq']) && $has_faq) : ?>
                 <section class="fp-exp-section" id="fp-exp-section-faq" data-fp-section="faq">
-                    <h2 class="fp-exp-section__title"><?php esc_html_e('Frequently asked questions', 'fp-experiences'); ?></h2>
+                    <header class="fp-exp-section__header">
+                        <span class="fp-exp-section__eyebrow"><?php esc_html_e('FAQ', 'fp-experiences'); ?></span>
+                        <h2 class="fp-exp-section__title"><?php esc_html_e('Frequently asked questions', 'fp-experiences'); ?></h2>
+                    </header>
                     <div class="fp-exp-accordion" data-fp-accordion>
                         <?php foreach ($faq as $index => $item) :
                             $button_id = $scope_class . '-faq-' . $index;
@@ -654,7 +729,10 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
 
             <?php if (! empty($sections['reviews']) && $has_reviews) : ?>
                 <section class="fp-exp-section" id="fp-exp-section-reviews" data-fp-section="reviews">
-                    <h2 class="fp-exp-section__title"><?php esc_html_e('Traveler reviews', 'fp-experiences'); ?></h2>
+                    <header class="fp-exp-section__header">
+                        <span class="fp-exp-section__eyebrow"><?php esc_html_e('Reviews', 'fp-experiences'); ?></span>
+                        <h2 class="fp-exp-section__title"><?php esc_html_e('Traveler reviews', 'fp-experiences'); ?></h2>
+                    </header>
                     <ul class="fp-exp-reviews" role="list">
                         <?php foreach ($reviews as $review) : ?>
                             <li class="fp-exp-review" data-fp-review>
@@ -692,7 +770,7 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
 
         <?php if ('none' !== $sidebar_position && ! empty($widget_html)) : ?>
             <aside
-                class="fp-aside"
+                class="fp-aside fp-exp-page__aside"
                 id="fp-exp-widget"
                 data-fp-sticky-container
                 aria-label="<?php esc_attr_e('Riepilogo prenotazione', 'fp-experiences'); ?>"


### PR DESCRIPTION
## Summary
- redesign highlights, inclusions, meeting point, and extras sections with structured wrappers and contextual summaries
- add dedicated highlight, inclusion, and essentials card styles to support the refreshed markup and spacing
- sync compiled template and stylesheet assets with the reorganized section layouts

## Testing
- php -l templates/front/experience.php
- php -l build/fp-experiences/templates/front/experience.php

------
https://chatgpt.com/codex/tasks/task_e_68de7176d0e8832f984d5104a7ef98d7