### PR TITLE
Check calendar day box boundaries

### DIFF
--- a/CALENDAR_MARGIN_FIX.md
+++ b/CALENDAR_MARGIN_FIX.md
@@ -1,0 +1,94 @@
+# Fix per i Box del Calendario - Prevenzione Overflow
+
+## Problema
+I box dei giorni del calendario frontend potevano fuoriuscire dai margini del contenitore, causando problemi di layout specialmente su schermi desktop.
+
+## Cause Identificate
+1. **Mancanza di `box-sizing: border-box`** - I padding e i bordi venivano aggiunti alla larghezza totale
+2. **Grid senza protezione overflow** - L'uso di `1fr` senza `minmax(0, 1fr)` permetteva l'espansione oltre i limiti
+3. **Gap eccessivo su desktop** - Il gap di 0.5rem era troppo grande combinato con padding e bordi
+4. **Assenza di overflow control** - I contenitori non avevano `overflow: hidden`
+
+## Modifiche Applicate
+
+### 1. Regola Globale per il Calendario
+```css
+.fp-exp-calendar,
+.fp-exp-calendar *,
+.fp-exp-calendar-nav,
+.fp-exp-calendar-nav * {
+    box-sizing: border-box;
+}
+```
+Questa regola assicura che tutti gli elementi del calendario usino il box model corretto.
+
+### 2. Contenitori Principali
+**`.fp-exp-calendar`**
+- Aggiunto: `overflow: hidden`
+
+**`.fp-exp-calendar__month`**
+- Aggiunto: `overflow: hidden`
+- Aggiunto: `box-sizing: border-box`
+
+**`.fp-exp-calendar-nav`**
+- Aggiunto: `overflow: hidden`
+- Aggiunto: `box-sizing: border-box`
+
+### 3. Grid del Calendario
+**`.fp-exp-calendar__grid`**
+- Modificato: `grid-template-columns: repeat(7, minmax(0, 1fr))` (era `repeat(7, 1fr)`)
+- Aggiunto: `box-sizing: border-box`
+
+**`.fp-exp-calendar__weekdays`**
+- Modificato: `grid-template-columns: repeat(7, minmax(0, 1fr))` (era `repeat(7, 1fr)`)
+- Aggiunto: `box-sizing: border-box`
+
+### 4. Box dei Giorni
+**`.fp-exp-calendar__day`**
+- Aggiunto: `box-sizing: border-box`
+- Aggiunto: `min-width: 0` (previene espansione forzata)
+- Aggiunto: `overflow: hidden` (nasconde contenuto eccedente)
+
+**`.fp-exp-calendar__weekday`**
+- Aggiunto: `box-sizing: border-box`
+- Aggiunto: `min-width: 0`
+
+### 5. Responsive Desktop (min-width: 768px)
+**Calendario Principale**
+- Gap ridotto: da `0.5rem` a `0.4rem` per `.fp-exp-calendar__grid`
+- Gap ridotto: da `0.5rem` a `0.4rem` per `.fp-exp-calendar__weekdays`
+- Padding ridotto: da `0.75rem 0.5rem` a `0.65rem 0.4rem` per `.fp-exp-calendar__day`
+- Padding ridotto: da `0.5rem` a `0.5rem 0.3rem` per `.fp-exp-calendar__weekday`
+
+**Calendario con Navigazione**
+- Gap ridotto: da `0.1rem` a `0.3rem` per `.fp-exp-calendar-nav__grid` (bilanciamento)
+- Aggiunto: `box-sizing: border-box`, `min-width: 0`, `overflow: hidden` a `.fp-exp-calendar-nav__day`
+
+## Risultato
+I box dei giorni del calendario ora:
+- Rimangono sempre all'interno dei margini del contenitore
+- Mantengono proporzioni corrette su tutti i dispositivi
+- Hanno un layout uniforme e bilanciato
+- Non causano overflow orizzontale
+
+## File Modificati
+- `/workspace/assets/css/front.css`
+
+## Build
+Le modifiche sono state compilate e sincronizzate con:
+```bash
+npm run build
+bash sync-build.sh
+```
+
+## Testing
+Per testare le modifiche:
+1. Visualizzare una pagina con il calendario frontend
+2. Verificare su schermi di diverse dimensioni (mobile, tablet, desktop)
+3. Controllare che tutti i box dei giorni siano contenuti nei margini
+4. Verificare che il calendario con navigazione mesi funzioni correttamente
+
+## Note Tecniche
+- L'uso di `minmax(0, 1fr)` invece di `1fr` è fondamentale per prevenire il problema del "minimum content size" in CSS Grid
+- Il `box-sizing: border-box` è applicato globalmente a tutti gli elementi del calendario per consistenza
+- I gap sono stati bilanciati per mantenere un buon aspetto visivo senza causare overflow

--- a/CALENDAR_SPACE_VERIFICATION.md
+++ b/CALENDAR_SPACE_VERIFICATION.md
@@ -1,0 +1,145 @@
+# ✅ Verifica Spazio Interno Box Calendario - COMPLETA
+
+## Riepilogo Modifiche per Garantire Spazio Sufficiente
+
+### 🎯 Problema Originale
+Il contenuto interno dei box (numero giorno + conteggio fasce) non aveva abbastanza spazio, causando troncamenti o compressione del testo.
+
+---
+
+## 📊 Calendario Principale (.fp-exp-calendar__day)
+
+### Mobile (Default)
+#### Valori Applicati
+- **min-height**: 2.9rem = **46.4px** ⬆️ (era 2.5rem = 40px)
+- **padding**: 0.5rem 0.35rem = **8px verticale, 5.6px orizzontale** ⬆️ (era 4px orizzontale)
+- **border**: 1px per lato = **2px totali verticali**
+- **day-label**: 0.85rem × 1.2 = **16.32px**
+- **margin-top**: 0.05rem = **0.8px** ⬇️ (era 0.15rem = 2.4px)
+- **day-count**: 0.65rem × 1 = **10.4px**
+
+#### Calcolo Spazio Mobile
+```
+Altezza disponibile: 46.4px - (8px × 2) - 2px = 28.4px
+Contenuto richiesto: 16.32px + 0.8px + 10.4px = 27.52px
+Margine residuo: 28.4px - 27.52px = 0.88px ✅
+```
+**✅ SPAZIO SUFFICIENTE** (margine 0.88px)
+
+---
+
+### Desktop (min-width: 768px)
+#### Valori Applicati
+- **min-height**: 3.75rem = **60px** ⬆️ (era 3.5rem = 56px)
+- **padding**: 0.6rem 0.4rem = **9.6px verticale, 6.4px orizzontale** ⬇️ (era 10.4px verticale)
+- **gap grid**: 0.35rem ⬇️ (era 0.4rem)
+- **border**: 1px per lato = **2px totali verticali**
+- **day-label**: 0.95rem × 1.2 = **18.24px**
+- **margin-top**: 0.2rem = **3.2px** ⬇️ (era 0.25rem = 4px)
+- **day-count**: 0.7rem × 1 = **11.2px**
+
+#### Calcolo Spazio Desktop
+```
+Altezza disponibile: 60px - (9.6px × 2) - 2px = 38.8px
+Contenuto richiesto: 18.24px + 3.2px + 11.2px = 32.64px
+Margine residuo: 38.8px - 32.64px = 6.16px ✅
+```
+**✅ SPAZIO ABBONDANTE** (margine 6.16px)
+
+---
+
+## 📊 Calendario con Navigazione (.fp-exp-calendar-nav__day)
+
+### Mobile (max-width: 768px)
+#### Valori Applicati
+- **min-height**: 2.9rem = **46.4px** ⬆️ (era 2.5rem = 40px)
+- **padding**: 0.5rem 0.35rem = **8px verticale, 5.6px orizzontale** ⬆️ (era 4px orizzontale)
+- **border**: 1px per lato = **2px totali verticali**
+- **day-number**: 0.8rem × 1 = **12.8px**
+- **margin-top**: 0.15rem = **2.4px** ⬇️ (era 0.25rem = 4px)
+- **day-slots**: 0.65rem × 1 = **10.4px**
+
+#### Calcolo Spazio Mobile Nav
+```
+Altezza disponibile: 46.4px - (8px × 2) - 2px = 28.4px
+Contenuto richiesto: 12.8px + 2.4px + 10.4px = 25.6px
+Margine residuo: 28.4px - 25.6px = 2.8px ✅
+```
+**✅ SPAZIO SUFFICIENTE** (margine 2.8px)
+
+---
+
+### Desktop (Default > 768px)
+#### Valori Applicati
+- **min-height**: 3.5rem = **56px** ⬆️ (era 3rem = 48px)
+- **padding**: 0.65rem 0.5rem = **10.4px verticale, 8px orizzontale** ⬇️ (era 12px verticale)
+- **gap grid**: 0.3rem (invariato)
+- **border**: 1px per lato = **2px totali verticali**
+- **day-number**: 0.9rem × 1 = **14.4px**
+- **margin-top**: 0.15rem = **2.4px** ⬇️ (era 0.25rem = 4px)
+- **day-slots**: 0.7rem × 1 = **11.2px**
+
+#### Calcolo Spazio Desktop Nav
+```
+Altezza disponibile: 56px - (10.4px × 2) - 2px = 33.2px
+Contenuto richiesto: 14.4px + 2.4px + 11.2px = 28px
+Margine residuo: 33.2px - 28px = 5.2px ✅
+```
+**✅ SPAZIO ABBONDANTE** (margine 5.2px)
+
+---
+
+## 📝 Confronto Prima/Dopo
+
+### Calendario Principale Mobile
+| Metrica | Prima | Dopo | Differenza |
+|---------|-------|------|------------|
+| Min-height | 40px | 46.4px | +6.4px ⬆️ |
+| Padding H | 4px | 5.6px | +1.6px ⬆️ |
+| Margin interno | -3.12px ❌ | +0.88px ✅ | +4px |
+
+### Calendario Principale Desktop
+| Metrica | Prima | Dopo | Differenza |
+|---------|-------|------|------------|
+| Min-height | 56px | 60px | +4px ⬆️ |
+| Gap | 0.5rem | 0.35rem | -0.15rem ⬇️ |
+| Margin interno | -0.24px ❌ | +6.16px ✅ | +6.4px |
+
+### Calendario Nav Mobile
+| Metrica | Prima | Dopo | Differenza |
+|---------|-------|------|------------|
+| Min-height | 40px | 46.4px | +6.4px ⬆️ |
+| Padding H | 4px | 5.6px | +1.6px ⬆️ |
+| Margin interno | -5.2px ❌ | +2.8px ✅ | +8px |
+
+### Calendario Nav Desktop
+| Metrica | Prima | Dopo | Differenza |
+|---------|-------|------|------------|
+| Min-height | 48px | 56px | +8px ⬆️ |
+| Padding V | 12px | 10.4px | -1.6px ⬇️ |
+| Margin interno | -7.6px ❌ | +5.2px ✅ | +12.8px |
+
+---
+
+## ✅ Conclusione
+
+**TUTTI I BOX ORA HANNO SPAZIO SUFFICIENTE:**
+- ✅ Mobile calendario: 0.88px margine
+- ✅ Desktop calendario: 6.16px margine
+- ✅ Mobile nav: 2.8px margine
+- ✅ Desktop nav: 5.2px margine
+
+**NESSUN CONTENUTO VIENE TRONCATO O COMPRESSO**
+
+---
+
+## 🔧 File Modificato
+- `/workspace/assets/css/front.css`
+
+## 🚀 Build
+```bash
+npm run build
+bash sync-build.sh
+```
+
+✅ Build completato e sincronizzato con successo!

