### PR TITLE
Reorder fp-exp-section and fp-exp-highlights

### DIFF
--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -2654,6 +2654,16 @@
     }
 }
 
+@media (max-width: 1023px) {
+    .fp-exp-page__aside {
+        order: 5;
+    }
+
+    .fp-exp-highlights {
+        order: 10;
+    }
+}
+
 .fp-layout {
     position: relative;
     display: block;

--- a/build/fp-experiences/assets/css/front.css
+++ b/build/fp-experiences/assets/css/front.css
@@ -2654,6 +2654,16 @@
     }
 }
 
+@media (max-width: 1023px) {
+    .fp-exp-page__aside {
+        order: 5;
+    }
+
+    .fp-exp-highlights {
+        order: 10;
+    }
+}
+
 .fp-layout {
     position: relative;
     display: block;


### PR DESCRIPTION
Reorder the booking widget (`fp-exp-page__aside`) to appear before the highlights section (`fp-exp-highlights`) on mobile devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-08b54a42-7550-4a32-9303-12ed3094487a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-08b54a42-7550-4a32-9303-12ed3094487a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

