### PR TITLE
Remove styling from fp-exp-quantity

### DIFF
--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -2009,10 +2009,7 @@
     justify-content: flex-end;
     gap: 0.5rem;
     padding: 0.35rem;
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--fp-color-primary) 6%, #fff);
     border: 1px solid color-mix(in srgb, var(--fp-color-primary) 18%, rgba(15, 23, 42, 0.12));
-    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
     flex-wrap: nowrap;
     min-width: 0;
 }

--- a/build/fp-experiences/assets/css/front.css
+++ b/build/fp-experiences/assets/css/front.css
@@ -2009,10 +2009,7 @@
     justify-content: flex-end;
     gap: 0.5rem;
     padding: 0.35rem;
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--fp-color-primary) 6%, #fff);
     border: 1px solid color-mix(in srgb, var(--fp-color-primary) 18%, rgba(15, 23, 42, 0.12));
-    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
     flex-wrap: nowrap;
     min-width: 0;
 }


### PR DESCRIPTION
Remove `border-radius`, `background`, and `box-shadow` from `.fp-exp-quantity` as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-14f8f648-872a-4d1c-a4fc-1c1306f2eb93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-14f8f648-872a-4d1c-a4fc-1c1306f2eb93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

