### PR TITLE
Fix missing featured image in experience list

### DIFF
--- a/FEATURED_IMAGE_FIX.md
+++ b/FEATURED_IMAGE_FIX.md
@@ -1,0 +1,62 @@
+# Fix: Featured Image non visibile nella lista esperienze
+
+## Problema
+Le immagini in evidenza (featured images) non venivano visualizzate nella lista delle esperienze.
+
+## Causa
+Il codice nella classe `ListShortcode` utilizzava solamente `get_the_post_thumbnail_url()` per recuperare l'immagine, ma non aveva un fallback per:
+1. L'immagine hero personalizzata (`_fp_hero_image_id`)
+2. Le immagini della galleria (`_fp_gallery_ids`)
+
+## Soluzione Implementata
+
+### File modificato: `src/Shortcodes/ListShortcode.php`
+
+1. **Aggiunta funzione `get_experience_thumbnail()`** (linee 1119-1153):
+   - Controlla prima la featured image di WordPress
+   - Fallback sulla hero image personalizzata
+   - Fallback sulla prima immagine della galleria se disponibile
+   - Restituisce stringa vuota se nessuna immagine è disponibile
+
+2. **Aggiornato il metodo `map_experience()`** (linea 521):
+   - Sostituito `get_the_post_thumbnail_url($id, 'large')` con `$this->get_experience_thumbnail($id)`
+
+3. **Aggiunto import necessario** (linea 37):
+   - Aggiunto `use function wp_get_attachment_image_url;`
+
+## Dettagli Tecnici
+
+La nuova funzione `get_experience_thumbnail()` segue questa logica a cascata:
+
+```php
+1. WordPress Featured Image → get_the_post_thumbnail_url()
+   ↓ (se non disponibile)
+2. Hero Image Meta → _fp_hero_image_id
+   ↓ (se non disponibile)
+3. Prima immagine Gallery → _fp_gallery_ids[0]
+   ↓ (se non disponibile)
+4. Stringa vuota → Verrà mostrato il placeholder CSS
+```
+
+## Benefici
+
+- ✅ Compatibilità retroattiva: continua a usare la featured image come prima priorità
+- ✅ Fallback intelligenti: utilizza hero image o gallery se la featured image non è impostata
+- ✅ Nessun errore: gestisce tutti i casi edge con controlli appropriati
+- ✅ Performance: mantiene la stessa efficienza con controlli condizionali rapidi
+
+## File Aggiornati
+
+- `/workspace/src/Shortcodes/ListShortcode.php`
+- `/workspace/build/fp-experiences/src/Shortcodes/ListShortcode.php`
+
+## Test Consigliati
+
+1. Verificare che le esperienze con featured image mostrino correttamente l'immagine
+2. Verificare che le esperienze senza featured image ma con hero image mostrino la hero image
+3. Verificare che le esperienze con solo gallery images mostrino la prima immagine della galleria
+4. Verificare che le esperienze senza immagini mostrino il placeholder
+
+## Note
+
+La sincronizzazione tra hero image e featured image avviene in `ExperienceMetaBoxes.php` (linee 2191-2197), ma questo fix garantisce che anche se la sincronizzazione fallisce, l'immagine verrà comunque visualizzata nella lista.

