### PR TITLE
Fix desktop calendar overflow bug

### DIFF
--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -1456,6 +1456,151 @@
 
 /* Layout mobile invariato: già a colonna */
 
+/* Calendario standalone senza navigazione */
+.fp-exp-calendar {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.fp-exp-calendar-only__header {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+.fp-exp-calendar-only__title {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--fp-color-text);
+}
+
+.fp-exp-calendar__month {
+    border: 1px solid rgba(15, 23, 42, 0.1);
+    border-radius: 12px;
+    padding: 1rem;
+    background: var(--fp-color-surface, #fff);
+}
+
+.fp-exp-calendar__month-header {
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: var(--fp-color-text);
+    margin-bottom: 1rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 2px solid var(--fp-color-primary);
+    text-align: center;
+}
+
+.fp-exp-calendar__weekdays {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 0.25rem;
+    margin-bottom: 0.5rem;
+}
+
+.fp-exp-calendar__weekday {
+    text-align: center;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--fp-color-muted);
+    text-transform: uppercase;
+    padding: 0.5rem 0.25rem;
+}
+
+.fp-exp-calendar__grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 0.25rem;
+    width: 100%;
+}
+
+.fp-exp-calendar__empty {
+    visibility: hidden;
+}
+
+.fp-exp-calendar__day {
+    border: 1px solid rgba(15, 23, 42, 0.1);
+    border-radius: 8px;
+    padding: 0.5rem 0.25rem;
+    background: var(--fp-color-surface, #fff);
+    cursor: pointer;
+    transition: all 0.2s ease;
+    font-weight: 500;
+    color: var(--fp-color-text);
+    text-align: center;
+    min-height: 2.5rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    font-size: 0.85rem;
+}
+
+.fp-exp-calendar__day:not(:disabled):hover {
+    border-color: var(--fp-color-primary);
+    box-shadow: 0 0 0 2px rgba(11, 110, 253, 0.15);
+    transform: translateY(-1px);
+}
+
+.fp-exp-calendar__day[aria-pressed="true"] {
+    border-color: var(--fp-color-primary);
+    background: color-mix(in srgb, var(--fp-color-primary) 12%, #fff);
+    box-shadow: 0 0 0 2px rgba(11, 110, 253, 0.25);
+}
+
+.fp-exp-calendar__day:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+    background: rgba(15, 23, 42, 0.02);
+}
+
+.fp-exp-calendar__day-label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    line-height: 1.2;
+}
+
+.fp-exp-calendar__day-count {
+    font-size: 0.65rem;
+    color: var(--fp-color-primary);
+    font-weight: 500;
+    margin-top: 0.15rem;
+    line-height: 1;
+}
+
+/* Responsive per desktop: più spazio per evitare overflow */
+@media (min-width: 768px) {
+    .fp-exp-calendar__grid {
+        gap: 0.5rem;
+        max-width: 100%;
+    }
+    
+    .fp-exp-calendar__day {
+        padding: 0.75rem 0.5rem;
+        min-height: 3.5rem;
+        font-size: 0.9rem;
+    }
+    
+    .fp-exp-calendar__day-label {
+        font-size: 0.95rem;
+    }
+    
+    .fp-exp-calendar__day-count {
+        font-size: 0.7rem;
+        margin-top: 0.25rem;
+    }
+    
+    .fp-exp-calendar__weekday {
+        font-size: 0.8rem;
+        padding: 0.5rem;
+    }
+    
+    .fp-exp-calendar__month {
+        padding: 1.5rem;
+    }
+}
+
 /* Calendario con navigazione mesi */
 .fp-exp-calendar-nav {
     margin-bottom: 1.5rem;

--- a/build/fp-experiences/assets/css/front.css
+++ b/build/fp-experiences/assets/css/front.css
@@ -1456,75 +1456,315 @@
 
 /* Layout mobile invariato: già a colonna */
 
-.fp-exp-calendar__grid,
-.fp-exp-calendar-only__days {
-    display: grid;
-    gap: 0.65rem;
+/* Calendario standalone senza navigazione */
+.fp-exp-calendar {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
 }
 
-/* Griglia 7 colonne e intestazioni per vista calendario */
-.fp-exp-calendar[data-show-calendar="1"] .fp-exp-calendar__weekdays,
-.fp-exp-calendar[data-show-calendar="1"] .fp-exp-calendar__grid {
+.fp-exp-calendar-only__header {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+.fp-exp-calendar-only__title {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--fp-color-text);
+}
+
+.fp-exp-calendar__month {
+    border: 1px solid rgba(15, 23, 42, 0.1);
+    border-radius: 12px;
+    padding: 1rem;
+    background: var(--fp-color-surface, #fff);
+}
+
+.fp-exp-calendar__month-header {
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: var(--fp-color-text);
+    margin-bottom: 1rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 2px solid var(--fp-color-primary);
+    text-align: center;
+}
+
+.fp-exp-calendar__weekdays {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 0.25rem;
+    margin-bottom: 0.5rem;
+}
+
+.fp-exp-calendar__weekday {
+    text-align: center;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--fp-color-muted);
+    text-transform: uppercase;
+    padding: 0.5rem 0.25rem;
+}
+
+.fp-exp-calendar__grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 0.25rem;
+    width: 100%;
+}
+
+.fp-exp-calendar__empty {
+    visibility: hidden;
+}
+
+.fp-exp-calendar__day {
+    border: 1px solid rgba(15, 23, 42, 0.1);
+    border-radius: 8px;
+    padding: 0.5rem 0.25rem;
+    background: var(--fp-color-surface, #fff);
+    cursor: pointer;
+    transition: all 0.2s ease;
+    font-weight: 500;
+    color: var(--fp-color-text);
+    text-align: center;
+    min-height: 2.5rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    font-size: 0.85rem;
+}
+
+.fp-exp-calendar__day:not(:disabled):hover {
+    border-color: var(--fp-color-primary);
+    box-shadow: 0 0 0 2px rgba(11, 110, 253, 0.15);
+    transform: translateY(-1px);
+}
+
+.fp-exp-calendar__day[aria-pressed="true"] {
+    border-color: var(--fp-color-primary);
+    background: color-mix(in srgb, var(--fp-color-primary) 12%, #fff);
+    box-shadow: 0 0 0 2px rgba(11, 110, 253, 0.25);
+}
+
+.fp-exp-calendar__day:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+    background: rgba(15, 23, 42, 0.02);
+}
+
+.fp-exp-calendar__day-label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    line-height: 1.2;
+}
+
+.fp-exp-calendar__day-count {
+    font-size: 0.65rem;
+    color: var(--fp-color-primary);
+    font-weight: 500;
+    margin-top: 0.15rem;
+    line-height: 1;
+}
+
+/* Responsive per desktop: più spazio per evitare overflow */
+@media (min-width: 768px) {
+    .fp-exp-calendar__grid {
+        gap: 0.5rem;
+        max-width: 100%;
+    }
+    
+    .fp-exp-calendar__day {
+        padding: 0.75rem 0.5rem;
+        min-height: 3.5rem;
+        font-size: 0.9rem;
+    }
+    
+    .fp-exp-calendar__day-label {
+        font-size: 0.95rem;
+    }
+    
+    .fp-exp-calendar__day-count {
+        font-size: 0.7rem;
+        margin-top: 0.25rem;
+    }
+    
+    .fp-exp-calendar__weekday {
+        font-size: 0.8rem;
+        padding: 0.5rem;
+    }
+    
+    .fp-exp-calendar__month {
+        padding: 1.5rem;
+    }
+}
+
+/* Calendario con navigazione mesi */
+.fp-exp-calendar-nav {
+    margin-bottom: 1.5rem;
+    border: 1px solid rgba(15, 23, 42, 0.1);
+    border-radius: 12px;
+    padding: 1rem;
+}
+
+.fp-exp-calendar-nav__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1.5rem;
+    padding-bottom: 1rem;
+    border-bottom: 2px solid var(--fp-color-primary);
+}
+
+.fp-exp-calendar-nav__prev-month,
+.fp-exp-calendar-nav__next-month {
+    background: var(--fp-color-primary);
+    color: white;
+    border: none;
+    border-radius: 50%;
+    width: 2.5rem;
+    height: 2.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-size: 1.2rem;
+    font-weight: bold;
+    transition: all 0.2s ease;
+}
+
+.fp-exp-calendar-nav__prev-month:hover,
+.fp-exp-calendar-nav__next-month:hover {
+    background: color-mix(in srgb, var(--fp-color-primary) 85%, #000);
+    transform: scale(1.05);
+}
+
+.fp-exp-calendar-nav__prev-month:disabled,
+.fp-exp-calendar-nav__next-month:disabled {
+    background: rgba(15, 23, 42, 0.3);
+    color: rgba(15, 23, 42, 0.5);
+    cursor: not-allowed;
+    transform: none;
+}
+
+.fp-exp-calendar-nav__title-container {
+    text-align: center;
+}
+
+.fp-exp-calendar-nav__month {
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: var(--fp-color-text);
+    margin: 0 0 0.25rem 0;
+}
+
+.fp-exp-calendar-nav__year {
+    font-size: 1rem;
+    font-weight: 500;
+    color: var(--fp-color-primary);
+    margin: 0;
+}
+
+.fp-exp-calendar-nav__grid {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
     gap: 0.5rem;
 }
 
-/* Fix per desktop: riduci gap per evitare overflow */
+/* Fix per desktop: riduci gap e padding per evitare overflow */
 @media (min-width: 768px) {
-    .fp-exp-calendar[data-show-calendar="1"] .fp-exp-calendar__weekdays,
-    .fp-exp-calendar[data-show-calendar="1"] .fp-exp-calendar__grid {
+    .fp-exp-calendar-nav__grid {
         gap: 0.1rem;
+    }
+    
+    .fp-exp-calendar-nav__day {
+        padding: 0.5rem 0.3rem;
     }
 }
 
-.fp-exp-calendar__weekdays {
-    margin-bottom: 0.35rem;
-}
-
-.fp-exp-calendar__weekday {
-    font-size: .85rem;
-    font-weight: 600;
-    color: var(--fp-color-muted);
-    text-align: center;
-}
-
-.fp-exp-calendar__empty {
-    min-height: 2.75rem;
-}
-
-.fp-exp-calendar__day,
-.fp-exp-calendar-only__day {
+.fp-exp-calendar-nav__day {
     border: 1px solid rgba(15, 23, 42, 0.1);
-    border-radius: var(--fp-exp-radius-base, 12px);
-    padding: 0.85rem;
+    border-radius: 8px;
+    padding: 0.75rem 0.5rem;
     background: var(--fp-color-surface);
     cursor: pointer;
-    transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
-    font-weight: 600;
+    transition: all 0.2s ease;
+    font-weight: 500;
     color: var(--fp-color-text);
+    text-align: center;
+    min-height: 3rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
 }
 
-.fp-exp-calendar__day[data-available="1"]:hover,
-.fp-exp-calendar__day[data-available="1"]:focus-visible {
+.fp-exp-calendar-nav__day:hover:not(:disabled) {
     border-color: var(--fp-color-primary);
-    box-shadow: 0 0 0 3px rgba(11, 110, 253, 0.15);
-    transform: translateY(-2px);
+    box-shadow: 0 0 0 2px rgba(11, 110, 253, 0.15);
+    transform: translateY(-1px);
 }
 
-.fp-exp-calendar__day.is-selected,
-.fp-exp-calendar-only__day.is-selected {
+.fp-exp-calendar-nav__day.is-selected {
     border-color: var(--fp-color-primary);
     background: color-mix(in srgb, var(--fp-color-primary) 12%, #fff);
-    box-shadow: 0 0 0 3px rgba(11, 110, 253, 0.15);
+    box-shadow: 0 0 0 2px rgba(11, 110, 253, 0.25);
 }
 
-.fp-exp-calendar__day:disabled,
-.fp-exp-calendar-only__day:disabled {
+.fp-exp-calendar-nav__day:disabled {
+    opacity: 0.4;
     cursor: not-allowed;
-    opacity: 0.5;
-    box-shadow: none;
-    transform: none;
+    background: rgba(15, 23, 42, 0.02);
+}
+
+.fp-exp-calendar-nav__day.is-past {
+    opacity: 0.3;
+}
+
+.fp-exp-calendar-nav__day-number {
+    font-size: 0.9rem;
+    font-weight: 600;
+    line-height: 1;
+}
+
+.fp-exp-calendar-nav__day-slots {
+    font-size: 0.7rem;
+    color: var(--fp-color-primary);
+    font-weight: 500;
+    margin-top: 0.25rem;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .fp-exp-calendar-nav {
+        padding: 0.75rem;
+    }
+    
+    .fp-exp-calendar-nav__grid {
+        gap: 0.25rem;
+    }
+    
+    .fp-exp-calendar-nav__day {
+        padding: 0.5rem 0.25rem;
+        min-height: 2.5rem;
+    }
+    
+    .fp-exp-calendar-nav__day-number {
+        font-size: 0.8rem;
+    }
+    
+    .fp-exp-calendar-nav__day-slots {
+        font-size: 0.65rem;
+    }
+    
+    .fp-exp-calendar-nav__prev-month,
+    .fp-exp-calendar-nav__next-month {
+        width: 2rem;
+        height: 2rem;
+        font-size: 1rem;
+    }
 }
 
 .fp-exp-slots {
@@ -1561,6 +1801,75 @@
     box-shadow: 0 0 0 3px rgba(11, 110, 253, 0.15);
     transform: translateY(-1px);
     outline: none;
+}
+
+/* Slot inline semplificati */
+.fp-exp-slots-inline {
+    margin-top: 0.5rem;
+    padding: 0.75rem;
+    background: rgba(15, 23, 42, 0.02);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: var(--fp-exp-radius-base, 12px);
+    animation: fp-exp-slots-inline-fade-in 0.3s ease-out;
+}
+
+.fp-exp-slots-inline__loading,
+.fp-exp-slots-inline__empty,
+.fp-exp-slots-inline__error {
+    text-align: center;
+    padding: 0.5rem;
+    font-size: 0.9rem;
+    color: var(--fp-color-muted);
+    font-style: italic;
+}
+
+.fp-exp-slots-inline__error {
+    color: #dc2626;
+}
+
+.fp-exp-slots-inline__list {
+    display: grid;
+    gap: 0.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.fp-exp-slots-inline__item {
+    padding: 0.6rem 0.8rem;
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    border-radius: calc(var(--fp-exp-radius-base, 12px) / 1.5);
+    background: var(--fp-color-surface, #fff);
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--fp-color-text);
+    cursor: pointer;
+    text-align: center;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, background-color 0.2s ease;
+}
+
+.fp-exp-slots-inline__item:hover,
+.fp-exp-slots-inline__item:focus-visible {
+    border-color: var(--fp-color-primary);
+    box-shadow: 0 0 0 2px rgba(11, 110, 253, 0.15);
+    transform: translateY(-1px);
+    outline: none;
+}
+
+.fp-exp-slots-inline__item.is-selected {
+    border-color: var(--fp-color-primary);
+    background: color-mix(in srgb, var(--fp-color-primary) 12%, #fff);
+    box-shadow: 0 0 0 2px rgba(11, 110, 253, 0.25);
+    color: color-mix(in srgb, var(--fp-color-primary) 80%, #0f172a);
+}
+
+@keyframes fp-exp-slots-inline-fade-in {
+    from {
+        opacity: 0;
+        transform: translateY(-8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 .fp-exp-slot-option {
@@ -2167,30 +2476,7 @@
     color: #b91c1c;
 }
 
-/* Calendar shortcode */
-.fp-exp-calendar-only {
-    background: #fff;
-    border-radius: var(--fp-exp-radius-base, 12px);
-    padding: 1.5rem;
-    box-shadow: var(--fp-exp-shadow-base, 0 10px 30px rgba(0,0,0,0.08));
-}
-
-.fp-exp-calendar-only__months {
-    display: grid;
-    gap: 1.5rem;
-}
-
-.fp-exp-calendar-only__day {
-    list-style: none;
-}
-
-.fp-exp-calendar-only__slot {
-    display: flex;
-    justify-content: space-between;
-    padding: 0.35rem 0;
-    border-bottom: 1px solid rgba(0,0,0,0.05);
-    font-size: 0.9rem;
-}
+/* CSS semplificato - input date nativo */
 
 /* Checkout */
 .fp-exp-checkout {
@@ -2332,7 +2618,6 @@
     }
 
     .fp-exp-widget,
-    .fp-exp-calendar-only,
     .fp-exp-checkout {
         padding: 1.25rem;
     }


### PR DESCRIPTION
Add missing CSS styles for calendar components to prevent overflow on desktop.

The calendar template used classes like `.fp-exp-calendar__grid` and `.fp-exp-calendar__day` which were not defined in `front.css`, causing the calendar boxes to extend beyond their container on desktop. This PR adds the necessary styles, including responsive adjustments, to correctly display the calendar on both mobile and desktop.

---
<a href="https://cursor.com/background-agent?bcId=bc-c6b67492-531a-4052-8d49-04c2a670b160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c6b67492-531a-4052-8d49-04c2a670b160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

