### PR TITLE
Clarify recurrence frequency selection in calendar tab

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -141,6 +141,69 @@
     gap: 8px;
 }
 
+.fp-exp-radio-cards {
+    display: grid;
+    gap: 12px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.fp-exp-radio-card {
+    position: relative;
+    display: grid;
+    gap: 6px;
+    align-content: start;
+    padding: 16px;
+    border: 1px solid #dcdcde;
+    border-radius: 8px;
+    background: #fff;
+    box-shadow: 0 1px 1px rgb(15 23 42 / 0.05);
+    cursor: pointer;
+    min-height: 100%;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.fp-exp-radio-card:hover {
+    border-color: var(--fp-exp-color-primary, #8b1e3f);
+    box-shadow: 0 3px 12px rgb(15 23 42 / 0.12);
+    transform: translateY(-1px);
+}
+
+.fp-exp-radio-card:focus-within {
+    border-color: var(--fp-exp-color-primary, #8b1e3f);
+    box-shadow: 0 0 0 1px var(--fp-exp-color-primary, #8b1e3f), 0 4px 12px rgb(15 23 42 / 0.12);
+}
+
+.fp-exp-radio-card.is-selected {
+    border-color: var(--fp-exp-color-primary, #8b1e3f);
+    box-shadow: 0 4px 14px rgb(15 23 42 / 0.14);
+    transform: translateY(-1px);
+}
+
+.fp-exp-radio-card input[type="radio"] {
+    position: absolute;
+    inset: 0;
+    margin: 0;
+    opacity: 0;
+}
+
+.fp-exp-radio-card__title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--fp-exp-color-text, #1f1f1f);
+}
+
+.fp-exp-radio-card__text {
+    font-size: 13px;
+    color: var(--fp-exp-color-muted, #505050);
+    line-height: 1.45;
+}
+
+.fp-exp-recurrence__summary {
+    margin-top: 8px;
+    font-size: 12px;
+    color: var(--fp-exp-color-muted, #505050);
+}
+
 .fp-exp-tools {
     display: flex;
     flex-direction: column;

--- a/build/fp-experiences/assets/css/admin.css
+++ b/build/fp-experiences/assets/css/admin.css
@@ -140,6 +140,60 @@
     flex-wrap: wrap;
     gap: 8px;
 }
+.fp-exp-radio-cards {
+    display: grid;
+    gap: 12px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+.fp-exp-radio-card {
+    position: relative;
+    display: grid;
+    gap: 6px;
+    align-content: start;
+    padding: 16px;
+    border: 1px solid #dcdcde;
+    border-radius: 8px;
+    background: #fff;
+    box-shadow: 0 1px 1px rgba(15,23,42,0.05);
+    cursor: pointer;
+    min-height: 100%;
+    transition: border-color .2s ease,box-shadow .2s ease,transform .2s ease;
+}
+.fp-exp-radio-card:hover {
+    border-color: var(--fp-exp-color-primary,#8b1e3f);
+    box-shadow: 0 3px 12px rgba(15,23,42,0.12);
+    transform: translateY(-1px);
+}
+.fp-exp-radio-card:focus-within {
+    border-color: var(--fp-exp-color-primary,#8b1e3f);
+    box-shadow: 0 0 0 1px var(--fp-exp-color-primary,#8b1e3f),0 4px 12px rgba(15,23,42,0.12);
+}
+.fp-exp-radio-card.is-selected {
+    border-color: var(--fp-exp-color-primary,#8b1e3f);
+    box-shadow: 0 4px 14px rgba(15,23,42,0.14);
+    transform: translateY(-1px);
+}
+.fp-exp-radio-card input[type=radio] {
+    position: absolute;
+    inset: 0;
+    margin: 0;
+    opacity: 0;
+}
+.fp-exp-radio-card__title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--fp-exp-color-text,#1f1f1f);
+}
+.fp-exp-radio-card__text {
+    font-size: 13px;
+    color: var(--fp-exp-color-muted,#505050);
+    line-height: 1.45;
+}
+.fp-exp-recurrence__summary {
+    margin-top: 8px;
+    font-size: 12px;
+    color: var(--fp-exp-color-muted,#505050);
+}
 
 .fp-exp-tools {
     display: flex;


### PR DESCRIPTION
## Summary
- replace the recurrence frequency dropdown with descriptive radio options for daily, weekly, and specific availability
- surface contextual helper text and ensure weekday selectors only appear for the weekly mode
- update the admin recurrence script to read the new radio inputs and toggle the contextual notes
- style the new recurrence frequency cards so the active choice stays visually highlighted
- show a dynamic summary of the selected recurrence mode and weekly days, refreshing automatically as options change

## Testing
- php -l src/Admin/ExperienceMetaBoxes.php
- php -l build/fp-experiences/src/Admin/ExperienceMetaBoxes.php

------
https://chatgpt.com/codex/tasks/task_e_68de7cb5d8f0832f84488ed8b38f80e8