### PR TITLE
Reorder fp-exp components on mobile

### DIFF
--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -2658,6 +2658,10 @@
     .fp-exp-page__aside {
         order: 5;
     }
+
+    .fp-exp-highlights {
+        order: 6;
+    }
 }
 
 .fp-layout {

--- a/build/fp-experiences/assets/css/front.css
+++ b/build/fp-experiences/assets/css/front.css
@@ -2658,6 +2658,10 @@
     .fp-exp-page__aside {
         order: 5;
     }
+
+    .fp-exp-highlights {
+        order: 6;
+    }
 }
 
 .fp-layout {


### PR DESCRIPTION
Reorder widget and highlights section on mobile to display the widget before the highlights.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3f6a248-bf42-48c0-8bba-fdce48d163d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d3f6a248-bf42-48c0-8bba-fdce48d163d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

