### PR TITLE
Reorder exp sections for mobile view

### DIFF
--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -2658,10 +2658,6 @@
     .fp-exp-page__aside {
         order: 5;
     }
-
-    .fp-exp-highlights {
-        order: 10;
-    }
 }
 
 .fp-layout {

--- a/build/fp-experiences/assets/css/front.css
+++ b/build/fp-experiences/assets/css/front.css
@@ -2658,10 +2658,6 @@
     .fp-exp-page__aside {
         order: 5;
     }
-
-    .fp-exp-highlights {
-        order: 10;
-    }
 }
 
 .fp-layout {


### PR DESCRIPTION
Remove `order: 10` from `.fp-exp-highlights` in mobile CSS to correctly position it after the widget, not at the end.

---
<a href="https://cursor.com/background-agent?bcId=bc-5cb3d077-bd9d-40a9-a30b-b987a865d225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5cb3d077-bd9d-40a9-a30b-b987a865d225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

