### PR TITLE
Fix ticket price display logic

### DIFF
--- a/build/fp-experiences/src/Shortcodes/ExperienceShortcode.php
+++ b/build/fp-experiences/src/Shortcodes/ExperienceShortcode.php
@@ -493,23 +493,19 @@ final class ExperienceShortcode extends BaseShortcode
             return null;
         }
 
-        $min_price = null;
+        // Use the price from the first valid ticket type instead of the minimum
         foreach ($tickets as $ticket) {
             if (! is_array($ticket) || ! isset($ticket['price'])) {
                 continue;
             }
 
             $price = (float) $ticket['price'];
-            if ($price <= 0) {
-                continue;
-            }
-
-            if (null === $min_price || $price < $min_price) {
-                $min_price = $price;
+            if ($price > 0) {
+                return $price;
             }
         }
 
-        return $min_price;
+        return null;
     }
 
     /**
@@ -901,18 +897,17 @@ final class ExperienceShortcode extends BaseShortcode
      */
     private function resolve_price(int $experience_id, array $tickets): float
     {
-        $prices = array_filter(array_map(static function (array $ticket) {
+        // Use the price from the first valid ticket type instead of the minimum
+        foreach ($tickets as $ticket) {
             if (! isset($ticket['price'])) {
-                return null;
+                continue;
             }
 
             $price = $ticket['price'];
 
-            return is_numeric($price) ? (float) $price : null;
-        }, $tickets));
-
-        if (! empty($prices)) {
-            return (float) min($prices);
+            if (is_numeric($price) && (float) $price > 0) {
+                return (float) $price;
+            }
         }
 
         $base_price = get_post_meta($experience_id, '_fp_base_price', true);

--- a/build/fp-experiences/src/Shortcodes/ListShortcode.php
+++ b/build/fp-experiences/src/Shortcodes/ListShortcode.php
@@ -1101,22 +1101,18 @@ final class ListShortcode extends BaseShortcode
             return null;
         }
 
-        $min_price = null;
+        // Use the price from the first valid ticket type instead of the minimum
         foreach ($tickets as $ticket) {
             if (! is_array($ticket) || ! isset($ticket['price'])) {
                 continue;
             }
 
             $price = (float) $ticket['price'];
-            if ($price <= 0) {
-                continue;
-            }
-
-            if (null === $min_price || $price < $min_price) {
-                $min_price = $price;
+            if ($price > 0) {
+                return $price;
             }
         }
 
-        return $min_price;
+        return null;
     }
 }

--- a/build/fp-experiences/src/Shortcodes/SimpleArchiveShortcode.php
+++ b/build/fp-experiences/src/Shortcodes/SimpleArchiveShortcode.php
@@ -243,25 +243,18 @@ final class SimpleArchiveShortcode extends BaseShortcode
             return null;
         }
 
-        $prices = [];
-
+        // Use the price from the first valid ticket type instead of the minimum
         foreach ($tickets as $ticket) {
             if (! is_array($ticket) || ! isset($ticket['price'])) {
                 continue;
             }
 
             $price = (float) $ticket['price'];
-            if ($price <= 0) {
-                continue;
+            if ($price > 0) {
+                return $price;
             }
-
-            $prices[] = $price;
         }
 
-        if (empty($prices)) {
-            return null;
-        }
-
-        return min($prices);
+        return null;
     }
 }

--- a/build/fp-experiences/templates/front/widget.php
+++ b/build/fp-experiences/templates/front/widget.php
@@ -141,6 +141,7 @@ foreach ($slots as $slot) {
     $price_from_value = null === $price_from_value ? $price : min($price_from_value, $price);
 }
 
