### PR TITLE
Fix calendar date selection bug

### DIFF
--- a/build/fp-experiences/src/Booking/AvailabilityService.php
+++ b/build/fp-experiences/src/Booking/AvailabilityService.php
@@ -155,7 +155,7 @@ final class AvailabilityService
         }
 
         try {
-            $range_end = new DateTimeImmutable($end_utc, new DateTimeZone('UTC'));
+            $range_end = new DateTimeImmutable($end_utc . ' 23:59:59', new DateTimeZone('UTC'));
         } catch (Exception $e) {
             $range_end = $range_start;
         }
@@ -347,7 +347,7 @@ final class AvailabilityService
         }
 
         try {
-            $range_end = new DateTimeImmutable($end_utc, new DateTimeZone('UTC'));
+            $range_end = new DateTimeImmutable($end_utc . ' 23:59:59', new DateTimeZone('UTC'));
         } catch (Exception $e) {
             $range_end = $range_start;
         }

--- a/build/fp-experiences/src/Shortcodes/CalendarShortcode.php
+++ b/build/fp-experiences/src/Shortcodes/CalendarShortcode.php
@@ -159,12 +159,13 @@ final class CalendarShortcode extends BaseShortcode
             $month_label = $date->format('F Y');
 
             // Ottieni gli slot per questo mese
-            $start_of_month = $date->modify('first day of this month')->setTime(0, 0, 0);
-            $end_of_month = $date->modify('last day of this month')->setTime(23, 59, 59);
+            // Usa il primo e ultimo giorno del mese nel timezone locale
+            $start_of_month = $date->modify('first day of this month');
+            $end_of_month = $date->modify('last day of this month');
 
-            $start_utc = $start_of_month->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d');
-            // Include l'intero ultimo giorno del mese passando la data completa con orario
-            $end_utc = $end_of_month->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d');
+            // Passa le date in formato Y-m-d senza conversione timezone per evitare shift di giorni
+            $start_utc = $start_of_month->format('Y-m-d');
+            $end_utc = $end_of_month->format('Y-m-d');
 
             // Usa AvailabilityService per ottenere gli slot virtuali
             $slots = \FP_Exp\Booking\AvailabilityService::get_virtual_slots($experience_id, $start_utc, $end_utc);

--- a/build/fp-experiences/src/Shortcodes/CalendarShortcode.php
+++ b/build/fp-experiences/src/Shortcodes/CalendarShortcode.php
@@ -163,6 +163,7 @@ final class CalendarShortcode extends BaseShortcode
             $end_of_month = $date->modify('last day of this month')->setTime(23, 59, 59);
 
             $start_utc = $start_of_month->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d');
+            // Include l'intero ultimo giorno del mese passando la data completa con orario
             $end_utc = $end_of_month->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d');
 
             // Usa AvailabilityService per ottenere gli slot virtuali

--- a/src/Booking/AvailabilityService.php
+++ b/src/Booking/AvailabilityService.php
@@ -155,7 +155,7 @@ final class AvailabilityService
         }
 
         try {
-            $range_end = new DateTimeImmutable($end_utc, new DateTimeZone('UTC'));
+            $range_end = new DateTimeImmutable($end_utc . ' 23:59:59', new DateTimeZone('UTC'));
         } catch (Exception $e) {
             $range_end = $range_start;
         }
@@ -347,7 +347,7 @@ final class AvailabilityService
         }
 
         try {
-            $range_end = new DateTimeImmutable($end_utc, new DateTimeZone('UTC'));
+            $range_end = new DateTimeImmutable($end_utc . ' 23:59:59', new DateTimeZone('UTC'));
         } catch (Exception $e) {
             $range_end = $range_start;
         }

--- a/src/Shortcodes/CalendarShortcode.php
+++ b/src/Shortcodes/CalendarShortcode.php
@@ -159,12 +159,13 @@ final class CalendarShortcode extends BaseShortcode
             $month_label = $date->format('F Y');
 
             // Ottieni gli slot per questo mese
-            $start_of_month = $date->modify('first day of this month')->setTime(0, 0, 0);
-            $end_of_month = $date->modify('last day of this month')->setTime(23, 59, 59);
+            // Usa il primo e ultimo giorno del mese nel timezone locale
+            $start_of_month = $date->modify('first day of this month');
+            $end_of_month = $date->modify('last day of this month');
 
-            $start_utc = $start_of_month->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d');
-            // Include l'intero ultimo giorno del mese passando la data completa con orario
-            $end_utc = $end_of_month->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d');
+            // Passa le date in formato Y-m-d senza conversione timezone per evitare shift di giorni
+            $start_utc = $start_of_month->format('Y-m-d');
+            $end_utc = $end_of_month->format('Y-m-d');
 
             // Usa AvailabilityService per ottenere gli slot virtuali
             $slots = \FP_Exp\Booking\AvailabilityService::get_virtual_slots($experience_id, $start_utc, $end_utc);

--- a/src/Shortcodes/CalendarShortcode.php
+++ b/src/Shortcodes/CalendarShortcode.php
@@ -163,6 +163,7 @@ final class CalendarShortcode extends BaseShortcode
             $end_of_month = $date->modify('last day of this month')->setTime(23, 59, 59);
 
             $start_utc = $start_of_month->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d');
+            // Include l'intero ultimo giorno del mese passando la data completa con orario
             $end_utc = $end_of_month->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d');
 
             // Usa AvailabilityService per ottenere gli slot virtuali


### PR DESCRIPTION
Fixes the inability to select the last two days of the month in the frontend calendar.

The `$range_end` in `AvailabilityService` was set to midnight of the last day of the month, causing slots starting after midnight (e.g., on the 30th or 31st) to be incorrectly excluded. Appending ` 23:59:59` to `$range_end` ensures the entire last day is included in the availability calculation.

---
<a href="https://cursor.com/background-agent?bcId=bc-820c51af-7d22-4ff6-b9db-4cb3780aa69a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-820c51af-7d22-4ff6-b9db-4cb3780aa69a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

