### PR TITLE
Streamline overview section around trust badges

### DIFF
--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -1291,11 +1291,11 @@
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
-.fp-exp-addon label {
+.fp-exp-addon__card {
     display: grid;
-    grid-template-columns: auto minmax(140px, 180px) 1fr auto;
-    gap: 0.75rem;
-    align-items: center;
+    grid-template-columns: auto minmax(140px, 180px) minmax(0, 1fr);
+    gap: 0.85rem 1rem;
+    align-items: stretch;
     padding: 0.85rem 1rem;
     border: 1px solid rgba(15, 23, 42, 0.12);
     border-radius: var(--fp-exp-radius-base, 12px);
@@ -1304,13 +1304,19 @@
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.fp-exp-addon label:hover,
-.fp-exp-addon label:focus-within {
+.fp-exp-addon__card:hover,
+.fp-exp-addon__card:focus-within {
     border-color: var(--fp-color-primary);
     box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
 }
 
-.fp-exp-addon input[type="checkbox"] {
+.fp-exp-addon__input {
+    display: flex;
+    align-items: flex-start;
+    padding-top: 0.35rem;
+}
+
+.fp-exp-addon__input input[type="checkbox"] {
     width: 18px;
     height: 18px;
     accent-color: var(--fp-color-primary);
@@ -1349,20 +1355,30 @@
     height: 28px;
 }
 
-.fp-exp-addon__details {
+.fp-exp-addon__content {
     display: flex;
     flex-direction: column;
-    gap: 0.35rem;
+    gap: 0.5rem;
+    min-width: 0;
+}
+
+.fp-exp-addon__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.75rem;
 }
 
 .fp-exp-addon__label {
     font-weight: 600;
     color: var(--fp-color-text);
+    min-width: 0;
+    flex: 1;
 }
 
-.fp-exp-addon__description {
+.fp-exp-addon__summary {
     color: var(--fp-color-muted, #475569);
-    font-size: 0.875rem;
+    font-size: 0.95rem;
     line-height: 1.4;
     margin: 0;
 }
@@ -1370,19 +1386,21 @@
 .fp-exp-addon__price {
     font-weight: 700;
     color: var(--fp-color-text);
-    justify-self: end;
     white-space: nowrap;
 }
 
 @media (max-width: 640px) {
-    .fp-exp-addon label {
-        grid-template-columns: auto 120px 1fr;
+    .fp-exp-addon__card {
+        grid-template-columns: auto minmax(0, 1fr);
         grid-template-rows: auto auto;
     }
 
-    .fp-exp-addon__price {
+    .fp-exp-addon__media {
+        grid-column: 2 / -1;
+    }
+
+    .fp-exp-addon__content {
         grid-column: 1 / -1;
-        justify-self: flex-end;
     }
 }
 
@@ -1463,26 +1481,96 @@
 
 .fp-exp-party-table {
     width: 100%;
-    border-collapse: collapse;
+    border-collapse: separate;
+    border-spacing: 0;
+    background: var(--fp-color-surface);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: var(--fp-exp-radius-base, 12px);
+    overflow: hidden;
+}
+
+.fp-exp-party-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.fp-exp-party-table tbody {
+    display: flex;
+    flex-direction: column;
+}
+
+.fp-exp-party-table tr {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+        'label'
+        'price'
+        'quantity';
+    gap: 0.75rem;
+    padding: clamp(16px, 2vw, 18px);
+}
+
+.fp-exp-party-table tr + tr {
+    border-top: 1px solid rgba(15, 23, 42, 0.08);
 }
 
 .fp-exp-party-table th,
 .fp-exp-party-table td {
-    padding: 0.75rem 0;
-    border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+    padding: 0;
+    border: 0;
     text-align: left;
     font-size: 0.95rem;
+}
+
+.fp-exp-party-table th {
+    grid-area: label;
+    font-weight: 600;
+}
+
+.fp-exp-party-table td:nth-of-type(1) {
+    grid-area: price;
+}
+
+.fp-exp-party-table td:nth-of-type(2) {
+    grid-area: quantity;
+}
+
+.fp-exp-ticket__label {
+    display: block;
+}
+
+.fp-exp-ticket__description {
+    display: block;
+    margin-top: 0.35rem;
+    color: var(--fp-color-muted);
+    font-size: 0.85rem;
+}
+
+.fp-exp-ticket__price {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
 }
 
 .fp-exp-quantity {
     display: inline-flex;
     align-items: center;
-    gap: 0.35rem;
+    gap: 0.45rem;
 }
 
 .fp-exp-quantity__control {
     width: 34px;
     height: 34px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     border-radius: 999px;
     border: 1px solid rgba(15, 23, 42, 0.12);
     background: var(--fp-color-surface);
@@ -1503,12 +1591,37 @@
 
 .fp-exp-quantity__input {
     width: 4.25rem;
+    flex: 0 0 4.25rem;
+    min-width: 3.25rem;
     text-align: center;
     padding: 0.45rem;
     border-radius: 8px;
     border: 1px solid rgba(15, 23, 42, 0.15);
     font-weight: 600;
     color: var(--fp-color-text);
+}
+
+.fp-exp-quantity__control,
+.fp-exp-quantity__input {
+    flex-shrink: 0;
+}
+
+@media (min-width: 768px) {
+    .fp-exp-party-table tr {
+        grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr);
+        grid-template-areas: 'label price quantity';
+        align-items: center;
+        column-gap: clamp(16px, 3vw, 32px);
+    }
+
+    .fp-exp-party-table td:nth-of-type(1) {
+        justify-self: end;
+        text-align: right;
+    }
+
+    .fp-exp-party-table td:nth-of-type(2) {
+        justify-self: end;
+    }
 }
 
 .fp-exp-ticket__price,
@@ -1969,20 +2082,6 @@
     gap: 0.75rem;
 }
 
-.fp-exp-hero__eyebrow {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.35rem 0.75rem;
-    border-radius: 999px;
-    background: rgba(139, 30, 63, 0.12);
-    color: var(--fp-color-primary);
-    font-weight: 600;
-    font-size: 0.75rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-}
-
 .fp-exp-hero__title {
     margin: 0;
     font-size: clamp(2.1rem, 2.6vw + 1rem, 3.35rem);
@@ -2022,6 +2121,12 @@
     height: 1.1rem;
     color: var(--fp-color-primary);
     flex-shrink: 0;
+}
+
+.fp-exp-hero__highlight-icon svg {
+    width: 100%;
+    height: 100%;
+    display: block;
 }
 
 .fp-exp-hero__highlight-text {
@@ -2114,71 +2219,26 @@
     gap: clamp(1.5rem, 3vw, 2.25rem);
 }
 
-.fp-exp-overview__grid {
+.fp-exp-overview__trust-list {
     display: grid;
-    gap: clamp(1.25rem, 3vw, 2rem);
+    gap: clamp(1rem, 2.5vw, 1.5rem);
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.fp-exp-overview__item {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-.fp-exp-overview__label {
-    font-size: 0.85rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--fp-color-muted);
-    font-weight: 600;
-}
-
-.fp-exp-overview__value {
-    font-size: clamp(1.05rem, 2vw, 1.3rem);
-    font-weight: 600;
-    color: var(--fp-color-text);
-}
-
-.fp-exp-overview__value--badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.45rem 0.85rem;
-    border-radius: 999px;
-    background: rgba(139, 30, 63, 0.12);
-    color: var(--fp-color-primary);
-    font-weight: 600;
-}
-
-.fp-exp-overview__chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.4rem;
     list-style: none;
     margin: 0;
     padding: 0;
 }
 
-.fp-exp-overview__summary {
-    margin: 0;
-    color: var(--fp-color-text);
-    font-size: 1.05rem;
-    line-height: 1.6;
-    max-width: 58ch;
-}
-
 
 .fp-exp-overview__chip {
-    display: inline-flex;
+    display: flex;
     align-items: flex-start;
     gap: 0.6rem;
     padding: 0.65rem 0.85rem;
     border-radius: 16px;
     background: rgba(15, 23, 42, 0.08);
     color: var(--fp-color-text);
-    min-width: 200px;
-    max-width: 280px;
+    min-width: 0;
+    width: 100%;
 }
 
 .fp-exp-overview__chip-icon {
@@ -2224,49 +2284,6 @@
     color: rgba(15, 23, 42, 0.75);
 }
 
-.fp-exp-overview__languages {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-}
-
-.fp-exp-overview__language {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.35rem 0.65rem;
-    border-radius: 999px;
-    background: rgba(15, 23, 42, 0.08);
-    font-weight: 600;
-    color: var(--fp-color-text);
-}
-
-.fp-exp-overview__language-flag {
-    display: inline-flex;
-    width: 1.5rem;
-    height: 1rem;
-    border-radius: 2px;
-    overflow: hidden;
-    box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.12);
-}
-
-.fp-exp-overview__language-flag svg {
-    width: 100%;
-    height: 100%;
-    display: block;
-}
-
-.fp-exp-overview__language-code {
-    font-size: 0.85rem;
-}
-
-.fp-exp-overview__muted {
-    font-size: 0.85rem;
-    color: var(--fp-color-muted);
-}
 
 .fp-exp-gallery__track {
     display: grid;

--- a/assets/js/front.js
+++ b/assets/js/front.js
@@ -655,18 +655,60 @@
         const feedback = giftSection.querySelector('[data-fp-gift-feedback]');
         const success = giftSection.querySelector('[data-fp-gift-success]');
 
-        page.querySelectorAll('[data-fp-gift-toggle]').forEach((button) => {
-            button.addEventListener('click', (event) => {
-                event.preventDefault();
+        const toggleButtons = page.querySelectorAll('[data-fp-gift-toggle]');
+        const setToggleExpanded = (expanded) => {
+            toggleButtons.forEach((button) => {
+                button.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+            });
+        };
+
+        const showGiftSection = ({ focusFirstField = false, scroll = true } = {}) => {
+            const wasHidden = giftSection.hasAttribute('hidden') || giftSection.hidden;
+            if (wasHidden) {
+                giftSection.hidden = false;
+            }
+
+            setToggleExpanded(true);
+
+            if (giftSection.id) {
+                const giftHash = `#${giftSection.id}`;
+                if (window.location.hash !== giftHash) {
+                    try {
+                        window.history.replaceState(null, '', giftHash);
+                    } catch (_error) {
+                        window.location.hash = giftHash;
+                    }
+                }
+            }
+
+            if (scroll) {
                 giftSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                const firstField = form ? form.querySelector('input, textarea, select') : null;
+            }
+
+            if (focusFirstField && form && wasHidden) {
+                const firstField = form.querySelector('input, textarea, select');
                 if (firstField instanceof HTMLElement) {
                     window.setTimeout(() => {
                         firstField.focus();
                     }, 280);
                 }
+            }
+        };
+
+        toggleButtons.forEach((button) => {
+            button.addEventListener('click', (event) => {
+                event.preventDefault();
+                showGiftSection({ focusFirstField: true });
             });
         });
+
+        if (!giftSection.hasAttribute('hidden') && !giftSection.hidden) {
+            setToggleExpanded(true);
+        }
+
+        if (giftSection.id && window.location.hash === `#${giftSection.id}`) {
+            showGiftSection({ scroll: false });
+        }
 
         if (!form) {
             return;

--- a/build/fp-experiences/assets/css/front.css
+++ b/build/fp-experiences/assets/css/front.css
@@ -1291,11 +1291,11 @@
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
-.fp-exp-addon label {
+.fp-exp-addon__card {
     display: grid;
-    grid-template-columns: auto minmax(140px, 180px) 1fr auto;
-    gap: 0.75rem;
-    align-items: center;
+    grid-template-columns: auto minmax(140px, 180px) minmax(0, 1fr);
+    gap: 0.85rem 1rem;
+    align-items: stretch;
     padding: 0.85rem 1rem;
     border: 1px solid rgba(15, 23, 42, 0.12);
     border-radius: var(--fp-exp-radius-base, 12px);
@@ -1304,13 +1304,19 @@
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.fp-exp-addon label:hover,
-.fp-exp-addon label:focus-within {
+.fp-exp-addon__card:hover,
+.fp-exp-addon__card:focus-within {
     border-color: var(--fp-color-primary);
     box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
 }
 
-.fp-exp-addon input[type="checkbox"] {
+.fp-exp-addon__input {
+    display: flex;
+    align-items: flex-start;
+    padding-top: 0.35rem;
+}
+
+.fp-exp-addon__input input[type="checkbox"] {
     width: 18px;
     height: 18px;
     accent-color: var(--fp-color-primary);
@@ -1349,20 +1355,30 @@
     height: 28px;
 }
 
-.fp-exp-addon__details {
+.fp-exp-addon__content {
     display: flex;
     flex-direction: column;
-    gap: 0.35rem;
+    gap: 0.5rem;
+    min-width: 0;
+}
+
+.fp-exp-addon__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.75rem;
 }
 
 .fp-exp-addon__label {
     font-weight: 600;
     color: var(--fp-color-text);
+    min-width: 0;
+    flex: 1;
 }
 
-.fp-exp-addon__description {
+.fp-exp-addon__summary {
     color: var(--fp-color-muted, #475569);
-    font-size: 0.875rem;
+    font-size: 0.95rem;
     line-height: 1.4;
     margin: 0;
 }
@@ -1370,19 +1386,21 @@
 .fp-exp-addon__price {
     font-weight: 700;
     color: var(--fp-color-text);
-    justify-self: end;
     white-space: nowrap;
 }
 
 @media (max-width: 640px) {
-    .fp-exp-addon label {
-        grid-template-columns: auto 120px 1fr;
+    .fp-exp-addon__card {
+        grid-template-columns: auto minmax(0, 1fr);
         grid-template-rows: auto auto;
     }
 
-    .fp-exp-addon__price {
+    .fp-exp-addon__media {
+        grid-column: 2 / -1;
+    }
+
+    .fp-exp-addon__content {
         grid-column: 1 / -1;
-        justify-self: flex-end;
     }
 }
 
@@ -1463,26 +1481,96 @@
 
 .fp-exp-party-table {
     width: 100%;
-    border-collapse: collapse;
+    border-collapse: separate;
+    border-spacing: 0;
+    background: var(--fp-color-surface);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: var(--fp-exp-radius-base, 12px);
+    overflow: hidden;
+}
+
+.fp-exp-party-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.fp-exp-party-table tbody {
+    display: flex;
+    flex-direction: column;
+}
+
+.fp-exp-party-table tr {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+        'label'
+        'price'
+        'quantity';
+    gap: 0.75rem;
+    padding: clamp(16px, 2vw, 18px);
+}
+
+.fp-exp-party-table tr + tr {
+    border-top: 1px solid rgba(15, 23, 42, 0.08);
 }
 
 .fp-exp-party-table th,
 .fp-exp-party-table td {
-    padding: 0.75rem 0;
-    border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+    padding: 0;
+    border: 0;
     text-align: left;
     font-size: 0.95rem;
+}
+
+.fp-exp-party-table th {
+    grid-area: label;
+    font-weight: 600;
+}
+
+.fp-exp-party-table td:nth-of-type(1) {
+    grid-area: price;
+}
+
+.fp-exp-party-table td:nth-of-type(2) {
+    grid-area: quantity;
+}
+
+.fp-exp-ticket__label {
+    display: block;
+}
+
+.fp-exp-ticket__description {
+    display: block;
+    margin-top: 0.35rem;
+    color: var(--fp-color-muted);
+    font-size: 0.85rem;
+}
+
+.fp-exp-ticket__price {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
 }
 
 .fp-exp-quantity {
     display: inline-flex;
     align-items: center;
-    gap: 0.35rem;
+    gap: 0.45rem;
 }
 
 .fp-exp-quantity__control {
     width: 34px;
     height: 34px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     border-radius: 999px;
     border: 1px solid rgba(15, 23, 42, 0.12);
     background: var(--fp-color-surface);
@@ -1503,12 +1591,37 @@
 
 .fp-exp-quantity__input {
     width: 4.25rem;
+    flex: 0 0 4.25rem;
+    min-width: 3.25rem;
     text-align: center;
     padding: 0.45rem;
     border-radius: 8px;
     border: 1px solid rgba(15, 23, 42, 0.15);
     font-weight: 600;
     color: var(--fp-color-text);
+}
+
+.fp-exp-quantity__control,
+.fp-exp-quantity__input {
+    flex-shrink: 0;
+}
+
+@media (min-width: 768px) {
+    .fp-exp-party-table tr {
+        grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr);
+        grid-template-areas: 'label price quantity';
+        align-items: center;
+        column-gap: clamp(16px, 3vw, 32px);
+    }
+
+    .fp-exp-party-table td:nth-of-type(1) {
+        justify-self: end;
+        text-align: right;
+    }
+
+    .fp-exp-party-table td:nth-of-type(2) {
+        justify-self: end;
+    }
 }
 
 .fp-exp-ticket__price,
@@ -1969,20 +2082,6 @@
     gap: 0.75rem;
 }
 
-.fp-exp-hero__eyebrow {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.35rem 0.75rem;
-    border-radius: 999px;
-    background: rgba(139, 30, 63, 0.12);
-    color: var(--fp-color-primary);
-    font-weight: 600;
-    font-size: 0.75rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-}
-
 .fp-exp-hero__title {
     margin: 0;
     font-size: clamp(2.1rem, 2.6vw + 1rem, 3.35rem);
@@ -2022,6 +2121,12 @@
     height: 1.1rem;
     color: var(--fp-color-primary);
     flex-shrink: 0;
+}
+
+.fp-exp-hero__highlight-icon svg {
+    width: 100%;
+    height: 100%;
+    display: block;
 }
 
 .fp-exp-hero__highlight-text {
@@ -2114,71 +2219,26 @@
     gap: clamp(1.5rem, 3vw, 2.25rem);
 }
 
-.fp-exp-overview__grid {
+.fp-exp-overview__trust-list {
     display: grid;
-    gap: clamp(1.25rem, 3vw, 2rem);
+    gap: clamp(1rem, 2.5vw, 1.5rem);
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.fp-exp-overview__item {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-.fp-exp-overview__label {
-    font-size: 0.85rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--fp-color-muted);
-    font-weight: 600;
-}
-
-.fp-exp-overview__value {
-    font-size: clamp(1.05rem, 2vw, 1.3rem);
-    font-weight: 600;
-    color: var(--fp-color-text);
-}
-
-.fp-exp-overview__value--badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.45rem 0.85rem;
-    border-radius: 999px;
-    background: rgba(139, 30, 63, 0.12);
-    color: var(--fp-color-primary);
-    font-weight: 600;
-}
-
-.fp-exp-overview__chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.4rem;
     list-style: none;
     margin: 0;
     padding: 0;
 }
 
-.fp-exp-overview__summary {
-    margin: 0;
-    color: var(--fp-color-text);
-    font-size: 1.05rem;
-    line-height: 1.6;
-    max-width: 58ch;
-}
-
 
 .fp-exp-overview__chip {
-    display: inline-flex;
+    display: flex;
     align-items: flex-start;
     gap: 0.6rem;
     padding: 0.65rem 0.85rem;
     border-radius: 16px;
     background: rgba(15, 23, 42, 0.08);
     color: var(--fp-color-text);
-    min-width: 200px;
-    max-width: 280px;
+    min-width: 0;
+    width: 100%;
 }
 
 .fp-exp-overview__chip-icon {
@@ -2224,49 +2284,6 @@
     color: rgba(15, 23, 42, 0.75);
 }
 
-.fp-exp-overview__languages {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-}
-
-.fp-exp-overview__language {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.35rem 0.65rem;
-    border-radius: 999px;
-    background: rgba(15, 23, 42, 0.08);
-    font-weight: 600;
-    color: var(--fp-color-text);
-}
-
-.fp-exp-overview__language-flag {
-    display: inline-flex;
-    width: 1.5rem;
-    height: 1rem;
-    border-radius: 2px;
-    overflow: hidden;
-    box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.12);
-}
-
-.fp-exp-overview__language-flag svg {
-    width: 100%;
-    height: 100%;
-    display: block;
-}
-
-.fp-exp-overview__language-code {
-    font-size: 0.85rem;
-}
-
-.fp-exp-overview__muted {
-    font-size: 0.85rem;
-    color: var(--fp-color-muted);
-}
 
 .fp-exp-gallery__track {
     display: grid;

--- a/build/fp-experiences/assets/js/front.js
+++ b/build/fp-experiences/assets/js/front.js
@@ -655,18 +655,60 @@
         const feedback = giftSection.querySelector('[data-fp-gift-feedback]');
         const success = giftSection.querySelector('[data-fp-gift-success]');
 
-        page.querySelectorAll('[data-fp-gift-toggle]').forEach((button) => {
-            button.addEventListener('click', (event) => {
-                event.preventDefault();
+        const toggleButtons = page.querySelectorAll('[data-fp-gift-toggle]');
+        const setToggleExpanded = (expanded) => {
+            toggleButtons.forEach((button) => {
+                button.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+            });
+        };
+
+        const showGiftSection = ({ focusFirstField = false, scroll = true } = {}) => {
+            const wasHidden = giftSection.hasAttribute('hidden') || giftSection.hidden;
+            if (wasHidden) {
+                giftSection.hidden = false;
+            }
+
+            setToggleExpanded(true);
+
+            if (giftSection.id) {
+                const giftHash = `#${giftSection.id}`;
+                if (window.location.hash !== giftHash) {
+                    try {
+                        window.history.replaceState(null, '', giftHash);
+                    } catch (_error) {
+                        window.location.hash = giftHash;
+                    }
+                }
+            }
+
+            if (scroll) {
                 giftSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                const firstField = form ? form.querySelector('input, textarea, select') : null;
+            }
+
+            if (focusFirstField && form && wasHidden) {
+                const firstField = form.querySelector('input, textarea, select');
                 if (firstField instanceof HTMLElement) {
                     window.setTimeout(() => {
                         firstField.focus();
                     }, 280);
                 }
+            }
+        };
+
+        toggleButtons.forEach((button) => {
+            button.addEventListener('click', (event) => {
+                event.preventDefault();
+                showGiftSection({ focusFirstField: true });
             });
         });
+
+        if (!giftSection.hasAttribute('hidden') && !giftSection.hidden) {
+            setToggleExpanded(true);
+        }
+
+        if (giftSection.id && window.location.hash === `#${giftSection.id}`) {
+            showGiftSection({ scroll: false });
+        }
 
         if (!form) {
             return;

--- a/build/fp-experiences/languages/fp-experiences.pot
+++ b/build/fp-experiences/languages/fp-experiences.pot
@@ -292,11 +292,11 @@ msgstr ""
 
 #: src/Admin/CalendarAdmin.php:302
 #: templates/front/widget.php:188
-msgid "Add-ons"
+msgid "Extra"
 msgstr ""
 
 #: src/Admin/CalendarAdmin.php:320
-msgid "No add-ons configured for this experience."
+msgid "No extras configured for this experience."
 msgstr ""
 
 #: src/Admin/CalendarAdmin.php:326
@@ -675,11 +675,11 @@ msgid "Capienza massima gruppo"
 msgstr ""
 
 #: src/Admin/ExperienceMetaBoxes.php:467
-msgid "Add-on"
+msgid "Extra"
 msgstr ""
 
 #: src/Admin/ExperienceMetaBoxes.php:483
-msgid "Aggiungi add-on"
+msgid "Aggiungi extra"
 msgstr ""
 
 #: src/Admin/ExperienceMetaBoxes.php:490
@@ -911,7 +911,7 @@ msgid "Capienza"
 msgstr ""
 
 #: src/Admin/ExperienceMetaBoxes.php:918
-msgid "Nome add-on"
+msgid "Nome extra"
 msgstr ""
 
 #: src/Admin/ExperienceMetaBoxes.php:919
@@ -3478,6 +3478,11 @@ msgstr ""
 
 #: templates/front/widget.php:244
 msgid "Enter your email address."
+msgstr ""
+
+#: templates/front/experience.php:316
+#: build/fp-experiences/templates/front/experience.php:314
+msgid "Perché prenotare con noi"
 msgstr ""
 
 #: templates/front/widget.php:246

--- a/build/fp-experiences/src/Admin/CalendarAdmin.php
+++ b/build/fp-experiences/src/Admin/CalendarAdmin.php
@@ -305,7 +305,7 @@ final class CalendarAdmin
         }
         echo '</td></tr>';
 
-        echo '<tr><th scope="row"><label>' . esc_html__('Add-ons', 'fp-experiences') . '</label></th><td>';
+        echo '<tr><th scope="row"><label>' . esc_html__('Extra', 'fp-experiences') . '</label></th><td>';
         if ($addon_config) {
             $currency = (string) get_option('woocommerce_currency', 'EUR');
             foreach ($addon_config as $slug => $addon) {
@@ -323,7 +323,7 @@ final class CalendarAdmin
                 }
             }
         } else {
-            echo '<p>' . esc_html__('No add-ons configured for this experience.', 'fp-experiences') . '</p>';
+            echo '<p>' . esc_html__('No extras configured for this experience.', 'fp-experiences') . '</p>';
         }
         echo '</td></tr>';
 

--- a/build/fp-experiences/src/Admin/ExperienceMetaBoxes.php
+++ b/build/fp-experiences/src/Admin/ExperienceMetaBoxes.php
@@ -857,7 +857,7 @@ final class ExperienceMetaBoxes
             </fieldset>
 
             <fieldset class="fp-exp-fieldset">
-                <legend><?php esc_html_e('Add-on', 'fp-experiences'); ?></legend>
+                <legend><?php esc_html_e('Extra', 'fp-experiences'); ?></legend>
                 <div
                     class="fp-exp-repeater"
                     data-repeater="addons"
@@ -873,7 +873,7 @@ final class ExperienceMetaBoxes
                     </template>
                     <p class="fp-exp-repeater__actions">
                         <button type="button" class="button button-secondary" data-repeater-add>
-                            <?php esc_html_e('Aggiungi add-on', 'fp-experiences'); ?>
+                            <?php esc_html_e('Aggiungi extra', 'fp-experiences'); ?>
                         </button>
                     </p>
                 </div>
@@ -1359,6 +1359,7 @@ final class ExperienceMetaBoxes
         $type_name = $is_template ? 'fp_exp_pricing[addons][__INDEX__][type]' : $name_prefix . '[type]';
         $slug_name = $is_template ? 'fp_exp_pricing[addons][__INDEX__][slug]' : $name_prefix . '[slug]';
         $image_name = $is_template ? 'fp_exp_pricing[addons][__INDEX__][image_id]' : $name_prefix . '[image_id]';
+        $description_name = $is_template ? 'fp_exp_pricing[addons][__INDEX__][description]' : $name_prefix . '[description]';
         $type_value = isset($addon['type']) ? (string) $addon['type'] : 'person';
         $image_id = isset($addon['image_id']) ? absint((string) $addon['image_id']) : 0;
         $image = $image_id > 0 ? wp_get_attachment_image_src($image_id, 'thumbnail') : false;
@@ -1421,12 +1422,16 @@ final class ExperienceMetaBoxes
                     </div>
                 </div>
                 <label>
-                    <span class="fp-exp-field__label"><?php esc_html_e('Nome add-on', 'fp-experiences'); ?></span>
+                    <span class="fp-exp-field__label"><?php esc_html_e('Nome extra', 'fp-experiences'); ?></span>
                     <input type="text" <?php echo $this->field_name_attribute($label_name, $is_template); ?> value="<?php echo esc_attr((string) ($addon['name'] ?? '')); ?>" placeholder="<?php echo esc_attr__('Transfer', 'fp-experiences'); ?>" />
                 </label>
                 <label>
                     <span class="fp-exp-field__label"><?php esc_html_e('Codice', 'fp-experiences'); ?></span>
                     <input type="text" <?php echo $this->field_name_attribute($slug_name, $is_template); ?> value="<?php echo esc_attr((string) ($addon['slug'] ?? '')); ?>" placeholder="<?php echo esc_attr__('transfer', 'fp-experiences'); ?>" />
+                </label>
+                <label>
+                    <span class="fp-exp-field__label"><?php esc_html_e('Descrizione breve', 'fp-experiences'); ?></span>
+                    <textarea rows="2" maxlength="160" <?php echo $this->field_name_attribute($description_name, $is_template); ?>><?php echo esc_textarea((string) ($addon['description'] ?? '')); ?></textarea>
                 </label>
                 <label>
                     <span class="fp-exp-field__label"><?php esc_html_e('Prezzo (€)', 'fp-experiences'); ?></span>
@@ -1771,6 +1776,7 @@ final class ExperienceMetaBoxes
                 $type = isset($addon['type']) ? sanitize_key((string) $addon['type']) : 'person';
                 $slug = isset($addon['slug']) ? sanitize_key((string) $addon['slug']) : '';
                 $image_id = isset($addon['image_id']) ? absint((string) $addon['image_id']) : 0;
+                $description = isset($addon['description']) ? sanitize_text_field((string) $addon['description']) : '';
                 if ($image_id > 0 && ! wp_attachment_is_image($image_id)) {
                     $image_id = 0;
                 }
@@ -1792,6 +1798,7 @@ final class ExperienceMetaBoxes
                     'type' => $type,
                     'slug' => $slug,
                     'image_id' => $image_id,
+                    'description' => $description,
                 ];
 
                 $legacy_addons[] = [
@@ -1800,7 +1807,7 @@ final class ExperienceMetaBoxes
                     'price' => $price,
                     'allow_multiple' => 'booking' !== $type,
                     'max' => 0,
-                    'description' => '',
+                    'description' => $description,
                     'image_id' => $image_id,
                 ];
             }

--- a/build/fp-experiences/src/Shortcodes/ExperienceShortcode.php
+++ b/build/fp-experiences/src/Shortcodes/ExperienceShortcode.php
@@ -651,25 +651,25 @@ final class ExperienceShortcode extends BaseShortcode
             return false;
         }
 
-        $has_themes = ! empty($overview['themes']);
-        $has_languages = ! empty($overview['language_badges']);
-        $has_biases = ! empty($overview['cognitive_biases']);
-        $has_short_description = '' !== ($overview['short_description'] ?? '');
+        $biases = $overview['cognitive_biases'] ?? [];
 
-        $meeting = $overview['meeting'] ?? [];
-        $meeting_summary = '';
-        if (is_array($meeting)) {
-            $meeting_summary = (string) ($meeting['summary'] ?? '');
+        if (! is_array($biases)) {
+            return false;
         }
 
-        $has_family = ! empty($overview['family_friendly']);
+        foreach ($biases as $bias) {
+            if (is_array($bias)) {
+                $label = isset($bias['label']) ? (string) $bias['label'] : '';
+            } else {
+                $label = (string) $bias;
+            }
 
-        return $has_themes
-            || $has_languages
-            || $has_biases
-            || $has_short_description
-            || '' !== $meeting_summary
-            || $has_family;
+            if ('' !== trim($label)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/build/fp-experiences/src/Utils/Helpers.php
+++ b/build/fp-experiences/src/Utils/Helpers.php
@@ -72,7 +72,7 @@ final class Helpers
      */
     private static ?array $cognitive_bias_icon_cache = null;
 
-    public const COGNITIVE_BIAS_MAX_SELECTION = 3;
+    public const COGNITIVE_BIAS_MAX_SELECTION = 6;
 
     public static function cognitive_bias_max_selection(): int
     {

--- a/build/fp-experiences/templates/front/experience.php
+++ b/build/fp-experiences/templates/front/experience.php
@@ -108,9 +108,6 @@ $experience_summary = isset($experience['summary']) ? (string) $experience['summ
 $hero_summary = '' !== $experience_summary ? $experience_summary : $experience_short_description;
 
 $overview = isset($overview) && is_array($overview) ? $overview : [];
-$overview_themes = isset($overview['themes']) && is_array($overview['themes']) ? $overview['themes'] : [];
-$overview_languages = isset($overview['language_badges']) && is_array($overview['language_badges']) ? $overview['language_badges'] : [];
-$overview_language_terms = isset($overview['language_terms']) && is_array($overview['language_terms']) ? $overview['language_terms'] : [];
 $overview_biases = isset($overview['cognitive_biases']) && is_array($overview['cognitive_biases'])
     ? array_values(array_filter(array_map(
         static function ($bias) {
@@ -139,21 +136,14 @@ $overview_biases = isset($overview['cognitive_biases']) && is_array($overview['c
         $overview['cognitive_biases']
     )))
     : [];
-$overview_short_description = isset($overview['short_description']) ? (string) $overview['short_description'] : '';
 $overview_meeting = isset($overview['meeting']) && is_array($overview['meeting']) ? $overview['meeting'] : [];
 $overview_meeting_title = isset($overview_meeting['title']) ? (string) $overview_meeting['title'] : '';
 $overview_meeting_address = isset($overview_meeting['address']) ? (string) $overview_meeting['address'] : '';
 $overview_meeting_summary = isset($overview_meeting['summary']) ? (string) $overview_meeting['summary'] : '';
-$overview_family = ! empty($overview['family_friendly']);
 $overview_has_content = isset($overview_has_content) ? (bool) $overview_has_content : null;
 
 if (null === $overview_has_content) {
-    $overview_has_content = ! empty($overview_themes)
-        || ! empty($overview_languages)
-        || ! empty($overview_biases)
-        || '' !== $overview_short_description
-        || '' !== $overview_meeting_summary
-        || $overview_family;
+    $overview_has_content = ! empty($overview_biases);
 }
 
 $has_overview = ! empty($sections['overview']) && $overview_has_content;
@@ -223,7 +213,6 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
 
                             <div class="fp-exp-hero__content">
                                 <header class="fp-exp-hero__header">
-                                    <span class="fp-exp-hero__eyebrow">FP Experiences</span>
                                     <h1 class="fp-exp-hero__title"><?php echo esc_html($experience['title']); ?></h1>
                                     <?php if ('' !== $hero_summary) : ?>
                                         <p class="fp-exp-hero__summary"><?php echo esc_html($hero_summary); ?></p>
@@ -235,7 +224,9 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
                                         <?php foreach ($hero_highlights as $highlight) : ?>
                                             <li class="fp-exp-hero__highlight">
                                                 <span class="fp-exp-hero__highlight-icon" aria-hidden="true">
-                                                    <svg viewBox="0 0 24 24"><path fill="currentColor" d="M9.75 18.25 3.5 12l1.41-1.41 4.84 4.84 9.34-9.34L20.5 7.5Z"/></svg>
+                                                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                                                        <path fill="currentColor" d="M9.75 18.25 3.5 12l1.41-1.41 4.84 4.84 9.34-9.34L20.5 7.5Z" />
+                                                    </svg>
                                                 </span>
                                                 <span class="fp-exp-hero__highlight-text"><?php echo esc_html($highlight); ?></span>
                                             </li>
@@ -304,13 +295,15 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
                             <h2 class="fp-exp-gift__title fp-exp-section__title"><?php esc_html_e('Gift this experience', 'fp-experiences'); ?></h2>
                             <p class="fp-exp-gift__description"><?php esc_html_e('Acquista un voucher e invialo con un messaggio personalizzato in pochi clic.', 'fp-experiences'); ?></p>
                         </div>
-                        <a
-                            href="#fp-exp-gift"
+                        <button
+                            type="button"
                             class="fp-exp-button fp-exp-button--secondary"
                             data-fp-gift-toggle
+                            aria-controls="fp-exp-gift"
+                            aria-expanded="false"
                         >
                             <?php esc_html_e('Gift this experience', 'fp-experiences'); ?>
-                        </a>
+                        </button>
                     </div>
                 </section>
             <?php endif; ?>
@@ -318,119 +311,44 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
             <?php if ($has_overview) : ?>
                 <section class="fp-exp-section fp-exp-overview" id="fp-exp-section-overview" data-fp-section="overview">
                     <header class="fp-exp-section__header fp-exp-overview__header">
-                        <span class="fp-exp-section__eyebrow"><?php esc_html_e('Overview', 'fp-experiences'); ?></span>
-                        <h2 class="fp-exp-section__title"><?php esc_html_e('Key details at a glance', 'fp-experiences'); ?></h2>
-                        <?php if ('' !== $overview_short_description) : ?>
-                            <p class="fp-exp-overview__summary"><?php echo esc_html($overview_short_description); ?></p>
-                        <?php elseif ('' !== $hero_summary) : ?>
-                            <p class="fp-exp-overview__summary"><?php echo esc_html($hero_summary); ?></p>
-                        <?php endif; ?>
+                        <h2 class="fp-exp-section__title"><?php esc_html_e('Perché prenotare con noi', 'fp-experiences'); ?></h2>
                     </header>
 
-                    <div class="fp-exp-overview__grid">
-                        <?php if (! empty($overview_themes)) : ?>
-                            <div class="fp-exp-overview__item">
-                                <span class="fp-exp-overview__label"><?php esc_html_e('Themes', 'fp-experiences'); ?></span>
-                                <div class="fp-exp-overview__chips">
-                                    <?php foreach ($overview_themes as $theme) : ?>
-                                        <span class="fp-exp-overview__chip"><?php echo esc_html((string) $theme); ?></span>
-                                    <?php endforeach; ?>
-                                </div>
-                            </div>
-                        <?php endif; ?>
+                    <?php if (! empty($overview_biases)) : ?>
+                        <ul class="fp-exp-overview__trust-list" role="list">
+                            <?php foreach ($overview_biases as $bias) :
+                                $label = isset($bias['label']) ? (string) $bias['label'] : '';
+                                if ('' === $label) {
+                                    continue;
+                                }
 
-                        <?php if (! empty($overview_languages)) : ?>
-                            <div class="fp-exp-overview__item">
-                                <span class="fp-exp-overview__label"><?php esc_html_e('Languages', 'fp-experiences'); ?></span>
-                                <ul class="fp-exp-overview__languages" role="list">
-                                    <?php foreach ($overview_languages as $badge) :
-                                        if (! is_array($badge)) {
-                                            continue;
-                                        }
-
-                                        $language_meta = isset($badge['language']) && is_array($badge['language']) ? $badge['language'] : [];
-                                        $sprite_id = isset($language_meta['sprite']) ? (string) $language_meta['sprite'] : '';
-                                        $aria_label = isset($language_meta['aria_label']) ? (string) $language_meta['aria_label'] : (string) ($badge['label'] ?? '');
-                                        $readable_label = isset($language_meta['label']) ? (string) $language_meta['label'] : (string) ($badge['label'] ?? '');
-                                        $code = isset($language_meta['code']) ? (string) $language_meta['code'] : (string) ($badge['label'] ?? '');
-                                        ?>
-                                        <li class="fp-exp-overview__language">
-                                            <?php if ($sprite_id) : ?>
-                                                <span class="fp-exp-overview__language-flag" role="img" aria-label="<?php echo esc_attr($aria_label); ?>">
-                                                    <svg viewBox="0 0 24 16" aria-hidden="true" focusable="false">
-                                                        <use href="<?php echo esc_url($language_sprite . '#' . $sprite_id); ?>"></use>
-                                                    </svg>
-                                                </span>
-                                            <?php endif; ?>
-                                            <span class="fp-exp-overview__language-code"><?php echo esc_html($code); ?></span>
-                                            <span class="screen-reader-text"><?php echo esc_html($readable_label); ?></span>
-                                        </li>
-                                    <?php endforeach; ?>
-                                </ul>
-                                <?php if (! empty($overview_language_terms)) : ?>
-                                    <span class="fp-exp-overview__muted"><?php echo esc_html(implode(', ', array_map('strval', $overview_language_terms))); ?></span>
-                                <?php endif; ?>
-                            </div>
-                        <?php endif; ?>
-
-                        <?php if (! empty($overview_biases)) : ?>
-                            <div class="fp-exp-overview__item">
-                                <span class="fp-exp-overview__label"><?php esc_html_e('Badge di fiducia', 'fp-experiences'); ?></span>
-                                <ul class="fp-exp-overview__chips" role="list">
-                                    <?php foreach ($overview_biases as $bias) :
-                                        $label = isset($bias['label']) ? (string) $bias['label'] : '';
-                                        if ('' === $label) {
-                                            continue;
-                                        }
-
-                                        $tagline = isset($bias['tagline']) ? (string) $bias['tagline'] : '';
-                                        $description = isset($bias['description']) ? (string) $bias['description'] : '';
-                                        $icon_name = isset($bias['icon']) ? (string) $bias['icon'] : '';
-                                        $icon_svg = \FP_Exp\Utils\Helpers::cognitive_bias_icon_svg($icon_name);
-                                        $chip_label_parts = array_values(array_filter([$label, $tagline, $description]));
-                                        $chip_label_text = ! empty($chip_label_parts)
-                                            ? implode(' – ', array_unique($chip_label_parts))
-                                            : '';
-                                        ?>
-                                        <li
-                                            class="fp-exp-overview__chip"
-                                            <?php if ('' !== $chip_label_text) : ?>title="<?php echo esc_attr($chip_label_text); ?>" aria-label="<?php echo esc_attr($chip_label_text); ?>"<?php endif; ?>
-                                        >
-                                            <span class="fp-exp-overview__chip-icon" aria-hidden="true"><?php echo $icon_svg; ?></span>
-                                            <span class="fp-exp-overview__chip-body">
-                                                <span class="fp-exp-overview__chip-label"><?php echo esc_html($label); ?></span>
-                                                <?php if ('' !== $tagline) : ?>
-                                                    <span class="fp-exp-overview__chip-tagline"><?php echo esc_html($tagline); ?></span>
-                                                <?php endif; ?>
-                                                <?php if ('' !== $description) : ?>
-                                                    <span class="fp-exp-overview__chip-description"><?php echo esc_html($description); ?></span>
-                                                <?php endif; ?>
-                                            </span>
-                                        </li>
-                                    <?php endforeach; ?>
-                                </ul>
-                            </div>
-                        <?php endif; ?>
-
-                        <?php if ('' !== $overview_meeting_summary) : ?>
-                            <div class="fp-exp-overview__item">
-                                <span class="fp-exp-overview__label"><?php esc_html_e('Meeting point', 'fp-experiences'); ?></span>
-                                <?php if ('' !== $overview_meeting_title) : ?>
-                                    <span class="fp-exp-overview__value"><?php echo esc_html($overview_meeting_title); ?></span>
-                                <?php endif; ?>
-                                <?php if ('' !== $overview_meeting_address) : ?>
-                                    <span class="fp-exp-overview__muted"><?php echo esc_html($overview_meeting_address); ?></span>
-                                <?php endif; ?>
-                            </div>
-                        <?php endif; ?>
-
-                        <?php if ($overview_family) : ?>
-                            <div class="fp-exp-overview__item">
-                                <span class="fp-exp-overview__label"><?php esc_html_e('Family', 'fp-experiences'); ?></span>
-                                <span class="fp-exp-overview__value fp-exp-overview__value--badge"><?php esc_html_e('Family friendly', 'fp-experiences'); ?></span>
-                            </div>
-                        <?php endif; ?>
-                    </div>
+                                $tagline = isset($bias['tagline']) ? (string) $bias['tagline'] : '';
+                                $description = isset($bias['description']) ? (string) $bias['description'] : '';
+                                $icon_name = isset($bias['icon']) ? (string) $bias['icon'] : '';
+                                $icon_svg = \FP_Exp\Utils\Helpers::cognitive_bias_icon_svg($icon_name);
+                                $chip_label_parts = array_values(array_filter([$label, $tagline, $description]));
+                                $chip_label_text = ! empty($chip_label_parts)
+                                    ? implode(' – ', array_unique($chip_label_parts))
+                                    : '';
+                                ?>
+                                <li
+                                    class="fp-exp-overview__chip"
+                                    <?php if ('' !== $chip_label_text) : ?>title="<?php echo esc_attr($chip_label_text); ?>" aria-label="<?php echo esc_attr($chip_label_text); ?>"<?php endif; ?>
+                                >
+                                    <span class="fp-exp-overview__chip-icon" aria-hidden="true"><?php echo $icon_svg; ?></span>
+                                    <span class="fp-exp-overview__chip-body">
+                                        <span class="fp-exp-overview__chip-label"><?php echo esc_html($label); ?></span>
+                                        <?php if ('' !== $tagline) : ?>
+                                            <span class="fp-exp-overview__chip-tagline"><?php echo esc_html($tagline); ?></span>
+                                        <?php endif; ?>
+                                        <?php if ('' !== $description) : ?>
+                                            <span class="fp-exp-overview__chip-description"><?php echo esc_html($description); ?></span>
+                                        <?php endif; ?>
+                                    </span>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php endif; ?>
                 </section>
             <?php endif; ?>
 
@@ -484,6 +402,7 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
                     id="fp-exp-gift"
                     data-fp-gift
                     data-fp-gift-config="<?php echo esc_attr(wp_json_encode($gift_config)); ?>"
+                    hidden
                 >
                     <div class="fp-gift__inner">
                         <h2 class="fp-gift__title"><?php esc_html_e('Gift this experience', 'fp-experiences'); ?></h2>

--- a/build/fp-experiences/templates/front/widget.php
+++ b/build/fp-experiences/templates/front/widget.php
@@ -147,7 +147,7 @@ $rtb_submit_label = 'pay_later' === $rtb_mode
                 <li class="fp-exp-step fp-exp-step--addons" data-fp-step="addons">
                     <header>
                         <span class="fp-exp-step__number">3</span>
-                        <h3 class="fp-exp-step__title"><?php echo esc_html__('Add-ons', 'fp-experiences'); ?></h3>
+                        <h3 class="fp-exp-step__title"><?php echo esc_html__('Extra', 'fp-experiences'); ?></h3>
                     </header>
                     <div class="fp-exp-step__content">
                         <ul class="fp-exp-addons">
@@ -159,8 +159,10 @@ $rtb_submit_label = 'pay_later' === $rtb_mode
                                 $image_height = isset($addon_image['height']) ? (int) $addon_image['height'] : 0;
                                 ?>
                                 <li class="fp-exp-addon" data-addon="<?php echo esc_attr($addon['slug']); ?>">
-                                    <label>
-                                        <input type="checkbox" value="1">
+                                    <label class="fp-exp-addon__card">
+                                        <span class="fp-exp-addon__input">
+                                            <input type="checkbox" value="1">
+                                        </span>
                                         <span class="fp-exp-addon__media">
                                             <?php if ($image_url) : ?>
                                                 <img
@@ -181,16 +183,18 @@ $rtb_submit_label = 'pay_later' === $rtb_mode
                                                         </g>
                                                     </svg>
                                                 </span>
-                                                <span class="screen-reader-text"><?php esc_html_e('Nessuna immagine disponibile per questo add-on', 'fp-experiences'); ?></span>
+                                                <span class="screen-reader-text"><?php esc_html_e('Nessuna immagine disponibile per questo extra', 'fp-experiences'); ?></span>
                                             <?php endif; ?>
                                         </span>
-                                        <span class="fp-exp-addon__details">
-                                            <span class="fp-exp-addon__label"><?php echo esc_html($addon['label']); ?></span>
+                                        <span class="fp-exp-addon__content">
+                                            <span class="fp-exp-addon__header">
+                                                <span class="fp-exp-addon__label"><?php echo esc_html($addon['label']); ?></span>
+                                                <span class="fp-exp-addon__price" data-price="<?php echo esc_attr((string) $addon['price']); ?>">€<?php echo esc_html(number_format_i18n((float) $addon['price'], 2)); ?></span>
+                                            </span>
                                             <?php if (! empty($addon['description'])) : ?>
-                                                <small class="fp-exp-addon__description"><?php echo esc_html($addon['description']); ?></small>
+                                                <p class="fp-exp-addon__summary"><?php echo esc_html($addon['description']); ?></p>
                                             <?php endif; ?>
                                         </span>
-                                        <span class="fp-exp-addon__price" data-price="<?php echo esc_attr((string) $addon['price']); ?>">€<?php echo esc_html(number_format_i18n((float) $addon['price'], 2)); ?></span>
                                     </label>
                                 </li>
                             <?php endforeach; ?>

--- a/docs/ADMIN-GUIDE.md
+++ b/docs/ADMIN-GUIDE.md
@@ -1,7 +1,7 @@
 # Admin Guide – FP Experiences 0.3.0
 
 ## Add-on images
-- Open an experience and switch to the **Extra/Add-ons** tab.
+- Open an experience and switch to the **Extra** tab.
 - Each add-on row includes a “Scegli immagine” button that opens the WordPress media modal.
 - Select or upload an image (medium size is used on the front end). Remove the image with “Rimuovi”.
 - Images are saved as attachment IDs in `_fp_addons` and lazy-loaded on the widget and listing cards.

--- a/languages/fp-experiences.pot
+++ b/languages/fp-experiences.pot
@@ -292,11 +292,11 @@ msgstr ""
 
 #: src/Admin/CalendarAdmin.php:302
 #: templates/front/widget.php:188
-msgid "Add-ons"
+msgid "Extra"
 msgstr ""
 
 #: src/Admin/CalendarAdmin.php:320
-msgid "No add-ons configured for this experience."
+msgid "No extras configured for this experience."
 msgstr ""
 
 #: src/Admin/CalendarAdmin.php:326
@@ -675,11 +675,11 @@ msgid "Capienza massima gruppo"
 msgstr ""
 
 #: src/Admin/ExperienceMetaBoxes.php:467
-msgid "Add-on"
+msgid "Extra"
 msgstr ""
 
 #: src/Admin/ExperienceMetaBoxes.php:483
-msgid "Aggiungi add-on"
+msgid "Aggiungi extra"
 msgstr ""
 
 #: src/Admin/ExperienceMetaBoxes.php:490
@@ -911,7 +911,7 @@ msgid "Capienza"
 msgstr ""
 
 #: src/Admin/ExperienceMetaBoxes.php:918
-msgid "Nome add-on"
+msgid "Nome extra"
 msgstr ""
 
 #: src/Admin/ExperienceMetaBoxes.php:919
@@ -3478,6 +3478,11 @@ msgstr ""
 
 #: templates/front/widget.php:244
 msgid "Enter your email address."
+msgstr ""
+
+#: templates/front/experience.php:316
+#: build/fp-experiences/templates/front/experience.php:314
+msgid "Perché prenotare con noi"
 msgstr ""
 
 #: templates/front/widget.php:246

--- a/src/Admin/CalendarAdmin.php
+++ b/src/Admin/CalendarAdmin.php
@@ -305,7 +305,7 @@ final class CalendarAdmin
         }
         echo '</td></tr>';
 
-        echo '<tr><th scope="row"><label>' . esc_html__('Add-ons', 'fp-experiences') . '</label></th><td>';
+        echo '<tr><th scope="row"><label>' . esc_html__('Extra', 'fp-experiences') . '</label></th><td>';
         if ($addon_config) {
             $currency = (string) get_option('woocommerce_currency', 'EUR');
             foreach ($addon_config as $slug => $addon) {
@@ -323,7 +323,7 @@ final class CalendarAdmin
                 }
             }
         } else {
-            echo '<p>' . esc_html__('No add-ons configured for this experience.', 'fp-experiences') . '</p>';
+            echo '<p>' . esc_html__('No extras configured for this experience.', 'fp-experiences') . '</p>';
         }
         echo '</td></tr>';
 

--- a/src/Admin/ExperienceMetaBoxes.php
+++ b/src/Admin/ExperienceMetaBoxes.php
@@ -857,7 +857,7 @@ final class ExperienceMetaBoxes
             </fieldset>
 
             <fieldset class="fp-exp-fieldset">
-                <legend><?php esc_html_e('Add-on', 'fp-experiences'); ?></legend>
+                <legend><?php esc_html_e('Extra', 'fp-experiences'); ?></legend>
                 <div
                     class="fp-exp-repeater"
                     data-repeater="addons"
@@ -873,7 +873,7 @@ final class ExperienceMetaBoxes
                     </template>
                     <p class="fp-exp-repeater__actions">
                         <button type="button" class="button button-secondary" data-repeater-add>
-                            <?php esc_html_e('Aggiungi add-on', 'fp-experiences'); ?>
+                            <?php esc_html_e('Aggiungi extra', 'fp-experiences'); ?>
                         </button>
                     </p>
                 </div>
@@ -1435,6 +1435,7 @@ final class ExperienceMetaBoxes
         $type_name = $is_template ? 'fp_exp_pricing[addons][__INDEX__][type]' : $name_prefix . '[type]';
         $slug_name = $is_template ? 'fp_exp_pricing[addons][__INDEX__][slug]' : $name_prefix . '[slug]';
         $image_name = $is_template ? 'fp_exp_pricing[addons][__INDEX__][image_id]' : $name_prefix . '[image_id]';
+        $description_name = $is_template ? 'fp_exp_pricing[addons][__INDEX__][description]' : $name_prefix . '[description]';
         $type_value = isset($addon['type']) ? (string) $addon['type'] : 'person';
         $image_id = isset($addon['image_id']) ? absint((string) $addon['image_id']) : 0;
         $image = $image_id > 0 ? wp_get_attachment_image_src($image_id, 'thumbnail') : false;
@@ -1497,12 +1498,16 @@ final class ExperienceMetaBoxes
                     </div>
                 </div>
                 <label>
-                    <span class="fp-exp-field__label"><?php esc_html_e('Nome add-on', 'fp-experiences'); ?></span>
+                    <span class="fp-exp-field__label"><?php esc_html_e('Nome extra', 'fp-experiences'); ?></span>
                     <input type="text" <?php echo $this->field_name_attribute($label_name, $is_template); ?> value="<?php echo esc_attr((string) ($addon['name'] ?? '')); ?>" placeholder="<?php echo esc_attr__('Transfer', 'fp-experiences'); ?>" />
                 </label>
                 <label>
                     <span class="fp-exp-field__label"><?php esc_html_e('Codice', 'fp-experiences'); ?></span>
                     <input type="text" <?php echo $this->field_name_attribute($slug_name, $is_template); ?> value="<?php echo esc_attr((string) ($addon['slug'] ?? '')); ?>" placeholder="<?php echo esc_attr__('transfer', 'fp-experiences'); ?>" />
+                </label>
+                <label>
+                    <span class="fp-exp-field__label"><?php esc_html_e('Descrizione breve', 'fp-experiences'); ?></span>
+                    <textarea rows="2" maxlength="160" <?php echo $this->field_name_attribute($description_name, $is_template); ?>><?php echo esc_textarea((string) ($addon['description'] ?? '')); ?></textarea>
                 </label>
                 <label>
                     <span class="fp-exp-field__label"><?php esc_html_e('Prezzo (€)', 'fp-experiences'); ?></span>
@@ -1847,6 +1852,7 @@ final class ExperienceMetaBoxes
                 $type = isset($addon['type']) ? sanitize_key((string) $addon['type']) : 'person';
                 $slug = isset($addon['slug']) ? sanitize_key((string) $addon['slug']) : '';
                 $image_id = isset($addon['image_id']) ? absint((string) $addon['image_id']) : 0;
+                $description = isset($addon['description']) ? sanitize_text_field((string) $addon['description']) : '';
                 if ($image_id > 0 && ! wp_attachment_is_image($image_id)) {
                     $image_id = 0;
                 }
@@ -1868,6 +1874,7 @@ final class ExperienceMetaBoxes
                     'type' => $type,
                     'slug' => $slug,
                     'image_id' => $image_id,
+                    'description' => $description,
                 ];
 
                 $legacy_addons[] = [
@@ -1876,7 +1883,7 @@ final class ExperienceMetaBoxes
                     'price' => $price,
                     'allow_multiple' => 'booking' !== $type,
                     'max' => 0,
-                    'description' => '',
+                    'description' => $description,
                     'image_id' => $image_id,
                 ];
             }

--- a/src/Shortcodes/ExperienceShortcode.php
+++ b/src/Shortcodes/ExperienceShortcode.php
@@ -651,25 +651,25 @@ final class ExperienceShortcode extends BaseShortcode
             return false;
         }
 
-        $has_themes = ! empty($overview['themes']);
-        $has_languages = ! empty($overview['language_badges']);
-        $has_biases = ! empty($overview['cognitive_biases']);
-        $has_short_description = '' !== ($overview['short_description'] ?? '');
+        $biases = $overview['cognitive_biases'] ?? [];
 
-        $meeting = $overview['meeting'] ?? [];
-        $meeting_summary = '';
-        if (is_array($meeting)) {
-            $meeting_summary = (string) ($meeting['summary'] ?? '');
+        if (! is_array($biases)) {
+            return false;
         }
 
-        $has_family = ! empty($overview['family_friendly']);
+        foreach ($biases as $bias) {
+            if (is_array($bias)) {
+                $label = isset($bias['label']) ? (string) $bias['label'] : '';
+            } else {
+                $label = (string) $bias;
+            }
 
-        return $has_themes
-            || $has_languages
-            || $has_biases
-            || $has_short_description
-            || '' !== $meeting_summary
-            || $has_family;
+            if ('' !== trim($label)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Utils/Helpers.php
+++ b/src/Utils/Helpers.php
@@ -72,7 +72,7 @@ final class Helpers
      */
     private static ?array $cognitive_bias_icon_cache = null;
 
-    public const COGNITIVE_BIAS_MAX_SELECTION = 3;
+    public const COGNITIVE_BIAS_MAX_SELECTION = 6;
 
     public static function cognitive_bias_max_selection(): int
     {

--- a/templates/front/experience.php
+++ b/templates/front/experience.php
@@ -108,9 +108,6 @@ $experience_summary = isset($experience['summary']) ? (string) $experience['summ
 $hero_summary = '' !== $experience_summary ? $experience_summary : $experience_short_description;
 
 $overview = isset($overview) && is_array($overview) ? $overview : [];
-$overview_themes = isset($overview['themes']) && is_array($overview['themes']) ? $overview['themes'] : [];
-$overview_languages = isset($overview['language_badges']) && is_array($overview['language_badges']) ? $overview['language_badges'] : [];
-$overview_language_terms = isset($overview['language_terms']) && is_array($overview['language_terms']) ? $overview['language_terms'] : [];
 $overview_biases = isset($overview['cognitive_biases']) && is_array($overview['cognitive_biases'])
     ? array_values(array_filter(array_map(
         static function ($bias) {
@@ -139,21 +136,14 @@ $overview_biases = isset($overview['cognitive_biases']) && is_array($overview['c
         $overview['cognitive_biases']
     )))
     : [];
-$overview_short_description = isset($overview['short_description']) ? (string) $overview['short_description'] : '';
 $overview_meeting = isset($overview['meeting']) && is_array($overview['meeting']) ? $overview['meeting'] : [];
 $overview_meeting_title = isset($overview_meeting['title']) ? (string) $overview_meeting['title'] : '';
 $overview_meeting_address = isset($overview_meeting['address']) ? (string) $overview_meeting['address'] : '';
 $overview_meeting_summary = isset($overview_meeting['summary']) ? (string) $overview_meeting['summary'] : '';
-$overview_family = ! empty($overview['family_friendly']);
 $overview_has_content = isset($overview_has_content) ? (bool) $overview_has_content : null;
 
 if (null === $overview_has_content) {
-    $overview_has_content = ! empty($overview_themes)
-        || ! empty($overview_languages)
-        || ! empty($overview_biases)
-        || '' !== $overview_short_description
-        || '' !== $overview_meeting_summary
-        || $overview_family;
+    $overview_has_content = ! empty($overview_biases);
 }
 
 $has_overview = ! empty($sections['overview']) && $overview_has_content;
@@ -222,7 +212,6 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
 
                         <div class="fp-exp-hero__content">
                             <header class="fp-exp-hero__header">
-                                <span class="fp-exp-hero__eyebrow">FP Experiences</span>
                                 <h1 class="fp-exp-hero__title"><?php echo esc_html($experience['title']); ?></h1>
                                 <?php if ('' !== $hero_summary) : ?>
                                     <p class="fp-exp-hero__summary"><?php echo esc_html($hero_summary); ?></p>
@@ -234,7 +223,9 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
                                     <?php foreach ($hero_highlights as $highlight) : ?>
                                         <li class="fp-exp-hero__highlight">
                                             <span class="fp-exp-hero__highlight-icon" aria-hidden="true">
-                                                <svg viewBox="0 0 24 24"><path fill="currentColor" d="M9.75 18.25 3.5 12l1.41 1-1.41 4.84 4.84 9.34-9.34L20.5 7.5Z"/></svg>
+                                                <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                                                    <path fill="currentColor" d="M9.75 18.25 3.5 12l1.41-1.41 4.84 4.84 9.34-9.34L20.5 7.5Z" />
+                                                </svg>
                                             </span>
                                             <span class="fp-exp-hero__highlight-text"><?php echo esc_html($highlight); ?></span>
                                         </li>
@@ -306,13 +297,15 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
                             <h2 class="fp-exp-gift__title fp-exp-section__title"><?php esc_html_e('Gift this experience', 'fp-experiences'); ?></h2>
                             <p class="fp-exp-gift__description"><?php esc_html_e('Acquista un voucher e invialo con un messaggio personalizzato in pochi clic.', 'fp-experiences'); ?></p>
                         </div>
-                        <a
-                            href="#fp-exp-gift"
+                        <button
+                            type="button"
                             class="fp-exp-button fp-exp-button--secondary"
                             data-fp-gift-toggle
+                            aria-controls="fp-exp-gift"
+                            aria-expanded="false"
                         >
                             <?php esc_html_e('Gift this experience', 'fp-experiences'); ?>
-                        </a>
+                        </button>
                     </div>
                 </section>
             <?php endif; ?>
@@ -320,119 +313,44 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
             <?php if ($has_overview) : ?>
                 <section class="fp-exp-section fp-exp-overview" id="fp-exp-section-overview" data-fp-section="overview">
                     <header class="fp-exp-section__header fp-exp-overview__header">
-                        <span class="fp-exp-section__eyebrow"><?php esc_html_e('Overview', 'fp-experiences'); ?></span>
-                        <h2 class="fp-exp-section__title"><?php esc_html_e('Key details at a glance', 'fp-experiences'); ?></h2>
-                        <?php if ('' !== $overview_short_description) : ?>
-                            <p class="fp-exp-overview__summary"><?php echo esc_html($overview_short_description); ?></p>
-                        <?php elseif ('' !== $hero_summary) : ?>
-                            <p class="fp-exp-overview__summary"><?php echo esc_html($hero_summary); ?></p>
-                        <?php endif; ?>
+                        <h2 class="fp-exp-section__title"><?php esc_html_e('Perché prenotare con noi', 'fp-experiences'); ?></h2>
                     </header>
 
-                    <div class="fp-exp-overview__grid">
-                        <?php if (! empty($overview_themes)) : ?>
-                            <div class="fp-exp-overview__item">
-                                <span class="fp-exp-overview__label"><?php esc_html_e('Themes', 'fp-experiences'); ?></span>
-                                <div class="fp-exp-overview__chips">
-                                    <?php foreach ($overview_themes as $theme) : ?>
-                                        <span class="fp-exp-overview__chip"><?php echo esc_html((string) $theme); ?></span>
-                                    <?php endforeach; ?>
-                                </div>
-                            </div>
-                        <?php endif; ?>
+                    <?php if (! empty($overview_biases)) : ?>
+                        <ul class="fp-exp-overview__trust-list" role="list">
+                            <?php foreach ($overview_biases as $bias) :
+                                $label = isset($bias['label']) ? (string) $bias['label'] : '';
+                                if ('' === $label) {
+                                    continue;
+                                }
 
-                        <?php if (! empty($overview_languages)) : ?>
-                            <div class="fp-exp-overview__item">
-                                <span class="fp-exp-overview__label"><?php esc_html_e('Languages', 'fp-experiences'); ?></span>
-                                <ul class="fp-exp-overview__languages" role="list">
-                                    <?php foreach ($overview_languages as $badge) :
-                                        if (! is_array($badge)) {
-                                            continue;
-                                        }
-
-                                        $language_meta = isset($badge['language']) && is_array($badge['language']) ? $badge['language'] : [];
-                                        $sprite_id = isset($language_meta['sprite']) ? (string) $language_meta['sprite'] : '';
-                                        $aria_label = isset($language_meta['aria_label']) ? (string) $language_meta['aria_label'] : (string) ($badge['label'] ?? '');
-                                        $readable_label = isset($language_meta['label']) ? (string) $language_meta['label'] : (string) ($badge['label'] ?? '');
-                                        $code = isset($language_meta['code']) ? (string) $language_meta['code'] : (string) ($badge['label'] ?? '');
-                                        ?>
-                                        <li class="fp-exp-overview__language">
-                                            <?php if ($sprite_id) : ?>
-                                                <span class="fp-exp-overview__language-flag" role="img" aria-label="<?php echo esc_attr($aria_label); ?>">
-                                                    <svg viewBox="0 0 24 16" aria-hidden="true" focusable="false">
-                                                        <use href="<?php echo esc_url($language_sprite . '#' . $sprite_id); ?>"></use>
-                                                    </svg>
-                                                </span>
-                                            <?php endif; ?>
-                                            <span class="fp-exp-overview__language-code"><?php echo esc_html($code); ?></span>
-                                            <span class="screen-reader-text"><?php echo esc_html($readable_label); ?></span>
-                                        </li>
-                                    <?php endforeach; ?>
-                                </ul>
-                                <?php if (! empty($overview_language_terms)) : ?>
-                                    <span class="fp-exp-overview__muted"><?php echo esc_html(implode(', ', array_map('strval', $overview_language_terms))); ?></span>
-                                <?php endif; ?>
-                            </div>
-                        <?php endif; ?>
-
-                        <?php if (! empty($overview_biases)) : ?>
-                            <div class="fp-exp-overview__item">
-                                <span class="fp-exp-overview__label"><?php esc_html_e('Badge di fiducia', 'fp-experiences'); ?></span>
-                                <ul class="fp-exp-overview__chips" role="list">
-                                    <?php foreach ($overview_biases as $bias) :
-                                        $label = isset($bias['label']) ? (string) $bias['label'] : '';
-                                        if ('' === $label) {
-                                            continue;
-                                        }
-
-                                        $tagline = isset($bias['tagline']) ? (string) $bias['tagline'] : '';
-                                        $description = isset($bias['description']) ? (string) $bias['description'] : '';
-                                        $icon_name = isset($bias['icon']) ? (string) $bias['icon'] : '';
-                                        $icon_svg = \FP_Exp\Utils\Helpers::cognitive_bias_icon_svg($icon_name);
-                                        $chip_label_parts = array_values(array_filter([$label, $tagline, $description]));
-                                        $chip_label_text = ! empty($chip_label_parts)
-                                            ? implode(' – ', array_unique($chip_label_parts))
-                                            : '';
-                                        ?>
-                                        <li
-                                            class="fp-exp-overview__chip"
-                                            <?php if ('' !== $chip_label_text) : ?>title="<?php echo esc_attr($chip_label_text); ?>" aria-label="<?php echo esc_attr($chip_label_text); ?>"<?php endif; ?>
-                                        >
-                                            <span class="fp-exp-overview__chip-icon" aria-hidden="true"><?php echo $icon_svg; ?></span>
-                                            <span class="fp-exp-overview__chip-body">
-                                                <span class="fp-exp-overview__chip-label"><?php echo esc_html($label); ?></span>
-                                                <?php if ('' !== $tagline) : ?>
-                                                    <span class="fp-exp-overview__chip-tagline"><?php echo esc_html($tagline); ?></span>
-                                                <?php endif; ?>
-                                                <?php if ('' !== $description) : ?>
-                                                    <span class="fp-exp-overview__chip-description"><?php echo esc_html($description); ?></span>
-                                                <?php endif; ?>
-                                            </span>
-                                        </li>
-                                    <?php endforeach; ?>
-                                </ul>
-                            </div>
-                        <?php endif; ?>
-
-                        <?php if ('' !== $overview_meeting_summary) : ?>
-                            <div class="fp-exp-overview__item">
-                                <span class="fp-exp-overview__label"><?php esc_html_e('Meeting point', 'fp-experiences'); ?></span>
-                                <?php if ('' !== $overview_meeting_title) : ?>
-                                    <span class="fp-exp-overview__value"><?php echo esc_html($overview_meeting_title); ?></span>
-                                <?php endif; ?>
-                                <?php if ('' !== $overview_meeting_address) : ?>
-                                    <span class="fp-exp-overview__muted"><?php echo esc_html($overview_meeting_address); ?></span>
-                                <?php endif; ?>
-                            </div>
-                        <?php endif; ?>
-
-                        <?php if ($overview_family) : ?>
-                            <div class="fp-exp-overview__item">
-                                <span class="fp-exp-overview__label"><?php esc_html_e('Family', 'fp-experiences'); ?></span>
-                                <span class="fp-exp-overview__value fp-exp-overview__value--badge"><?php esc_html_e('Family friendly', 'fp-experiences'); ?></span>
-                            </div>
-                        <?php endif; ?>
-                    </div>
+                                $tagline = isset($bias['tagline']) ? (string) $bias['tagline'] : '';
+                                $description = isset($bias['description']) ? (string) $bias['description'] : '';
+                                $icon_name = isset($bias['icon']) ? (string) $bias['icon'] : '';
+                                $icon_svg = \FP_Exp\Utils\Helpers::cognitive_bias_icon_svg($icon_name);
+                                $chip_label_parts = array_values(array_filter([$label, $tagline, $description]));
+                                $chip_label_text = ! empty($chip_label_parts)
+                                    ? implode(' – ', array_unique($chip_label_parts))
+                                    : '';
+                                ?>
+                                <li
+                                    class="fp-exp-overview__chip"
+                                    <?php if ('' !== $chip_label_text) : ?>title="<?php echo esc_attr($chip_label_text); ?>" aria-label="<?php echo esc_attr($chip_label_text); ?>"<?php endif; ?>
+                                >
+                                    <span class="fp-exp-overview__chip-icon" aria-hidden="true"><?php echo $icon_svg; ?></span>
+                                    <span class="fp-exp-overview__chip-body">
+                                        <span class="fp-exp-overview__chip-label"><?php echo esc_html($label); ?></span>
+                                        <?php if ('' !== $tagline) : ?>
+                                            <span class="fp-exp-overview__chip-tagline"><?php echo esc_html($tagline); ?></span>
+                                        <?php endif; ?>
+                                        <?php if ('' !== $description) : ?>
+                                            <span class="fp-exp-overview__chip-description"><?php echo esc_html($description); ?></span>
+                                        <?php endif; ?>
+                                    </span>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php endif; ?>
                 </section>
             <?php endif; ?>
 
@@ -486,6 +404,7 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
                     id="fp-exp-gift"
                     data-fp-gift
                     data-fp-gift-config="<?php echo esc_attr(wp_json_encode($gift_config)); ?>"
+                    hidden
                 >
                     <div class="fp-gift__inner">
                         <h2 class="fp-gift__title"><?php esc_html_e('Gift this experience', 'fp-experiences'); ?></h2>

--- a/templates/front/widget.php
+++ b/templates/front/widget.php
@@ -187,7 +187,7 @@ $format_currency = static function (string $amount) use ($currency_symbol, $curr
                 <li class="fp-exp-step fp-exp-step--addons" data-fp-step="addons">
                     <header>
                         <span class="fp-exp-step__number">3</span>
-                        <h3 class="fp-exp-step__title"><?php echo esc_html__('Add-ons', 'fp-experiences'); ?></h3>
+                        <h3 class="fp-exp-step__title"><?php echo esc_html__('Extra', 'fp-experiences'); ?></h3>
                     </header>
                     <div class="fp-exp-step__content">
                         <ul class="fp-exp-addons">
@@ -199,8 +199,10 @@ $format_currency = static function (string $amount) use ($currency_symbol, $curr
                                 $image_height = isset($addon_image['height']) ? (int) $addon_image['height'] : 0;
                                 ?>
                                 <li class="fp-exp-addon" data-addon="<?php echo esc_attr($addon['slug']); ?>">
-                                    <label>
-                                        <input type="checkbox" value="1">
+                                    <label class="fp-exp-addon__card">
+                                        <span class="fp-exp-addon__input">
+                                            <input type="checkbox" value="1">
+                                        </span>
                                         <span class="fp-exp-addon__media">
                                             <?php if ($image_url) : ?>
                                                 <img
@@ -221,19 +223,21 @@ $format_currency = static function (string $amount) use ($currency_symbol, $curr
                                                         </g>
                                                     </svg>
                                                 </span>
-                                                <span class="screen-reader-text"><?php esc_html_e('Nessuna immagine disponibile per questo add-on', 'fp-experiences'); ?></span>
+                                                <span class="screen-reader-text"><?php esc_html_e('Nessuna immagine disponibile per questo extra', 'fp-experiences'); ?></span>
                                             <?php endif; ?>
                                         </span>
-                                        <span class="fp-exp-addon__details">
-                                            <span class="fp-exp-addon__label"><?php echo esc_html($addon['label']); ?></span>
+                                        <span class="fp-exp-addon__content">
+                                            <span class="fp-exp-addon__header">
+                                                <span class="fp-exp-addon__label"><?php echo esc_html($addon['label']); ?></span>
+                                                <?php
+                                                $addon_price_display = $format_currency(number_format_i18n((float) $addon['price'], 2));
+                                                ?>
+                                                <span class="fp-exp-addon__price" data-price="<?php echo esc_attr((string) $addon['price']); ?>"><?php echo esc_html($addon_price_display); ?></span>
+                                            </span>
                                             <?php if (! empty($addon['description'])) : ?>
-                                                <small class="fp-exp-addon__description"><?php echo esc_html($addon['description']); ?></small>
+                                                <p class="fp-exp-addon__summary"><?php echo esc_html($addon['description']); ?></p>
                                             <?php endif; ?>
                                         </span>
-                                        <?php
-                                        $addon_price_display = $format_currency(number_format_i18n((float) $addon['price'], 2));
-                                        ?>
-                                        <span class="fp-exp-addon__price" data-price="<?php echo esc_attr((string) $addon['price']); ?>"><?php echo esc_html($addon_price_display); ?></span>
                                     </label>
                                 </li>
                             <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- replace the overview content with a trust-badge grid and retitle the section accordingly
- allow selecting and displaying up to six trust badges while keeping shortcode gating in sync
- prune unused overview styles and update the translation catalog

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deb70cea34832f9baad12f12ba1799