### PR TITLE
Fix calendar display last two days

### DIFF
--- a/build/fp-experiences/src/Booking/AvailabilityService.php
+++ b/build/fp-experiences/src/Booking/AvailabilityService.php
@@ -225,7 +225,7 @@ final class AvailabilityService
             $period = new DatePeriod(
                 $range_start->setTime(0, 0),
                 new DateInterval('P1D'),
-                $range_end->setTime(23, 59, 59)->add(new DateInterval('PT1S'))
+                $range_end->setTime(0, 0)->add(new DateInterval('P1D'))
             );
 
             foreach ($period as $day) {
@@ -414,7 +414,7 @@ final class AvailabilityService
             $period = new DatePeriod(
                 $range_start->setTime(0, 0),
                 new DateInterval('P1D'),
-                $range_end->setTime(23, 59, 59)->add(new DateInterval('PT1S'))
+                $range_end->setTime(0, 0)->add(new DateInterval('P1D'))
             );
 
             foreach ($period as $day) {

--- a/src/Booking/AvailabilityService.php
+++ b/src/Booking/AvailabilityService.php
@@ -225,7 +225,7 @@ final class AvailabilityService
             $period = new DatePeriod(
                 $range_start->setTime(0, 0),
                 new DateInterval('P1D'),
-                $range_end->setTime(23, 59, 59)->add(new DateInterval('PT1S'))
+                $range_end->setTime(0, 0)->add(new DateInterval('P1D'))
             );
 
             foreach ($period as $day) {
@@ -414,7 +414,7 @@ final class AvailabilityService
             $period = new DatePeriod(
                 $range_start->setTime(0, 0),
                 new DateInterval('P1D'),
-                $range_end->setTime(23, 59, 59)->add(new DateInterval('PT1S'))
+                $range_end->setTime(0, 0)->add(new DateInterval('P1D'))
             );
 
             foreach ($period as $day) {


### PR DESCRIPTION
Fix `DatePeriod` calculation to correctly include the last day of the month for slot generation.

The original `DatePeriod` end date calculation was exclusive and could omit the last day of the month due to edge cases with `->add(new DateInterval('PT1S'))`. The fix adjusts the end date to `->setTime(0, 0)->add(new DateInterval('P1D'))` to ensure all days, including the last, are properly iterated.

---
<a href="https://cursor.com/background-agent?bcId=bc-a887c2b2-1a22-4d5a-ae9a-63ea41325dff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a887c2b2-1a22-4d5a-ae9a-63ea41325dff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

