### PR TITLE
Adjust mobile display order of experience sections

### DIFF
--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -2655,9 +2655,29 @@
 }
 
 @media (max-width: 1023px) {
-    .fp-exp-page__aside {
-        order: 5;
+    /* Appiattisce main per permettere il riordino con aside */
+    .fp-exp-page__layout .fp-main {
+        display: contents;
     }
+    
+    /* Riordina le sezioni: widget dopo highlights */
+    .fp-exp-section.fp-exp-hero { order: 1; }
+    .fp-exp-section.fp-exp-overview { order: 2; }
+    .fp-exp-section.fp-exp-gallery { order: 3; }
+    .fp-exp-section.fp-exp-gift { order: 4; }
+    .fp-exp-section.fp-exp-highlights { order: 5; }
+    
+    /* Widget dopo highlights */
+    .fp-exp-page__aside {
+        order: 6;
+    }
+    
+    /* Altre sezioni dopo il widget */
+    .fp-exp-section.fp-exp-inclusions { order: 7; }
+    .fp-exp-section.fp-exp-meeting { order: 8; }
+    .fp-exp-section.fp-exp-essentials { order: 9; }
+    .fp-exp-section[data-fp-section="faq"] { order: 10; }
+    .fp-exp-section[data-fp-section="reviews"] { order: 11; }
 }
 
 .fp-layout {

--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -2660,19 +2660,20 @@
         display: contents;
     }
     
-    /* Riordina le sezioni: widget dopo highlights */
+    /* Riordina le sezioni: widget prima di highlights */
     .fp-exp-section.fp-exp-hero { order: 1; }
     .fp-exp-section.fp-exp-overview { order: 2; }
     .fp-exp-section.fp-exp-gallery { order: 3; }
     .fp-exp-section.fp-exp-gift { order: 4; }
-    .fp-exp-section.fp-exp-highlights { order: 5; }
     
-    /* Widget dopo highlights */
+    /* Widget prima di highlights */
     .fp-exp-page__aside {
-        order: 6;
+        order: 5;
     }
     
-    /* Altre sezioni dopo il widget */
+    .fp-exp-section.fp-exp-highlights { order: 6; }
+    
+    /* Altre sezioni dopo highlights */
     .fp-exp-section.fp-exp-inclusions { order: 7; }
     .fp-exp-section.fp-exp-meeting { order: 8; }
     .fp-exp-section.fp-exp-essentials { order: 9; }

--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -2658,10 +2658,6 @@
     .fp-exp-page__aside {
         order: 5;
     }
-
-    .fp-exp-highlights {
-        order: 6;
-    }
 }
 
 .fp-layout {

--- a/build/fp-experiences/assets/css/front.css
+++ b/build/fp-experiences/assets/css/front.css
@@ -2655,9 +2655,29 @@
 }
 
 @media (max-width: 1023px) {
-    .fp-exp-page__aside {
-        order: 5;
+    /* Appiattisce main per permettere il riordino con aside */
+    .fp-exp-page__layout .fp-main {
+        display: contents;
     }
+    
+    /* Riordina le sezioni: widget dopo highlights */
+    .fp-exp-section.fp-exp-hero { order: 1; }
+    .fp-exp-section.fp-exp-overview { order: 2; }
+    .fp-exp-section.fp-exp-gallery { order: 3; }
+    .fp-exp-section.fp-exp-gift { order: 4; }
+    .fp-exp-section.fp-exp-highlights { order: 5; }
+    
+    /* Widget dopo highlights */
+    .fp-exp-page__aside {
+        order: 6;
+    }
+    
+    /* Altre sezioni dopo il widget */
+    .fp-exp-section.fp-exp-inclusions { order: 7; }
+    .fp-exp-section.fp-exp-meeting { order: 8; }
+    .fp-exp-section.fp-exp-essentials { order: 9; }
+    .fp-exp-section[data-fp-section="faq"] { order: 10; }
+    .fp-exp-section[data-fp-section="reviews"] { order: 11; }
 }
 
 .fp-layout {

--- a/build/fp-experiences/assets/css/front.css
+++ b/build/fp-experiences/assets/css/front.css
@@ -2660,19 +2660,20 @@
         display: contents;
     }
     
-    /* Riordina le sezioni: widget dopo highlights */
+    /* Riordina le sezioni: widget prima di highlights */
     .fp-exp-section.fp-exp-hero { order: 1; }
     .fp-exp-section.fp-exp-overview { order: 2; }
     .fp-exp-section.fp-exp-gallery { order: 3; }
     .fp-exp-section.fp-exp-gift { order: 4; }
-    .fp-exp-section.fp-exp-highlights { order: 5; }
     
-    /* Widget dopo highlights */
+    /* Widget prima di highlights */
     .fp-exp-page__aside {
-        order: 6;
+        order: 5;
     }
     
-    /* Altre sezioni dopo il widget */
+    .fp-exp-section.fp-exp-highlights { order: 6; }
+    
+    /* Altre sezioni dopo highlights */
     .fp-exp-section.fp-exp-inclusions { order: 7; }
     .fp-exp-section.fp-exp-meeting { order: 8; }
     .fp-exp-section.fp-exp-essentials { order: 9; }

--- a/build/fp-experiences/assets/css/front.css
+++ b/build/fp-experiences/assets/css/front.css
@@ -2658,10 +2658,6 @@
     .fp-exp-page__aside {
         order: 5;
     }
-
-    .fp-exp-highlights {
-        order: 6;
-    }
 }
 
 .fp-layout {


### PR DESCRIPTION
Remove `order: 6` from `.fp-exp-highlights` in mobile media queries to fix its incorrect positioning at the bottom of the page.

---
<a href="https://cursor.com/background-agent?bcId=bc-cee3d773-cfaf-4eb4-849a-7bbefce24f90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cee3d773-cfaf-4eb4-849a-7bbefce24f90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