+// Use the price from the first valid ticket type instead of the minimum
 if (null === $price_from_value) {
     foreach ($tickets as $ticket) {
         if (! is_array($ticket)) {
@@ -149,11 +150,10 @@ if (null === $price_from_value) {
 
         $price = isset($ticket['price']) ? (float) $ticket['price'] : 0.0;
 
-        if ($price <= 0) {
-            continue;
+        if ($price > 0) {
+            $price_from_value = $price;
+            break;
         }
-
-        $price_from_value = null === $price_from_value ? $price : min($price_from_value, $price);
     }
 }
 

--- a/src/Shortcodes/ExperienceShortcode.php
+++ b/src/Shortcodes/ExperienceShortcode.php
@@ -493,23 +493,19 @@ final class ExperienceShortcode extends BaseShortcode
             return null;
         }
 
-        $min_price = null;
+        // Use the price from the first valid ticket type instead of the minimum
         foreach ($tickets as $ticket) {
             if (! is_array($ticket) || ! isset($ticket['price'])) {
                 continue;
             }
 
             $price = (float) $ticket['price'];
-            if ($price <= 0) {
-                continue;
-            }
-
-            if (null === $min_price || $price < $min_price) {
-                $min_price = $price;
+            if ($price > 0) {
+                return $price;
             }
         }
 
-        return $min_price;
+        return null;
     }
 
     /**
@@ -901,18 +897,17 @@ final class ExperienceShortcode extends BaseShortcode
      */
     private function resolve_price(int $experience_id, array $tickets): float
     {
-        $prices = array_filter(array_map(static function (array $ticket) {
+        // Use the price from the first valid ticket type instead of the minimum
+        foreach ($tickets as $ticket) {
             if (! isset($ticket['price'])) {
-                return null;
+                continue;
             }
 
             $price = $ticket['price'];
 
-            return is_numeric($price) ? (float) $price : null;
-        }, $tickets));
-
-        if (! empty($prices)) {
-            return (float) min($prices);
+            if (is_numeric($price) && (float) $price > 0) {
+                return (float) $price;
+            }
         }
 
         $base_price = get_post_meta($experience_id, '_fp_base_price', true);

--- a/src/Shortcodes/ListShortcode.php
+++ b/src/Shortcodes/ListShortcode.php
@@ -1101,22 +1101,18 @@ final class ListShortcode extends BaseShortcode
             return null;
         }
 
-        $min_price = null;
+        // Use the price from the first valid ticket type instead of the minimum
         foreach ($tickets as $ticket) {
             if (! is_array($ticket) || ! isset($ticket['price'])) {
                 continue;
             }
 
             $price = (float) $ticket['price'];
-            if ($price <= 0) {
-                continue;
-            }
-
-            if (null === $min_price || $price < $min_price) {
-                $min_price = $price;
+            if ($price > 0) {
+                return $price;
             }
         }
 
-        return $min_price;
+        return null;
     }
 }

--- a/src/Shortcodes/SimpleArchiveShortcode.php
+++ b/src/Shortcodes/SimpleArchiveShortcode.php
@@ -243,25 +243,18 @@ final class SimpleArchiveShortcode extends BaseShortcode
             return null;
         }
 
-        $prices = [];
-
+        // Use the price from the first valid ticket type instead of the minimum
         foreach ($tickets as $ticket) {
             if (! is_array($ticket) || ! isset($ticket['price'])) {
                 continue;
             }
 
             $price = (float) $ticket['price'];
-            if ($price <= 0) {
-                continue;
+            if ($price > 0) {
+                return $price;
             }
-
-            $prices[] = $price;
         }
 
-        if (empty($prices)) {
-            return null;
-        }
-
-        return min($prices);
+        return null;
     }
 }

--- a/templates/front/widget.php
+++ b/templates/front/widget.php
@@ -141,6 +141,7 @@ foreach ($slots as $slot) {
     $price_from_value = null === $price_from_value ? $price : min($price_from_value, $price);
 }
 
+// Use the price from the first valid ticket type instead of the minimum
 if (null === $price_from_value) {
     foreach ($tickets as $ticket) {
         if (! is_array($ticket)) {
@@ -149,11 +150,10 @@ if (null === $price_from_value) {
 
         $price = isset($ticket['price']) ? (float) $ticket['price'] : 0.0;
 
-        if ($price <= 0) {
-            continue;
+        if ($price > 0) {
+            $price_from_value = $price;
+            break;
         }
-
-        $price_from_value = null === $price_from_value ? $price : min($price_from_value, $price);
     }
 }
 


### PR DESCRIPTION
Update "from..." price calculation to display the price of the first configured ticket type.

Previously, the "from..." price displayed the lowest available ticket price (e.g., child ticket), instead of the price of the first configured ticket type as intended. This change ensures the displayed starting price aligns with the primary ticket option.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe975f6f-a586-4df0-9978-d516bc39df6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe975f6f-a586-4df0-9978-d516bc39df6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