--- a/FEATURED_IMAGE_FIX_SUMMARY.md
+++ b/FEATURED_IMAGE_FIX_SUMMARY.md
@@ -1,0 +1,133 @@
+# Risoluzione Bug: Featured Image nella Lista Esperienze
+
+## ✅ PROBLEMA RISOLTO
+
+**Issue**: Le immagini in evidenza non si vedevano nella lista esperienze.
+
+## 🔧 MODIFICHE APPLICATE
+
+### File Modificato
+- **`src/Shortcodes/ListShortcode.php`**
+- **`build/fp-experiences/src/Shortcodes/ListShortcode.php`**
+
+### Modifiche Implementate
+
+#### 1. Nuova Funzione `get_experience_thumbnail()` (Linee 1119-1153)
+
+Implementa una logica di fallback a cascata per recuperare le immagini:
+
+```php
+1. WordPress Featured Image (prima priorità)
+   ↓ se non disponibile
+2. Hero Image (_fp_hero_image_id)  
+   ↓ se non disponibile
+3. Prima immagine Gallery (_fp_gallery_ids[0])
+   ↓ se non disponibile
+4. Stringa vuota (mostra placeholder CSS)
+```
+
+#### 2. Aggiornamento Metodo `map_experience()` (Linea 521)
+
+```php
+// PRIMA (non funzionava sempre)
+$thumbnail = get_the_post_thumbnail_url($id, 'large') ?: '';
+
+// DOPO (con fallback)
+$thumbnail = $this->get_experience_thumbnail($id);
+```
+
+#### 3. Aggiunto Import (Linea 37)
+
+```php
+use function wp_get_attachment_image_url;
+```
+
+## 🎯 COPERTURA
+
+Il fix si applica automaticamente a:
+
+- ✅ Shortcode `[fp_exp_list]`
+- ✅ Elementor Widget "FP Experiences List" (usa `do_shortcode`)
+- ✅ Entrambe le varianti del template (cards e classic)
+- ✅ Tutte le modalità di visualizzazione (grid e list)
+
+## 📋 COMPATIBILITÀ
+
+- ✅ **Retrocompatibile**: Le esperienze con featured image continuano a funzionare normalmente
+- ✅ **Zero Breaking Changes**: Nessuna modifica all'API o ai template
+- ✅ **Performance**: Nessun impatto sulle prestazioni (controlli condizionali rapidi)
+
+## 🧪 TEST ESEGUITI
+
+- ✅ Nessun errore di linting
+- ✅ Sintassi PHP corretta
+- ✅ Import delle funzioni completato
+- ✅ File copiati nella build directory
+
+## 📝 SCENARI GESTITI
+
+1. **Esperienza con Featured Image**: ✅ Mostra la featured image
+2. **Esperienza senza Featured Image ma con Hero Image**: ✅ Mostra la hero image
+3. **Esperienza solo con Gallery**: ✅ Mostra la prima immagine della gallery
+4. **Esperienza senza immagini**: ✅ Mostra il placeholder CSS (gradient)
+
+## 🔍 DETTAGLI TECNICI
+
+### Template (list.php)
+Il template controlla correttamente `$experience['thumbnail']`:
+
+```php
+<?php if (! empty($experience['thumbnail'])) : ?>
+    <img src="<?php echo esc_url($experience['thumbnail']); ?>" ... />
+<?php else : ?>
+    <span class="fp-listing__image fp-listing__image--placeholder"></span>
+<?php endif; ?>
+```
+
+### CSS
+Il placeholder è già definito in `assets/css/front/listing.css` (linee 264-270):
+
+```css
+.fp-listing__image--placeholder {
+    display: block;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(135deg, var(--fp-color-primary), var(--fp-color-accent));
+    opacity: 0.25;
+}
+```
+
+## 📦 FILE AGGIORNATI
+
+```
+✅ src/Shortcodes/ListShortcode.php
+✅ build/fp-experiences/src/Shortcodes/ListShortcode.php
+📄 FEATURED_IMAGE_FIX.md (documentazione dettagliata)
+📄 FEATURED_IMAGE_FIX_SUMMARY.md (questo file)
+```
+
+## 🚀 STATO
+
+**COMPLETATO E PRONTO PER IL DEPLOY**
+
+Non sono necessarie ulteriori azioni. Il fix è:
+- ✅ Implementato
+- ✅ Testato (linting)
+- ✅ Documentato
+- ✅ Compilato nella build directory
+
+## 📞 NOTE PER IL TEAM
+
+Se le immagini continuano a non essere visibili dopo il deploy:
+1. Verificare che le esperienze abbiano almeno una delle seguenti:
+   - Featured image impostata
+   - Hero image impostata (`_fp_hero_image_id`)
+   - Gallery con almeno un'immagine (`_fp_gallery_ids`)
+2. Controllare che gli ID delle immagini siano validi e che le immagini esistano nella media library
+3. Verificare i permessi di lettura degli attachment
+
+---
+
+**Data Fix**: 2025-10-08  
+**Autore**: AI Assistant (Cursor)  
+**Versione Plugin**: FP Experiences (current)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ e questo progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/)
 
 ## [Unreleased]
 
+### Fixed
+- **Featured Image nella Lista Esperienze**: Aggiunto fallback intelligente per recuperare immagini nella lista esperienze. Se la featured image non è disponibile, ora viene utilizzata automaticamente la hero image o la prima immagine della gallery. Questo risolve il problema delle immagini non visibili nella lista. (`ListShortcode.php`)
+
 ### Planned
 - [ ] Multi-currency support
 - [ ] Advanced reporting dashboard


### PR DESCRIPTION
Add intelligent fallback for experience thumbnails to ensure images are always displayed in the experience list.

Previously, the experience list only retrieved the standard WordPress featured image. This change introduces a new method that prioritizes the WordPress featured image, then falls back to a custom hero image (`_fp_hero_image_id`), and finally to the first image in the experience's gallery (`_fp_gallery_ids`) if no other image is found. This resolves cases where experiences had hero or gallery images but no standard featured image, causing them to appear without an image in the list.

---
<a href="https://cursor.com/background-agent?bcId=bc-93357ea9-81fc-4055-8c5d-aec52a01d443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-93357ea9-81fc-4055-8c5d-aec52a01d443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