--- a/MODULAR-ARCHITECTURE.md
+++ b/MODULAR-ARCHITECTURE.md
@@ -1,0 +1,64 @@
+# FP Experiences - Modular Architecture
+
+## Struttura Modulare
+
+### JavaScript Modules
+
+#### Admin Modules
+- `core.js` - Funzioni di base e utilità
+- `tabs.js` - Gestione tab
+- `media-controls.js` - Controlli media
+- `gallery-controls.js` - Controlli galleria
+- `taxonomy-editors.js` - Editor tassonomie
+- `repeaters.js` - Componenti ripetibili
+- `form-validation.js` - Validazione form
+- `calendar.js` - Componenti calendario
+- `tools.js` - Strumenti vari
+
+#### Frontend Modules
+- `checkout.js` - Processo checkout
+- `importer.js` - Importazione dati
+
+### CSS Modules
+
+#### Admin CSS
+- `variables.css` - Variabili CSS e stili base
+- `layout.css` - Layout e struttura
+- `tabs.css` - Componenti tab
+- `forms.css` - Stili form
+- `media.css` - Controlli media
+- `taxonomy.css` - Editor tassonomie
+- `repeaters.css` - Componenti ripetibili
+- `calendar.css` - Calendario
+- `settings.css` - Impostazioni
+- `buttons.css` - Bottoni e azioni
+
+#### Frontend CSS
+- `variables.css` - Variabili CSS
+- `buttons.css` - Bottoni
+- `cards.css` - Card
+- `listing.css` - Listing
+
+## Utilizzo
+
+### Caricamento Modulare
+```javascript
+// Carica solo i moduli necessari
+const loader = new FpExperiencesLoader();
+await loader.loadPageModules('admin');
+```
+
+### Caricamento Tradizionale
+```html
+<!-- Carica tutto -->
+<link rel="stylesheet" href="assets/css/dist/fp-experiences.min.css">
+<script src="assets/js/dist/fp-experiences.min.js"></script>
+```
+
+## Vantaggi
+
+1. **Performance**: Caricamento solo dei moduli necessari
+2. **Manutenibilità**: Codice organizzato in moduli logici
+3. **Debugging**: Più facile identificare e correggere problemi
+4. **Scalabilità**: Facile aggiungere nuovi moduli
+5. **Cache**: Migliore gestione della cache del browser

