### PR TITLE
Debug and fix plugin update issue

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install composer deps (no dev)
         run: |
           composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader
-          composer dump-autoload -o --classmap-authoritative
+          composer dump-autoload -o
 
       - name: Ensure tools present
         run: |

--- a/build.sh
+++ b/build.sh
@@ -104,7 +104,7 @@ else
 fi
 
 composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader
-composer dump-autoload -o --classmap-authoritative
+composer dump-autoload -o
 
 BUILD_ROOT="$ROOT_DIR/build"
 TARGET_DIR="$BUILD_ROOT/$PLUGIN_SLUG"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "build": [
             "rm -rf vendor",
             "composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader",
-            "composer dump-autoload -o --classmap-authoritative"
+            "composer dump-autoload -o"
         ]
     }
 }

--- a/sync-build.sh
+++ b/sync-build.sh
@@ -30,5 +30,11 @@ cp "$ROOT_DIR/fp-experiences.php" "$TARGET_DIR/" 2>/dev/null || true
 cp "$ROOT_DIR/readme.txt" "$TARGET_DIR/" 2>/dev/null || true
 cp "$ROOT_DIR/uninstall.php" "$TARGET_DIR/" 2>/dev/null || true
 
+# Rigenera l'autoloader per assicurare che le modifiche vengano caricate
+if [[ -d "$TARGET_DIR/vendor" ]]; then
+    echo "  🔄 Rigenerando autoloader..."
+    (cd "$TARGET_DIR" && composer dump-autoload -o 2>/dev/null) || echo "  ⚠️  Impossibile rigenerare autoloader (opzionale)"
+fi
+
 echo "✅ Build sincronizzato con successo!"
 echo "📁 Modifiche applicate in: $TARGET_DIR"


### PR DESCRIPTION
Remove `--classmap-authoritative` from Composer commands and add autoloader regeneration to `sync-build.sh` to allow plugin updates to be recognized during development.

The `--classmap-authoritative` flag instructs Composer to rely solely on the classmap cache, ignoring filesystem changes. While beneficial for production performance, it prevented the plugin from reflecting code modifications, even with OPcache disabled. This change ensures that Composer rebuilds the autoloader and detects new code.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa18b23c-b362-4e7f-a673-76940fd7a086"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aa18b23c-b362-4e7f-a673-76940fd7a086"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