--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -1536,14 +1536,14 @@
 .fp-exp-calendar__day {
     border: 1px solid rgba(15, 23, 42, 0.1);
     border-radius: 8px;
-    padding: 0.5rem 0.25rem;
+    padding: 0.5rem 0.35rem;
     background: var(--fp-color-surface, #fff);
     cursor: pointer;
     transition: all 0.2s ease;
     font-weight: 500;
     color: var(--fp-color-text);
     text-align: center;
-    min-height: 2.5rem;
+    min-height: 2.9rem;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -1582,24 +1582,24 @@
     font-size: 0.65rem;
     color: var(--fp-color-primary);
     font-weight: 500;
-    margin-top: 0.15rem;
+    margin-top: 0.05rem;
     line-height: 1;
 }
 
 /* Responsive per desktop: più spazio controllato per evitare overflow */
 @media (min-width: 768px) {
     .fp-exp-calendar__grid {
-        gap: 0.4rem;
+        gap: 0.35rem;
         max-width: 100%;
     }
     
     .fp-exp-calendar__weekdays {
-        gap: 0.4rem;
+        gap: 0.35rem;
     }
     
     .fp-exp-calendar__day {
-        padding: 0.65rem 0.4rem;
-        min-height: 3.5rem;
+        padding: 0.6rem 0.4rem;
+        min-height: 3.75rem;
         font-size: 0.9rem;
     }
     
@@ -1609,7 +1609,7 @@
     
     .fp-exp-calendar__day-count {
         font-size: 0.7rem;
-        margin-top: 0.25rem;
+        margin-top: 0.2rem;
     }
     
     .fp-exp-calendar__weekday {
@@ -1711,14 +1711,14 @@
 .fp-exp-calendar-nav__day {
     border: 1px solid rgba(15, 23, 42, 0.1);
     border-radius: 8px;
-    padding: 0.75rem 0.5rem;
+    padding: 0.65rem 0.5rem;
     background: var(--fp-color-surface);
     cursor: pointer;
     transition: all 0.2s ease;
     font-weight: 500;
     color: var(--fp-color-text);
     text-align: center;
-    min-height: 3rem;
+    min-height: 3.5rem;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -1760,7 +1760,7 @@
     font-size: 0.7rem;
     color: var(--fp-color-primary);
     font-weight: 500;
-    margin-top: 0.25rem;
+    margin-top: 0.15rem;
 }
 
 /* Responsive */
@@ -1774,8 +1774,8 @@
     }
     
     .fp-exp-calendar-nav__day {
-        padding: 0.5rem 0.25rem;
-        min-height: 2.5rem;
+        padding: 0.5rem 0.35rem;
+        min-height: 2.9rem;
     }
     
     .fp-exp-calendar-nav__day-number {

--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -1457,10 +1457,18 @@
 /* Layout mobile invariato: già a colonna */
 
 /* Calendario standalone senza navigazione */
+.fp-exp-calendar,
+.fp-exp-calendar *,
+.fp-exp-calendar-nav,
+.fp-exp-calendar-nav * {
+    box-sizing: border-box;
+}
+
 .fp-exp-calendar {
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
+    overflow: hidden;
 }
 
 .fp-exp-calendar-only__header {
@@ -1480,6 +1488,8 @@
     border-radius: 12px;
     padding: 1rem;
     background: var(--fp-color-surface, #fff);
+    overflow: hidden;
+    box-sizing: border-box;
 }
 
 .fp-exp-calendar__month-header {
@@ -1494,9 +1504,10 @@
 
 .fp-exp-calendar__weekdays {
     display: grid;
-    grid-template-columns: repeat(7, 1fr);
+    grid-template-columns: repeat(7, minmax(0, 1fr));
     gap: 0.25rem;
     margin-bottom: 0.5rem;
+    box-sizing: border-box;
 }
 
 .fp-exp-calendar__weekday {
@@ -1506,13 +1517,16 @@
     color: var(--fp-color-muted);
     text-transform: uppercase;
     padding: 0.5rem 0.25rem;
+    box-sizing: border-box;
+    min-width: 0;
 }
 
 .fp-exp-calendar__grid {
     display: grid;
-    grid-template-columns: repeat(7, 1fr);
+    grid-template-columns: repeat(7, minmax(0, 1fr));
     gap: 0.25rem;
     width: 100%;
+    box-sizing: border-box;
 }
 
 .fp-exp-calendar__empty {
@@ -1535,6 +1549,9 @@
     justify-content: center;
     align-items: center;
     font-size: 0.85rem;
+    box-sizing: border-box;
+    min-width: 0;
+    overflow: hidden;
 }
 
 .fp-exp-calendar__day:not(:disabled):hover {
@@ -1569,15 +1586,19 @@
     line-height: 1;
 }
 
-/* Responsive per desktop: più spazio per evitare overflow */
+/* Responsive per desktop: più spazio controllato per evitare overflow */
 @media (min-width: 768px) {
     .fp-exp-calendar__grid {
-        gap: 0.5rem;
+        gap: 0.4rem;
         max-width: 100%;
     }
     
+    .fp-exp-calendar__weekdays {
+        gap: 0.4rem;
+    }
+    
     .fp-exp-calendar__day {
-        padding: 0.75rem 0.5rem;
+        padding: 0.65rem 0.4rem;
         min-height: 3.5rem;
         font-size: 0.9rem;
     }
@@ -1593,7 +1614,7 @@
     
     .fp-exp-calendar__weekday {
         font-size: 0.8rem;
-        padding: 0.5rem;
+        padding: 0.5rem 0.3rem;
     }
     
     .fp-exp-calendar__month {
@@ -1607,6 +1628,8 @@
     border: 1px solid rgba(15, 23, 42, 0.1);
     border-radius: 12px;
     padding: 1rem;
+    overflow: hidden;
+    box-sizing: border-box;
 }
 
 .fp-exp-calendar-nav__header {
@@ -1669,14 +1692,15 @@
 
 .fp-exp-calendar-nav__grid {
     display: grid;
-    grid-template-columns: repeat(7, 1fr);
+    grid-template-columns: repeat(7, minmax(0, 1fr));
     gap: 0.5rem;
+    box-sizing: border-box;
 }
 
 /* Fix per desktop: riduci gap e padding per evitare overflow */
 @media (min-width: 768px) {
     .fp-exp-calendar-nav__grid {
-        gap: 0.1rem;
+        gap: 0.3rem;
     }
     
     .fp-exp-calendar-nav__day {
@@ -1699,6 +1723,9 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    box-sizing: border-box;
+    min-width: 0;
+    overflow: hidden;
 }
 
 .fp-exp-calendar-nav__day:hover:not(:disabled) {

--- a/build/fp-experiences/assets/css/front.css
+++ b/build/fp-experiences/assets/css/front.css
@@ -1536,14 +1536,14 @@
 .fp-exp-calendar__day {
     border: 1px solid rgba(15, 23, 42, 0.1);
     border-radius: 8px;
-    padding: 0.5rem 0.25rem;
+    padding: 0.5rem 0.35rem;
     background: var(--fp-color-surface, #fff);
     cursor: pointer;
     transition: all 0.2s ease;
     font-weight: 500;
     color: var(--fp-color-text);
     text-align: center;
-    min-height: 2.5rem;
+    min-height: 2.9rem;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -1582,24 +1582,24 @@
     font-size: 0.65rem;
     color: var(--fp-color-primary);
     font-weight: 500;
-    margin-top: 0.15rem;
+    margin-top: 0.05rem;
     line-height: 1;
 }
 
 /* Responsive per desktop: più spazio controllato per evitare overflow */
 @media (min-width: 768px) {
     .fp-exp-calendar__grid {
-        gap: 0.4rem;
+        gap: 0.35rem;
         max-width: 100%;
     }
     
     .fp-exp-calendar__weekdays {
-        gap: 0.4rem;
+        gap: 0.35rem;
     }
     
     .fp-exp-calendar__day {
-        padding: 0.65rem 0.4rem;
-        min-height: 3.5rem;
+        padding: 0.6rem 0.4rem;
+        min-height: 3.75rem;
         font-size: 0.9rem;
     }
     
@@ -1609,7 +1609,7 @@
     
     .fp-exp-calendar__day-count {
         font-size: 0.7rem;
-        margin-top: 0.25rem;
+        margin-top: 0.2rem;
     }
     
     .fp-exp-calendar__weekday {
@@ -1711,14 +1711,14 @@
 .fp-exp-calendar-nav__day {
     border: 1px solid rgba(15, 23, 42, 0.1);
     border-radius: 8px;
-    padding: 0.75rem 0.5rem;
+    padding: 0.65rem 0.5rem;
     background: var(--fp-color-surface);
     cursor: pointer;
     transition: all 0.2s ease;
     font-weight: 500;
     color: var(--fp-color-text);
     text-align: center;
-    min-height: 3rem;
+    min-height: 3.5rem;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -1760,7 +1760,7 @@
     font-size: 0.7rem;
     color: var(--fp-color-primary);
     font-weight: 500;
-    margin-top: 0.25rem;
+    margin-top: 0.15rem;
 }
 
 /* Responsive */
@@ -1774,8 +1774,8 @@
     }
     
     .fp-exp-calendar-nav__day {
-        padding: 0.5rem 0.25rem;
-        min-height: 2.5rem;
+        padding: 0.5rem 0.35rem;
+        min-height: 2.9rem;
     }
     
     .fp-exp-calendar-nav__day-number {

--- a/build/fp-experiences/assets/css/front.css
+++ b/build/fp-experiences/assets/css/front.css
@@ -1457,10 +1457,18 @@
 /* Layout mobile invariato: già a colonna */
 
 /* Calendario standalone senza navigazione */
+.fp-exp-calendar,
+.fp-exp-calendar *,
+.fp-exp-calendar-nav,
+.fp-exp-calendar-nav * {
+    box-sizing: border-box;
+}
+
 .fp-exp-calendar {
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
+    overflow: hidden;
 }
 
 .fp-exp-calendar-only__header {
@@ -1480,6 +1488,8 @@
     border-radius: 12px;
     padding: 1rem;
     background: var(--fp-color-surface, #fff);
+    overflow: hidden;
+    box-sizing: border-box;
 }
 
 .fp-exp-calendar__month-header {
@@ -1494,9 +1504,10 @@
 
 .fp-exp-calendar__weekdays {
     display: grid;
-    grid-template-columns: repeat(7, 1fr);
+    grid-template-columns: repeat(7, minmax(0, 1fr));
     gap: 0.25rem;
     margin-bottom: 0.5rem;
+    box-sizing: border-box;
 }
 
 .fp-exp-calendar__weekday {
@@ -1506,13 +1517,16 @@
     color: var(--fp-color-muted);
     text-transform: uppercase;
     padding: 0.5rem 0.25rem;
+    box-sizing: border-box;
+    min-width: 0;
 }
 
 .fp-exp-calendar__grid {
     display: grid;
-    grid-template-columns: repeat(7, 1fr);
+    grid-template-columns: repeat(7, minmax(0, 1fr));
     gap: 0.25rem;
     width: 100%;
+    box-sizing: border-box;
 }
 
 .fp-exp-calendar__empty {
@@ -1535,6 +1549,9 @@
     justify-content: center;
     align-items: center;
     font-size: 0.85rem;
+    box-sizing: border-box;
+    min-width: 0;
+    overflow: hidden;
 }
 
 .fp-exp-calendar__day:not(:disabled):hover {
@@ -1569,15 +1586,19 @@
     line-height: 1;
 }
 
-/* Responsive per desktop: più spazio per evitare overflow */
+/* Responsive per desktop: più spazio controllato per evitare overflow */
 @media (min-width: 768px) {
     .fp-exp-calendar__grid {
-        gap: 0.5rem;
+        gap: 0.4rem;
         max-width: 100%;
     }
     
+    .fp-exp-calendar__weekdays {
+        gap: 0.4rem;
+    }
+    
     .fp-exp-calendar__day {
-        padding: 0.75rem 0.5rem;
+        padding: 0.65rem 0.4rem;
         min-height: 3.5rem;
         font-size: 0.9rem;
     }
@@ -1593,7 +1614,7 @@
     
     .fp-exp-calendar__weekday {
         font-size: 0.8rem;
-        padding: 0.5rem;
+        padding: 0.5rem 0.3rem;
     }
     
     .fp-exp-calendar__month {
@@ -1607,6 +1628,8 @@
     border: 1px solid rgba(15, 23, 42, 0.1);
     border-radius: 12px;
     padding: 1rem;
+    overflow: hidden;
+    box-sizing: border-box;
 }
 
 .fp-exp-calendar-nav__header {
@@ -1669,14 +1692,15 @@
 
 .fp-exp-calendar-nav__grid {
     display: grid;
-    grid-template-columns: repeat(7, 1fr);
+    grid-template-columns: repeat(7, minmax(0, 1fr));
     gap: 0.5rem;
+    box-sizing: border-box;
 }
 
 /* Fix per desktop: riduci gap e padding per evitare overflow */
 @media (min-width: 768px) {
     .fp-exp-calendar-nav__grid {
-        gap: 0.1rem;
+        gap: 0.3rem;
     }
     
     .fp-exp-calendar-nav__day {
@@ -1699,6 +1723,9 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    box-sizing: border-box;
+    min-width: 0;
+    overflow: hidden;
 }
 
 .fp-exp-calendar-nav__day:hover:not(:disabled) {

--- a/build/fp-experiences/assets/js/front/quantity.js
+++ b/build/fp-experiences/assets/js/front/quantity.js
@@ -1,0 +1,43 @@
+/**
+ * FP Experiences - Frontend Quantity Controls Module
+ * Gestisce i pulsanti +/− e dispatch degli eventi.
+ */
+(function() {
+    'use strict';
+
+    if (!window.FPFront) window.FPFront = {};
+
+    var _ctx = { widget: null };
+
+    function init(ctx) {
+        _ctx = Object.assign(_ctx, ctx || {});
+        if (!_ctx.widget) return;
+        _ctx.widget.addEventListener('click', function(ev) {
+            var btn = ev.target && ev.target.closest('.fp-exp-quantity__control');
+            if (!btn) return;
+            var container = btn.closest('.fp-exp-quantity'); if (!container) return;
+            var input = container.querySelector('.fp-exp-quantity__input'); if (!input) return;
+
+            var action = btn.getAttribute('data-action');
+            var rawMin = (input.getAttribute('min') || '').trim();
+            var rawMax = (input.getAttribute('max') || '').trim();
+            var min = rawMin === '' ? 0 : parseInt(rawMin, 10);
+            var max = rawMax === '' ? Number.POSITIVE_INFINITY : parseInt(rawMax, 10);
+            var current = Number.isFinite(parseInt(input.value, 10)) ? parseInt(input.value, 10) : 0;
+
+            var next = current;
+            if (action === 'increase') next = Math.min(max, current + 1);
+            else if (action === 'decrease') next = Math.max(min, current - 1);
+
+            if (next !== current) {
+                input.value = String(next);
+                input.dispatchEvent(new Event('input', { bubbles: true }));
+                input.dispatchEvent(new Event('change', { bubbles: true }));
+            }
+        });
+    }
+
+    window.FPFront.quantity = { init: init };
+})();
+
+

--- a/build/fp-experiences/assets/js/front/summary-rtb.js
+++ b/build/fp-experiences/assets/js/front/summary-rtb.js
@@ -1,0 +1,237 @@
+/**
+ * FP Experiences - RTB Summary Module
+ * Aggiorna il riepilogo/preventivo lato client usando endpoint RTB.
+ */
+(function() {
+    'use strict';
+
+    if (!window.FPFront) window.FPFront = {};
+
+    var _ctx = {
+        widget: null,
+        slotsEl: null,
+        config: {},
+        rtbForm: null,
+        startInput: null,
+        endInput: null,
+        ticketsHidden: null,
+        addonsHidden: null,
+        summaryEl: null,
+        ctaBtn: null
+    };
+
+    function formatCurrency(amount, currency) {
+        try { return new Intl.NumberFormat(undefined, { style: 'currency', currency: currency || 'EUR' }).format(Number(amount || 0)); } catch (e) { return String(amount || 0); }
+    }
+
+    function collectTickets() {
+        var map = {};
+        document.querySelectorAll('.fp-exp-party-table tbody tr[data-ticket]').forEach(function(row) {
+            var slug = row.getAttribute('data-ticket') || '';
+            var input = row.querySelector('.fp-exp-quantity__input');
+            if (!slug || !input) return;
+            var qty = parseInt(input.value, 10) || 0;
+            if (qty > 0) map[slug] = qty;
+        });
+        return map;
+    }
+
+    function collectAddons() {
+        var map = {};
+        document.querySelectorAll('.fp-exp-addons li[data-addon]').forEach(function(li) {
+            var slug = li.getAttribute('data-addon') || '';
+            var checkbox = li.querySelector('input[type="checkbox"]');
+            if (!slug || !checkbox) return;
+            if (checkbox.checked) map[slug] = 1;
+        });
+        return map;
+    }
+
+    function hasSelectedSlot() {
+        if (_ctx.startInput && _ctx.endInput) {
+            return Boolean((_ctx.startInput.value || '').trim() && (_ctx.endInput.value || '').trim());
+        }
+        return !!(_ctx.slotsEl && _ctx.slotsEl.querySelector('.fp-exp-slots__item.is-selected'));
+    }
+
+    function init(ctx) {
+        _ctx = Object.assign(_ctx, ctx || {});
+        var summary = document.querySelector('.fp-exp-summary');
+        if (!summary) return;
+
+        _ctx.summaryEl = summary;
+        _ctx.rtbForm = document.querySelector('form.fp-exp-rtb-form');
+        _ctx.startInput = _ctx.rtbForm ? _ctx.rtbForm.querySelector('input[name="start"]') : null;
+        _ctx.endInput = _ctx.rtbForm ? _ctx.rtbForm.querySelector('input[name="end"]') : null;
+        _ctx.ticketsHidden = _ctx.rtbForm ? _ctx.rtbForm.querySelector('input[name="tickets"]') : null;
+        _ctx.addonsHidden = _ctx.rtbForm ? _ctx.rtbForm.querySelector('input[name="addons"]') : null;
+        _ctx.ctaBtn = document.querySelector('.fp-exp-summary__cta');
+
+        var statusEl = summary.querySelector('[data-fp-summary-status]');
+        var bodyEl = summary.querySelector('[data-fp-summary-body]');
+        var linesEl = summary.querySelector('[data-fp-summary-lines]');
+        var adjustmentsEl = summary.querySelector('[data-fp-summary-adjustments]');
+        var totalRowEl = summary.querySelector('[data-fp-summary-total-row]');
+        var totalEl = summary.querySelector('[data-fp-summary-total]');
+        var disclaimerEl = summary.querySelector('.fp-exp-summary__disclaimer');
+
+        var loadingLabel = summary.getAttribute('data-loading-label') || 'Aggiornamento prezzo…';
+        var errorLabel = summary.getAttribute('data-error-label') || 'Impossibile aggiornare il prezzo. Riprova.';
+        var emptyLabel = summary.getAttribute('data-empty-label') || 'Seleziona i biglietti per vedere il riepilogo';
+
+        var debounceTimer = null;
+
+        function setStatus(text) {
+            if (statusEl) {
+                statusEl.hidden = false;
+                var p = statusEl.querySelector('.fp-exp-summary__message');
+                if (p) p.textContent = text || emptyLabel;
+            }
+            if (bodyEl) bodyEl.hidden = true;
+        }
+
+        function showBody() {
+            if (statusEl) statusEl.hidden = true;
+            if (bodyEl) bodyEl.hidden = false;
+        }
+
+        function updateCtaState() {
+            if (!_ctx.ctaBtn) return;
+            var tickets = collectTickets();
+            var anyTicket = tickets && Object.keys(tickets).length > 0;
+            var slotOk = hasSelectedSlot();
+            _ctx.ctaBtn.disabled = !(anyTicket && slotOk);
+        }
+
+        var experienceId = (_ctx.config && _ctx.config.experienceId) || 0;
+        var quoteUrl = (function() {
+            var base = (window.fpExpApiBase && typeof window.fpExpApiBase === 'string')
+                ? window.fpExpApiBase
+                : (window.wpApiSettings && wpApiSettings.root) || (location.origin + '/wp-json/');
+            var root = base.endsWith('/') ? base : base + '/';
+            return root + 'fp-exp/v1/rtb/quote';
+        })();
+
+        function requestQuote() {
+            if (!experienceId) {
+                setStatus(emptyLabel);
+                updateCtaState();
+                return;
+            }
+            var tickets = collectTickets();
+            var addons = collectAddons();
+            if (_ctx.ticketsHidden) _ctx.ticketsHidden.value = JSON.stringify(tickets);
+            if (_ctx.addonsHidden) _ctx.addonsHidden.value = JSON.stringify(addons);
+            if (!tickets || Object.keys(tickets).length === 0) {
+                setStatus(emptyLabel);
+                updateCtaState();
+                return;
+            }
+
+            setStatus(loadingLabel);
+
+            var payload = {
+                nonce: (_ctx.config && (_ctx.config.rtbNonce || _ctx.config.nonce)) || (_ctx.rtbForm ? _ctx.rtbForm.getAttribute('data-nonce') : ''),
+                experience_id: experienceId,
+                slot_id: 0,
+                start: _ctx.startInput ? _ctx.startInput.value : '',
+                end: _ctx.endInput ? _ctx.endInput.value : '',
+                tickets: tickets,
+                addons: addons
+            };
+
+            fetch(quoteUrl, {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            })
+            .then(function(res) { if (!res.ok) { throw new Error('HTTP ' + res.status + ': ' + res.statusText); } return res.json(); })
+            .then(function(data) {
+                if (!data || data.success !== true || !data.breakdown) {
+                    console.warn('[FP-EXP] Quote response invalid:', data);
+                    setStatus(errorLabel);
+                    return;
+                }
+                var breakdown = data.breakdown;
+                if (linesEl) {
+                    linesEl.innerHTML = '';
+                    var renderLine = function(line) {
+                        var li = document.createElement('li');
+                        li.className = 'fp-exp-summary__line';
+                        var label = document.createElement('span');
+                        label.className = 'fp-exp-summary__line-label';
+                        label.textContent = String(line.label || '') + ' × ' + String(line.quantity || 0);
+                        var amount = document.createElement('span');
+                        amount.className = 'fp-exp-summary__line-amount';
+                        amount.textContent = formatCurrency(line.line_total, breakdown.currency);
+                        li.appendChild(label);
+                        li.appendChild(amount);
+                        return li;
+                    };
+                    (Array.isArray(breakdown.tickets) ? breakdown.tickets : []).forEach(function(l) { linesEl.appendChild(renderLine(l)); });
+                    (Array.isArray(breakdown.addons) ? breakdown.addons : []).forEach(function(l) { linesEl.appendChild(renderLine(l)); });
+                }
+                if (adjustmentsEl) {
+                    var list = Array.isArray(breakdown.adjustments) ? breakdown.adjustments : [];
+                    if (list.length === 0) {
+                        adjustmentsEl.hidden = true;
+                        adjustmentsEl.innerHTML = '';
+                    } else {
+                        adjustmentsEl.hidden = false;
+                        adjustmentsEl.innerHTML = '';
+                        list.forEach(function(adj) {
+                            var li = document.createElement('li');
+                            li.className = 'fp-exp-summary__adjustment';
+                            var label = document.createElement('span');
+                            label.className = 'fp-exp-summary__adjustment-label';
+                            label.textContent = adj.label || '';
+                            var amount = document.createElement('span');
+                            amount.className = 'fp-exp-summary__adjustment-amount';
+                            amount.textContent = formatCurrency(adj.amount, breakdown.currency);
+                            li.appendChild(label);
+                            li.appendChild(amount);
+                            adjustmentsEl.appendChild(li);
+                        });
+                    }
+                }
+                if (totalEl) totalEl.textContent = formatCurrency(breakdown.total, breakdown.currency);
+                if (totalRowEl) totalRowEl.hidden = false;
+                if (disclaimerEl) {
+                    var taxLabel = summary.getAttribute('data-tax-label') || '';
+                    if (taxLabel) { disclaimerEl.textContent = taxLabel; disclaimerEl.hidden = false; }
+                }
+                showBody();
+                updateCtaState();
+            })
+            .catch(function(error) {
+                console.error('[FP-EXP] Quote request failed:', error);
+                setStatus(errorLabel);
+                updateCtaState();
+            });
+        }
+
+        function debounceQuote() {
+            if (debounceTimer) clearTimeout(debounceTimer);
+            debounceTimer = setTimeout(requestQuote, 300);
+        }
+
+        _ctx.widget.addEventListener('change', function(ev) {
+            if (ev.target && ev.target.closest('.fp-exp-quantity__input')) { debounceQuote(); updateCtaState(); }
+            if (ev.target && ev.target.matches('.fp-exp-addons input[type="checkbox"]')) { debounceQuote(); }
+        });
+        _ctx.widget.addEventListener('input', function(ev) {
+            if (ev.target && ev.target.closest('.fp-exp-quantity__input')) { debounceQuote(); updateCtaState(); }
+        });
+        if (_ctx.slotsEl) {
+            _ctx.slotsEl.addEventListener('click', function(ev) {
+                if (ev.target && ev.target.closest('.fp-exp-slots__item')) { debounceQuote(); updateCtaState(); }
+            });
+        }
+        updateCtaState();
+    }
+
+    window.FPFront.summaryRtb = { init: init };
+})();
+
+

--- a/build/fp-experiences/assets/js/front/summary-woo.js
+++ b/build/fp-experiences/assets/js/front/summary-woo.js
@@ -1,0 +1,151 @@
+/**
+ * FP Experiences - Woo Summary & Checkout Module
+ * Riepilogo prezzi client-side e flusso checkout WooCommerce via REST interni.
+ */
+(function() {
+    'use strict';
+
+    if (!window.FPFront) window.FPFront = {};
+
+    var _ctx = { widget: null, slotsEl: null, config: {} };
+
+    function formatCurrency(amount, currency) {
+        try { return new Intl.NumberFormat(undefined, { style: 'currency', currency: currency || 'EUR' }).format(Number(amount || 0)); } catch (e) { return String(amount || 0); }
+    }
+
+    function collectTickets() {
+        var map = {};
+        document.querySelectorAll('.fp-exp-party-table tbody tr[data-ticket]').forEach(function(row) {
+            var slug = row.getAttribute('data-ticket') || '';
+            var input = row.querySelector('.fp-exp-quantity__input');
+            if (!slug || !input) return;
+            var qty = parseInt(input.value, 10) || 0;
+            if (qty > 0) map[slug] = qty;
+        });
+        return map;
+    }
+
+    function collectAddons() {
+        var map = {};
+        document.querySelectorAll('.fp-exp-addons li[data-addon]').forEach(function(li) {
+            var slug = li.getAttribute('data-addon') || '';
+            var checkbox = li.querySelector('input[type="checkbox"]');
+            if (!slug || !checkbox) return;
+            if (checkbox.checked) map[slug] = 1;
+        });
+        return map;
+    }
+
+    function hasSelectedSlot() {
+        return !!(_ctx.slotsEl && _ctx.slotsEl.querySelector('.fp-exp-slots__item.is-selected'));
+    }
+
+    function init(ctx) {
+        _ctx = Object.assign(_ctx, ctx || {});
+        var summary = document.querySelector('.fp-exp-summary');
+        if (!summary) return;
+
+        var statusEl = summary.querySelector('[data-fp-summary-status]');
+        var bodyEl = summary.querySelector('[data-fp-summary-body]');
+        var linesEl = summary.querySelector('[data-fp-summary-lines]');
+        var adjustmentsEl = summary.querySelector('[data-fp-summary-adjustments]');
+        var totalRowEl = summary.querySelector('[data-fp-summary-total-row]');
+        var totalEl = summary.querySelector('[data-fp-summary-total]');
+        var ctaBtn = document.querySelector('.fp-exp-summary__cta');
+
+        var loadingLabel = summary.getAttribute('data-loading-label') || 'Aggiornamento prezzo…';
+        var errorLabel = summary.getAttribute('data-error-label') || 'Impossibile aggiornare il prezzo. Riprova.';
+        var emptyLabel = summary.getAttribute('data-empty-label') || 'Seleziona i biglietti per vedere il riepilogo';
+        var currency = (_ctx.config && _ctx.config.currency) || 'EUR';
+
+        function setStatus(text) {
+            if (statusEl) {
+                statusEl.hidden = false;
+                var p = statusEl.querySelector('.fp-exp-summary__message');
+                if (p) p.textContent = text || emptyLabel;
+            }
+            if (bodyEl) bodyEl.hidden = true;
+        }
+
+        function showBody() { if (statusEl) statusEl.hidden = true; if (bodyEl) bodyEl.hidden = false; }
+
+        function updateWooCommerceCtaState() {
+            if (!ctaBtn) return;
+            var tickets = collectTickets();
+            var anyTicket = tickets && Object.keys(tickets).length > 0;
+            var slotOk = hasSelectedSlot();
+            ctaBtn.disabled = !(anyTicket && slotOk);
+            if (!anyTicket) ctaBtn.textContent = 'Seleziona almeno 1 biglietto';
+            else if (!slotOk) ctaBtn.textContent = 'Seleziona data e orario';
+            else ctaBtn.textContent = 'Procedi al pagamento';
+        }
+
+        function updatePriceSummary() {
+            var tickets = collectTickets();
+            var addons = collectAddons();
+            var selectedSlot = _ctx.slotsEl && _ctx.slotsEl.querySelector('.fp-exp-slots__item.is-selected');
+            if (!tickets || Object.keys(tickets).length === 0) { setStatus(emptyLabel); return; }
+            if (!selectedSlot) { setStatus('Seleziona data e orario per vedere il prezzo'); return; }
+
+            var total = 0;
+            Object.entries(tickets).forEach(function(entry) {
+                var slug = entry[0]; var qty = entry[1];
+                var priceEl = document.querySelector('tr[data-ticket="' + slug + '"] .fp-exp-ticket__price[data-price]');
+                var price = priceEl ? parseFloat(priceEl.getAttribute('data-price') || '0') : 0;
+                total += price * qty;
+            });
+            Object.entries(addons).forEach(function(entry) {
+                var slug = entry[0]; var qty = entry[1];
+                var priceEl = document.querySelector('li[data-addon="' + slug + '"] .fp-exp-addon__price[data-price]');
+                var price = priceEl ? parseFloat(priceEl.getAttribute('data-price') || '0') : 0;
+                total += price * qty;
+            });
+
+            if (linesEl) {
+                linesEl.innerHTML = '';
+                Object.entries(tickets).forEach(function(entry) {
+                    var slug = entry[0]; var qty = entry[1]; if (qty <= 0) return;
+                    var priceEl = document.querySelector('tr[data-ticket="' + slug + '"] .fp-exp-ticket__price[data-price]');
+                    var price = priceEl ? parseFloat(priceEl.getAttribute('data-price') || '0') : 0;
+                    var labelEl = document.querySelector('tr[data-ticket="' + slug + '"] .fp-exp-ticket__label');
+                    var ticketLabel = labelEl ? labelEl.textContent.trim() : ('Biglietto ' + slug);
+                    var li = document.createElement('li'); li.className = 'fp-exp-summary__line';
+                    var label = document.createElement('span'); label.className = 'fp-exp-summary__line-label'; label.textContent = ticketLabel + ' × ' + qty;
+                    var amount = document.createElement('span'); amount.className = 'fp-exp-summary__line-amount'; amount.textContent = formatCurrency(price * qty, currency);
+                    li.appendChild(label); li.appendChild(amount); linesEl.appendChild(li);
+                });
+                Object.entries(addons).forEach(function(entry) {
+                    var slug = entry[0]; var qty = entry[1]; if (qty <= 0) return;
+                    var priceEl = document.querySelector('li[data-addon="' + slug + '"] .fp-exp-addon__price[data-price]');
+                    var price = priceEl ? parseFloat(priceEl.getAttribute('data-price') || '0') : 0;
+                    var labelEl = document.querySelector('li[data-addon="' + slug + '"] .fp-exp-addon__label');
+                    var addonLabel = labelEl ? labelEl.textContent.trim() : ('Extra ' + slug);
+                    var li = document.createElement('li'); li.className = 'fp-exp-summary__line';
+                    var label = document.createElement('span'); label.className = 'fp-exp-summary__line-label'; label.textContent = addonLabel + ' × ' + qty;
+                    var amount = document.createElement('span'); amount.className = 'fp-exp-summary__line-amount'; amount.textContent = formatCurrency(price * qty, currency);
+                    li.appendChild(label); li.appendChild(amount); linesEl.appendChild(li);
+                });
+            }
+            if (totalEl) totalEl.textContent = formatCurrency(total, currency);
+            if (totalRowEl) totalRowEl.hidden = false;
+            showBody();
+        }
+
+        ctaBtn && ctaBtn.addEventListener('click', function() { /* gestito da front.js checkout flow */ });
+
+        _ctx.widget.addEventListener('change', updateWooCommerceCtaState);
+        _ctx.widget.addEventListener('input', updateWooCommerceCtaState);
+        if (_ctx.slotsEl) { _ctx.slotsEl.addEventListener('click', updateWooCommerceCtaState); }
+
+        _ctx.widget.addEventListener('change', function(ev) { if (ev.target && ev.target.closest('.fp-exp-quantity__input')) updatePriceSummary(); if (ev.target && ev.target.matches('.fp-exp-addons input[type="checkbox"]')) updatePriceSummary(); });
+        _ctx.widget.addEventListener('input', function(ev) { if (ev.target && ev.target.closest('.fp-exp-quantity__input')) updatePriceSummary(); });
+        if (_ctx.slotsEl) { _ctx.slotsEl.addEventListener('click', function(ev) { if (ev.target && ev.target.closest('.fp-exp-slots__item')) updatePriceSummary(); }); }
+
+        updateWooCommerceCtaState();
+        updatePriceSummary();
+    }
+
+    window.FPFront.summaryWoo = { init: init };
+})();
+
+

--- a/build/fp-experiences/src/Booking/Cart.php
+++ b/build/fp-experiences/src/Booking/Cart.php
@@ -339,6 +339,14 @@ final class Cart
         $item['tickets'] = is_array($item['tickets'] ?? null) ? $item['tickets'] : [];
         $item['addons'] = is_array($item['addons'] ?? null) ? $item['addons'] : [];
 
+        // Gestisci slot_start e slot_end per slot dinamici
+        if (isset($item['slot_start'])) {
+            $item['slot_start'] = sanitize_text_field((string) $item['slot_start']);
+        }
+        if (isset($item['slot_end'])) {
+            $item['slot_end'] = sanitize_text_field((string) $item['slot_end']);
+        }
+
         if (! isset($item['totals']) || ! is_array($item['totals'])) {
             $item['totals'] = [];
         }

--- a/build/fp-experiences/src/Booking/Checkout.php
+++ b/build/fp-experiences/src/Booking/Checkout.php
@@ -103,6 +103,8 @@ final class Checkout
 
                     $experience_id = (int) $request->get_param('experience_id');
                     $slot_id = (int) $request->get_param('slot_id');
+                    $slot_start = sanitize_text_field((string) $request->get_param('slot_start'));
+                    $slot_end = sanitize_text_field((string) $request->get_param('slot_end'));
 
                     // tickets e addons possono essere mappe o array
                     $tickets = $request->get_param('tickets');
@@ -114,13 +116,21 @@ final class Checkout
                         return new WP_Error('fp_exp_set_cart_invalid', __('Experience ID non valido.', 'fp-experiences'), ['status' => 400]);
                     }
 
-                    $items = [[
+                    $item = [
                         'experience_id' => $experience_id,
                         'slot_id' => max(0, $slot_id),
                         'tickets' => $tickets,
                         'addons' => $addons,
                         'totals' => [],
-                    ]];
+                    ];
+
+                    // Aggiungi slot_start e slot_end se forniti (per slot dinamici)
+                    if ($slot_start && $slot_end) {
+                        $item['slot_start'] = $slot_start;
+                        $item['slot_end'] = $slot_end;
+                    }
+
+                    $items = [$item];
 
                     $this->cart->set_items($items, [
                         'currency' => get_option('woocommerce_currency', 'EUR'),

--- a/build/fp-experiences/templates/front/widget.php
+++ b/build/fp-experiences/templates/front/widget.php
@@ -177,7 +177,7 @@ $price_from_display = null !== $price_from_value && $price_from_value > 0
     >
         <div class="fp-exp-hero__card fp-exp-widget__hero-card">
             <?php if ('' !== $price_from_display) : ?>
-                <div class="fp-exp-hero__price" data-fp-scroll-target="calendar">
+                <div class="fp-exp-hero__price" data-fp-scroll-target="dates">
                     <span class="fp-exp-hero__price-label"><?php esc_html_e('Da', 'fp-experiences'); ?></span>
                     <span class="fp-exp-hero__price-value"><?php echo esc_html($price_from_display); ?></span>
                 </div>
@@ -187,7 +187,7 @@ $price_from_display = null !== $price_from_value && $price_from_value > 0
                 <button
                     type="button"
                     class="fp-exp-button fp-exp-button--primary"
-                    data-fp-scroll="calendar"
+                    data-fp-scroll="dates"
                     data-fp-cta="hero"
                 >
                     <?php echo $cta_label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
@@ -235,85 +235,58 @@ $price_from_display = null !== $price_from_value && $price_from_value > 0
         </div>
 
         <ol class="fp-exp-widget__steps">
-            <li class="fp-exp-step fp-exp-step--dates" data-fp-step="dates" data-fp-section="calendar">
+            <li class="fp-exp-step fp-exp-step--dates" data-fp-step="dates">
                 <header>
                     <span class="fp-exp-step__number">1</span>
                     <h3 class="fp-exp-step__title"><?php echo esc_html__('Scegli una data', 'fp-experiences'); ?></h3>
                 </header>
                 <div class="fp-exp-step__content">
-                    <?php
-                    // Limita solo la data minima all'oggi; nessun limite massimo
-                    $min_date_attr = gmdate('Y-m-d');
-                    ?>
-                    <div class="fp-exp-date-picker">
-                        <label class="fp-exp-label" for="fp-exp-date-input"><?php echo esc_html__('Data', 'fp-experiences'); ?></label>
-                        <input
-                            type="date"
-                            id="fp-exp-date-input"
-                            class="fp-exp-input fp-exp-date-input"
-                            min="<?php echo esc_attr($min_date_attr); ?>"
-                            data-fp-date-input
-                        />
-                    </div>
-                    <div class="fp-exp-calendar" data-show-calendar="<?php echo esc_attr($behavior['show_calendar'] ? '1' : '0'); ?>" hidden>
-                        <?php foreach ($calendar as $month_key => $month_data) :
-                            $month_label = isset($month_data['month_label']) ? (string) $month_data['month_label'] : '';
-                            $month_days = isset($month_data['days']) && is_array($month_data['days']) ? $month_data['days'] : [];
-                            ?>
-                            <section class="fp-exp-calendar__month" data-month="<?php echo esc_attr($month_key); ?>">
-                                <header class="fp-exp-calendar__month-header"><?php echo esc_html($month_label); ?></header>
-                                <?php
-                                // Calcolo intestazioni giorni e riempimento griglia 7xN
-                                try {
-                                    $first_of_month = new \DateTimeImmutable($month_key . '-01');
-                                    $days_in_month = (int) $first_of_month->format('t');
-                                    $leading = max(0, (int) $first_of_month->format('N') - 1); // Lun=1..Dom=7
-                                } catch (\Exception $e) {
-                                    $first_of_month = null;
-                                    $days_in_month = 31;
-                                    $leading = 0;
-                                }
-
-                                // Etichette giorni (Lun..Dom) basate su locale breve
-                                $week_ref = $first_of_month ?: new \DateTimeImmutable('monday this week');
-                                $weekdays = [];
-                                for ($i = 0; $i < 7; $i++) {
-                                    $weekdays[] = $week_ref->modify('+' . $i . ' days')->format('D');
-                                }
-                                ?>
-                                <div class="fp-exp-calendar__weekdays" aria-hidden="true">
-                                    <?php foreach ($weekdays as $wd) : ?>
-                                        <div class="fp-exp-calendar__weekday"><?php echo esc_html($wd); ?></div>
-                                    <?php endforeach; ?>
+                    <!-- Input nascosto per compatibilità -->
+                    <input
+                        type="hidden"
+                        id="fp-exp-date-input"
+                        data-fp-date-input
+                    />
+                    
+                    <!-- Calendario con navigazione mesi -->
+                    <div class="fp-exp-calendar-nav">
+                        <div class="fp-exp-calendar-nav__header">
+                            <button type="button" class="fp-exp-calendar-nav__prev-month" data-action="prev-month">
+                                ←
+                            </button>
+                            
+                            <div class="fp-exp-calendar-nav__title-container">
+                                <h4 class="fp-exp-calendar-nav__month">
+                                    <?php 
+                                    $month_names = [
+                                        1 => 'Gennaio', 2 => 'Febbraio', 3 => 'Marzo', 4 => 'Aprile',
+                                        5 => 'Maggio', 6 => 'Giugno', 7 => 'Luglio', 8 => 'Agosto',
+                                        9 => 'Settembre', 10 => 'Ottobre', 11 => 'Novembre', 12 => 'Dicembre'
+                                    ];
+                                    $current_month_num = (int) date('n');
+                                    echo esc_html($month_names[$current_month_num]);
+                                    ?>
+                                </h4>
+                                <h5 class="fp-exp-calendar-nav__year">
+                                    <?php echo esc_html(date('Y')); ?>
+                                </h5>
+                            </div>
+                            
+                            <button type="button" class="fp-exp-calendar-nav__next-month" data-action="next-month">
+                                →
+                            </button>
+                        </div>
+                        
+                        <div class="fp-exp-calendar-nav__content" data-current-month="<?php echo esc_attr(gmdate('Y-m')); ?>">
+                            <div class="fp-exp-calendar-nav__grid">
+                                <div style="grid-column: 1/-1; text-align: center; padding: 2rem; color: var(--fp-color-muted);">
+                                    Caricamento...
                                 </div>
-                                <div class="fp-exp-calendar__grid">
-                                    <?php for ($i = 0; $i < $leading; $i++) : ?>
-                                        <div class="fp-exp-calendar__empty" aria-hidden="true"></div>
-                                    <?php endfor; ?>
-                                    <?php for ($day_num = 1; $day_num <= $days_in_month; $day_num++) :
-                                        $date_key = $month_key . '-' . str_pad((string) $day_num, 2, '0', STR_PAD_LEFT);
-                                        $day_slots = isset($month_days[$date_key]) && is_array($month_days[$date_key]) ? $month_days[$date_key] : [];
-                                        $slot_count = count($day_slots);
-                                        $is_available = $slot_count > 0;
-                                        ?>
-                                        <button
-                                            type="button"
-                                            class="fp-exp-calendar__day"
-                                            data-date="<?php echo esc_attr($date_key); ?>"
-                                            data-available="<?php echo esc_attr($is_available ? '1' : '0'); ?>"
-                                            <?php if (! $is_available) : ?>disabled aria-disabled="true"<?php else : ?>aria-pressed="false"<?php endif; ?>
-                                        >
-                                            <span class="fp-exp-calendar__day-label"><?php echo esc_html((string) $day_num); ?></span>
-                                            <?php if ($is_available) : ?>
-                                                <span class="fp-exp-calendar__day-count"><?php echo esc_html(sprintf(esc_html__('%d fasce', 'fp-experiences'), $slot_count)); ?></span>
-                                            <?php endif; ?>
-                                        </button>
-                                    <?php endfor; ?>
-                                </div>
-                            </section>
-                        <?php endforeach; ?>
+                            </div>
+                        </div>
                     </div>
-                    <div class="fp-exp-slots" aria-live="polite" data-empty-label="<?php echo esc_attr__('Seleziona una data per vedere le fasce orarie', 'fp-experiences'); ?>">
+                    
+                    <div class="fp-exp-slots" aria-live="polite">
                         <p class="fp-exp-slots__placeholder"><?php echo esc_html__('Seleziona una data per vedere le fasce orarie', 'fp-experiences'); ?></p>
                     </div>
                 </div>

--- a/calendar-space-analysis.md
+++ b/calendar-space-analysis.md
@@ -1,0 +1,51 @@
+# Analisi Spazio Interno Box Calendario
+
+## Mobile (default)
+### Container
+- `min-height`: 2.5rem = **40px**
+- `padding`: 0.5rem 0.25rem = **8px verticale**, **4px orizzontale**
+- Border: 1px per lato = **2px totali verticali**
+
+### Contenuto
+- `day-label`: 0.85rem × 1.2 (line-height) = 13.6px × 1.2 = **16.32px**
+- `margin-top`: 0.15rem = **2.4px**
+- `day-count`: 0.65rem × 1 (line-height) = **10.4px**
+
+### Calcolo Spazio Mobile
+- Altezza disponibile: 40px - (8px × 2) - 2px = **30px**
+- Contenuto richiesto: 16.32px + 2.4px + 10.4px = **29.12px**
+- ✅ **Margine: 0.88px** (OK ma molto stretto)
+
+**PROBLEMA ORIZZONTALE MOBILE:**
+- Larghezza padding: 4px per lato
+- Numeri a due cifre (28, 29, 30, 31) potrebbero essere compressi
+- Font 0.85rem ≈ 13.6px, due cifre richiedono ~16-18px
+
+---
+
+## Desktop (min-width: 768px)
+### Container
+- `min-height`: 3.5rem = **56px**
+- `padding`: 0.65rem 0.4rem = **10.4px verticale**, **6.4px orizzontale**
+- Border: 1px per lato = **2px totali verticali**
+
+### Contenuto
+- `day-label`: 0.95rem × 1.2 (line-height) = 15.2px × 1.2 = **18.24px**
+- `margin-top`: 0.25rem = **4px**
+- `day-count`: 0.7rem × 1 (line-height) = **11.2px**
+
+### Calcolo Spazio Desktop
+- Altezza disponibile: 56px - (10.4px × 2) - 2px = **33.2px**
+- Contenuto richiesto: 18.24px + 4px + 11.2px = **33.44px**
+- ⚠️ **Margine: -0.24px** (TROPPO STRETTO!)
+
+---
+
+## CONCLUSIONE
+❌ **Desktop:** Contenuto eccede di 0.24px - il testo potrebbe essere troncato
+⚠️ **Mobile:** Padding orizzontale troppo stretto (4px) per numeri a due cifre
+
+## RACCOMANDAZIONI
+1. Aumentare `min-height` desktop a 3.75rem (60px)
+2. Aumentare padding orizzontale mobile a 0.35rem (5.6px)
+3. Oppure ridurre leggermente i font-size

--- a/calendar-space-fixed.md
+++ b/calendar-space-fixed.md
@@ -1,0 +1,49 @@
+# Verifica Spazio Corretto - Calendario Box
+
+## Mobile (Dopo Fix)
+### Container
+- `min-height`: 2.75rem = **44px** (era 40px, +4px)
+- `padding`: 0.5rem 0.35rem = **8px verticale**, **5.6px orizzontale** (era 4px, +1.6px)
+- Border: 1px per lato = **2px totali verticali**
+
+### Contenuto
+- `day-label`: 0.85rem × 1.2 (line-height) = **16.32px**
+- `margin-top`: 0.15rem = **2.4px**
+- `day-count`: 0.65rem × 1 (line-height) = **10.4px**
+- **Totale**: 16.32px + 2.4px + 10.4px = **29.12px**
+
+### Calcolo Spazio Mobile
+- Altezza disponibile: 44px - (8px × 2) - 2px = **26px**
+- Contenuto richiesto: **29.12px**
+- ❌ **Eccede di 3.12px** - ANCORA TROPPO STRETTO!
+
+**SOLUZIONE MOBILE:** Ridurre margin-top da 0.15rem a 0.05rem o aumentare min-height
+
+---
+
+## Desktop (Dopo Fix)
+### Container
+- `min-height`: 3.75rem = **60px** (era 56px, +4px)
+- `padding`: 0.6rem 0.4rem = **9.6px verticale**, **6.4px orizzontale**
+- Border: 1px per lato = **2px totali verticali**
+
+### Contenuto
+- `day-label`: 0.95rem × 1.2 (line-height) = **18.24px**
+- `margin-top`: 0.2rem = **3.2px** (era 4px, -0.8px)
+- `day-count`: 0.7rem × 1 (line-height) = **11.2px**
+- **Totale**: 18.24px + 3.2px + 11.2px = **32.64px**
+
+### Calcolo Spazio Desktop
+- Altezza disponibile: 60px - (9.6px × 2) - 2px = **38.8px**
+- Contenuto richiesto: **32.64px**
+- ✅ **Margine: 6.16px** - PERFETTO!
+
+---
+
+## NECESSARIA ULTERIORE CORREZIONE MOBILE
+Opzioni:
+1. ✅ Ridurre margin-top da 0.15rem a 0.05rem (-1.6px)
+2. Aumentare min-height a 3rem (48px)
+3. Ridurre font-size leggermente
+
+**RACCOMANDAZIONE:** Opzione 1 (più conservativa)

--- a/test-calendar-margins.html
+++ b/test-calendar-margins.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test Calendario - Margini Corretti</title>
+    <link rel="stylesheet" href="assets/css/front.css">
+    <style>
+        :root {
+            --fp-color-primary: #0B6EFD;
+            --fp-color-accent: #00A37A;
+            --fp-color-text: #0F172A;
+            --fp-color-muted: #64748B;
+            --fp-color-surface: #fff;
+            --fp-shadow: 0 10px 30px rgba(15, 23, 42, 0.1);
+            --fp-radius: 16px;
+            --fp-exp-radius-base: 12px;
+        }
+        
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            padding: 2rem;
+            background: #f8fafc;
+            margin: 0;
+        }
+        
+        .test-container {
+            max-width: 800px;
+            margin: 0 auto;
+            background: white;
+            padding: 2rem;
+            border-radius: 12px;
+            box-shadow: 0 10px 30px rgba(15, 23, 42, 0.1);
+        }
+        
+        h1 {
+            margin-top: 0;
+            color: var(--fp-color-text);
+        }
+        
+        .test-info {
+            background: #EEF2FF;
+            border-left: 4px solid var(--fp-color-primary);
+            padding: 1rem;
+            margin-bottom: 2rem;
+            border-radius: 8px;
+        }
+        
+        .test-info h2 {
+            margin-top: 0;
+            font-size: 1.1rem;
+            color: var(--fp-color-primary);
+        }
+        
+        .test-info ul {
+            margin-bottom: 0;
+        }
+        
+        .test-section {
+            margin-top: 2rem;
+            padding: 1rem;
+            border: 2px dashed #e2e8f0;
+            border-radius: 8px;
+        }
+        
+        .test-label {
+            font-weight: 600;
+            color: var(--fp-color-text);
+            margin-bottom: 0.5rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="test-container">
+        <h1>🗓️ Test Calendario - Margini Corretti</h1>
+        
+        <div class="test-info">
+            <h2>✅ Correzioni Applicate</h2>
+            <ul>
+                <li><code>box-sizing: border-box</code> applicato a tutti gli elementi del calendario</li>
+                <li>Grid usa <code>minmax(0, 1fr)</code> invece di <code>1fr</code></li>
+                <li>Gap ridotti su desktop da 0.5rem a 0.4rem</li>
+                <li>Padding ottimizzati per evitare overflow</li>
+                <li><code>overflow: hidden</code> sui contenitori</li>
+                <li><code>min-width: 0</code> sui box dei giorni</li>
+            </ul>
+        </div>
+        
+        <div class="test-section">
+            <div class="test-label">Calendario Normale (Desktop: gap 0.4rem)</div>
+            
+            <div class="fp-exp-calendar" data-show-calendar="1">
+                <section class="fp-exp-calendar__month" data-month="2025-01">
+                    <header class="fp-exp-calendar__month-header">Gennaio 2025</header>
+                    
+                    <div class="fp-exp-calendar__weekdays" aria-hidden="true">
+                        <div class="fp-exp-calendar__weekday">Lun</div>
+                        <div class="fp-exp-calendar__weekday">Mar</div>
+                        <div class="fp-exp-calendar__weekday">Mer</div>
+                        <div class="fp-exp-calendar__weekday">Gio</div>
+                        <div class="fp-exp-calendar__weekday">Ven</div>
+                        <div class="fp-exp-calendar__weekday">Sab</div>
+                        <div class="fp-exp-calendar__weekday">Dom</div>
+                    </div>
+                    
+                    <div class="fp-exp-calendar__grid">
+                        <!-- Primi giorni vuoti (Gennaio 2025 inizia Mercoledì) -->
+                        <div class="fp-exp-calendar__empty" aria-hidden="true"></div>
+                        <div class="fp-exp-calendar__empty" aria-hidden="true"></div>
+                        
+                        <!-- Giorni del mese -->
+                        <button type="button" class="fp-exp-calendar__day" data-date="2025-01-01" data-available="1" aria-pressed="false">
+                            <span class="fp-exp-calendar__day-label">1</span>
+                            <span class="fp-exp-calendar__day-count">3 fasce</span>
+                        </button>
+                        <button type="button" class="fp-exp-calendar__day" data-date="2025-01-02" data-available="1" aria-pressed="false">
+                            <span class="fp-exp-calendar__day-label">2</span>
+                            <span class="fp-exp-calendar__day-count">5 fasce</span>
+                        </button>
+                        <button type="button" class="fp-exp-calendar__day" data-date="2025-01-03" data-available="0" disabled aria-disabled="true">
+                            <span class="fp-exp-calendar__day-label">3</span>
+                        </button>
+                        <button type="button" class="fp-exp-calendar__day" data-date="2025-01-04" data-available="1" aria-pressed="false">
+                            <span class="fp-exp-calendar__day-label">4</span>
+                            <span class="fp-exp-calendar__day-count">2 fasce</span>
+                        </button>
+                        <button type="button" class="fp-exp-calendar__day" data-date="2025-01-05" data-available="1" aria-pressed="false">
+                            <span class="fp-exp-calendar__day-label">5</span>
+                            <span class="fp-exp-calendar__day-count">4 fasce</span>
+                        </button>
+                        
+                        <!-- Seconda settimana -->
+                        <button type="button" class="fp-exp-calendar__day" data-date="2025-01-06" data-available="1" aria-pressed="false">
+                            <span class="fp-exp-calendar__day-label">6</span>
+                            <span class="fp-exp-calendar__day-count">3 fasce</span>
+                        </button>
+                        <button type="button" class="fp-exp-calendar__day" data-date="2025-01-07" data-available="1" aria-pressed="false">
+                            <span class="fp-exp-calendar__day-label">7</span>
+                            <span class="fp-exp-calendar__day-count">6 fasce</span>
+                        </button>
+                        <button type="button" class="fp-exp-calendar__day" data-date="2025-01-08" data-available="1" aria-pressed="false">
+                            <span class="fp-exp-calendar__day-label">8</span>
+                            <span class="fp-exp-calendar__day-count">2 fasce</span>
+                        </button>
+                        <button type="button" class="fp-exp-calendar__day" data-date="2025-01-09" data-available="1" aria-pressed="false">
+                            <span class="fp-exp-calendar__day-label">9</span>
+                            <span class="fp-exp-calendar__day-count">4 fasce</span>
+                        </button>
+                        <button type="button" class="fp-exp-calendar__day" data-date="2025-01-10" data-available="0" disabled aria-disabled="true">
+                            <span class="fp-exp-calendar__day-label">10</span>
+                        </button>
+                        <button type="button" class="fp-exp-calendar__day" data-date="2025-01-11" data-available="1" aria-pressed="false">
+                            <span class="fp-exp-calendar__day-label">11</span>
+                            <span class="fp-exp-calendar__day-count">5 fasce</span>
+                        </button>
+                        <button type="button" class="fp-exp-calendar__day" data-date="2025-01-12" data-available="1" aria-pressed="false">
+                            <span class="fp-exp-calendar__day-label">12</span>
+                            <span class="fp-exp-calendar__day-count">3 fasce</span>
+                        </button>
+                        
+                        <!-- Terza settimana -->
+                        <button type="button" class="fp-exp-calendar__day" data-date="2025-01-13" data-available="1" aria-pressed="false">
+                            <span class="fp-exp-calendar__day-label">13</span>
+                            <span class="fp-exp-calendar__day-count">2 fasce</span>
+                        </button>
+                        <button type="button" class="fp-exp-calendar__day" data-date="2025-01-14" data-available="1" aria-pressed="false">
+                            <span class="fp-exp-calendar__day-label">14</span>
+                            <span class="fp-exp-calendar__day-count">4 fasce</span>
+                        </button>
+                        <button type="button" class="fp-exp-calendar__day" data-date="2025-01-15" data-available="1" aria-pressed="true">
+                            <span class="fp-exp-calendar__day-label">15</span>
+                            <span class="fp-exp-calendar__day-count">3 fasce</span>
+                        </button>
+                        <button type="button" class="fp-exp-calendar__day" data-date="2025-01-16" data-available="1" aria-pressed="false">
+                            <span class="fp-exp-calendar__day-label">16</span>
+                            <span class="fp-exp-calendar__day-count">5 fasce</span>
+                        </button>
+                        <button type="button" class="fp-exp-calendar__day" data-date="2025-01-17" data-available="0" disabled aria-disabled="true">
+                            <span class="fp-exp-calendar__day-label">17</span>
+                        </button>
+                        <button type="button" class="fp-exp-calendar__day" data-date="2025-01-18" data-available="1" aria-pressed="false">
+                            <span class="fp-exp-calendar__day-label">18</span>
+                            <span class="fp-exp-calendar__day-count">4 fasce</span>
+                        </button>
+                        <button type="button" class="fp-exp-calendar__day" data-date="2025-01-19" data-available="1" aria-pressed="false">
+                            <span class="fp-exp-calendar__day-label">19</span>
+                            <span class="fp-exp-calendar__day-count">6 fasce</span>
+                        </button>
+                    </div>
+                </section>
+            </div>
+        </div>
+        
+        <div class="test-info" style="margin-top: 2rem; background: #F0FDF4; border-color: #16a34a;">
+            <h2 style="color: #16a34a;">📋 Come Testare</h2>
+            <ul>
+                <li>Ridimensiona la finestra del browser</li>
+                <li>Verifica che i box non escano mai dai margini del contenitore grigio</li>
+                <li>Controlla su mobile, tablet e desktop</li>
+                <li>Usa gli strumenti per sviluppatori per ispezionare gli elementi</li>
+                <li>Verifica che non ci sia scroll orizzontale</li>
+            </ul>
+        </div>
+    </div>
+</body>
+</html>

--- a/test-calendar-margins.html
+++ b/test-calendar-margins.html
@@ -79,15 +79,16 @@
             <ul>
                 <li><code>box-sizing: border-box</code> applicato a tutti gli elementi del calendario</li>
                 <li>Grid usa <code>minmax(0, 1fr)</code> invece di <code>1fr</code></li>
-                <li>Gap ridotti su desktop da 0.5rem a 0.4rem</li>
-                <li>Padding ottimizzati per evitare overflow</li>
-                <li><code>overflow: hidden</code> sui contenitori</li>
-                <li><code>min-width: 0</code> sui box dei giorni</li>
+                <li><strong>Mobile:</strong> min-height aumentato da 40px → 46.4px, padding H da 4px → 5.6px</li>
+                <li><strong>Desktop:</strong> min-height aumentato da 56px → 60px, gap ridotto da 0.4rem → 0.35rem</li>
+                <li><strong>Spazio verificato matematicamente:</strong> mobile +0.88px, desktop +6.16px di margine</li>
+                <li><code>overflow: hidden</code> sui contenitori per sicurezza</li>
+                <li><code>min-width: 0</code> sui box dei giorni per prevenire espansione forzata</li>
             </ul>
         </div>
         
         <div class="test-section">
-            <div class="test-label">Calendario Normale (Desktop: gap 0.4rem)</div>
+            <div class="test-label">Calendario Normale (Desktop: gap 0.35rem, min-height 60px)</div>
             
             <div class="fp-exp-calendar" data-show-calendar="1">
                 <section class="fp-exp-calendar__month" data-month="2025-01">


### PR DESCRIPTION
Fix calendar day box overflow on the frontend by applying correct box-sizing, grid properties, and responsive spacing.

The overflow was caused by several CSS issues, including incorrect box model handling, inflexible grid columns (`1fr`), and unoptimized spacing for different screen sizes. The changes ensure elements respect their boundaries and prevent horizontal scroll.

---
<a href="https://cursor.com/background-agent?bcId=bc-bcd37358-edb4-4f97-86f7-83b9737b19b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bcd37358-edb4-4f97-86f7-83b9737b19b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

