### PR TITLE
Update backend ticket price logic

### DIFF
--- a/PREZZO_DA_CHECKBOX_FEATURE.md
+++ b/PREZZO_DA_CHECKBOX_FEATURE.md
@@ -1,0 +1,88 @@
+# Funzionalità: Checkbox "Prezzo da..." per Tipologie Biglietto
+
+## Descrizione
+
+È stato implementato un checkbox per ogni tipologia di biglietto nel backend che permette di controllare quale prezzo viene usato come prezzo di partenza ("da...") nelle visualizzazioni pubbliche.
+
+## Cosa è stato modificato
+
+### 1. Backend - Metabox Esperienza
+
+**File modificati:**
+- `/src/Admin/ExperienceMetaBoxes.php`
+- `/build/fp-experiences/src/Admin/ExperienceMetaBoxes.php`
+
+**Modifiche:**
+- Aggiunto un checkbox "Prezzo 'da...'" per ogni tipologia di biglietto nella tab "Biglietti & Prezzi"
+- Il campo viene salvato come `use_as_price_from` nell'array del biglietto
+- Se spuntato, quel biglietto verrà usato come prezzo di partenza
+
+### 2. Logica di Calcolo Prezzo "da..."
+
+**File modificati:**
+- `/src/Shortcodes/SimpleArchiveShortcode.php`
+- `/src/Shortcodes/ListShortcode.php`
+- `/src/Shortcodes/ExperienceShortcode.php`
+- `/src/Shortcodes/WidgetShortcode.php`
+- `/templates/front/widget.php`
+- Corrispondenti file in `/build/fp-experiences/`
+
+**Nuova logica:**
+1. **Prima verifica**: Cerca un biglietto con il checkbox "Prezzo 'da...'" spuntato
+2. **Se trovato**: Usa quel prezzo come prezzo di partenza
+3. **Altrimenti**: Usa il prezzo più basso tra tutte le tipologie di biglietto
+
+## Come usare la funzionalità
+
+### Nel Backend
+
+1. Vai nella pagina di modifica di un'esperienza
+2. Apri la tab "Biglietti & Prezzi"
+3. Per ogni tipologia di biglietto vedrai ora un checkbox "Prezzo 'da...'"
+4. Spunta il checkbox per la tipologia che vuoi usare come prezzo di partenza
+5. Salva l'esperienza
+
+**Nota:** È consigliato spuntare solo un checkbox per esperienza. Se ne spunti più di uno, verrà usato il primo trovato.
+
+### Comportamento
+
+**Esempio 1: Checkbox spuntato su "Adulto"**
+- Adulto: €50 ✓ (checkbox spuntato)
+- Bambino: €25
+- Senior: €40
+
+→ Prezzo mostrato: "Da €50"
+
+**Esempio 2: Nessun checkbox spuntato**
+- Adulto: €50
+- Bambino: €25
+- Senior: €40
+
+→ Prezzo mostrato: "Da €25" (prezzo più basso)
+
+**Esempio 3: Solo una tipologia**
+- Adulto: €50
+
+→ Prezzo mostrato: "Da €50"
+
+## Vantaggi
+
+1. **Controllo totale**: Puoi decidere esattamente quale prezzo mostrare come punto di partenza
+2. **Flessibilità**: Non sei più limitato al prezzo bambino o al prezzo più basso
+3. **Marketing**: Puoi scegliere il prezzo più rappresentativo della tua esperienza
+4. **Backward compatible**: Se non spunti nessun checkbox, il sistema usa automaticamente il prezzo più basso
+
+## Note Tecniche
+
+- Il campo `use_as_price_from` è salvato sia nell'array `_fp_exp_pricing` che in `_fp_ticket_types`
+- Il valore è un booleano (true/false)
+- La cache dei prezzi viene gestita automaticamente dal sistema esistente
+- Non richiede modifiche al database (usa i meta esistenti)
+
+## Test Consigliati
+
+1. Crea un'esperienza con più tipologie di biglietto
+2. Spunta il checkbox su una tipologia specifica
+3. Verifica che il prezzo "da..." corrisponda a quella tipologia
+4. Deseleziona il checkbox e verifica che torni al prezzo più basso
+5. Verifica anche nelle listing e negli archivi

--- a/build/fp-experiences/src/Admin/ExperienceMetaBoxes.php
+++ b/build/fp-experiences/src/Admin/ExperienceMetaBoxes.php
@@ -1609,6 +1609,8 @@ final class ExperienceMetaBoxes
         $price_name = $is_template ? 'fp_exp_pricing[tickets][__INDEX__][price]' : $name_prefix . '[price]';
         $capacity_name = $is_template ? 'fp_exp_pricing[tickets][__INDEX__][capacity]' : $name_prefix . '[capacity]';
         $slug_name = $is_template ? 'fp_exp_pricing[tickets][__INDEX__][slug]' : $name_prefix . '[slug]';
+        $use_as_price_from_name = $is_template ? 'fp_exp_pricing[tickets][__INDEX__][use_as_price_from]' : $name_prefix . '[use_as_price_from]';
+        $use_as_price_from_checked = ! empty($ticket['use_as_price_from']);
         ?>
         <div class="fp-exp-repeater-row" data-repeater-item draggable="true">
             <div class="fp-exp-repeater-row__fields">
@@ -1627,6 +1629,10 @@ final class ExperienceMetaBoxes
                 <label>
                     <span class="fp-exp-field__label"><?php esc_html_e('Capienza', 'fp-experiences'); ?></span>
                     <input type="number" min="0" step="1" <?php echo $this->field_name_attribute($capacity_name, $is_template); ?> value="<?php echo esc_attr((string) ($ticket['capacity'] ?? '')); ?>" />
+                </label>
+                <label style="display: flex; align-items: center; gap: 0.5rem;">
+                    <input type="checkbox" <?php echo $this->field_name_attribute($use_as_price_from_name, $is_template); ?> value="1" <?php checked($use_as_price_from_checked); ?> />
+                    <span class="fp-exp-field__label" style="margin: 0;"><?php esc_html_e('Prezzo "da..."', 'fp-experiences'); ?></span>
                 </label>
             </div>
             <p class="fp-exp-repeater-row__remove">
@@ -2439,6 +2445,7 @@ final class ExperienceMetaBoxes
                 $price = isset($ticket['price']) ? max(0.0, (float) $ticket['price']) : 0.0;
                 $capacity = isset($ticket['capacity']) ? absint((string) $ticket['capacity']) : 0;
                 $slug = isset($ticket['slug']) ? sanitize_key((string) $ticket['slug']) : '';
+                $use_as_price_from = ! empty($ticket['use_as_price_from']);
                 if ('' === $slug && '' !== $label) {
                     $slug = sanitize_key($label);
                 }
@@ -2452,6 +2459,7 @@ final class ExperienceMetaBoxes
                     'price' => $price,
                     'capacity' => $capacity,
                     'slug' => $slug,
+                    'use_as_price_from' => $use_as_price_from,
                 ];
 
                 $legacy_tickets[] = [
@@ -2462,6 +2470,7 @@ final class ExperienceMetaBoxes
                     'max' => $capacity,
                     'capacity' => $capacity,
                     'description' => '',
+                    'use_as_price_from' => $use_as_price_from,
                 ];
 
                 if ($price > 0) {

--- a/build/fp-experiences/src/Shortcodes/ExperienceShortcode.php
+++ b/build/fp-experiences/src/Shortcodes/ExperienceShortcode.php
@@ -493,19 +493,34 @@ final class ExperienceShortcode extends BaseShortcode
             return null;
         }
 
-        // Use the price from the first valid ticket type instead of the minimum
+        // First, look for a ticket marked as "use_as_price_from"
+        foreach ($tickets as $ticket) {
+            if (! is_array($ticket) || ! isset($ticket['price'])) {
+                continue;
+            }
+
+            if (! empty($ticket['use_as_price_from'])) {
+                $price = (float) $ticket['price'];
+                if ($price > 0) {
+                    return $price;
+                }
+            }
+        }
+
+        // If no ticket is marked, fall back to the lowest price
+        $min_price = null;
         foreach ($tickets as $ticket) {
             if (! is_array($ticket) || ! isset($ticket['price'])) {
                 continue;
             }
 
             $price = (float) $ticket['price'];
-            if ($price > 0) {
-                return $price;
+            if ($price > 0 && (null === $min_price || $price < $min_price)) {
+                $min_price = $price;
             }
         }
 
-        return null;
+        return $min_price;
     }
 
     /**

--- a/build/fp-experiences/src/Shortcodes/ListShortcode.php
+++ b/build/fp-experiences/src/Shortcodes/ListShortcode.php
@@ -1102,19 +1102,34 @@ final class ListShortcode extends BaseShortcode
             return null;
         }
 
-        // Use the price from the first valid ticket type instead of the minimum
+        // First, look for a ticket marked as "use_as_price_from"
+        foreach ($tickets as $ticket) {
+            if (! is_array($ticket) || ! isset($ticket['price'])) {
+                continue;
+            }
+
+            if (! empty($ticket['use_as_price_from'])) {
+                $price = (float) $ticket['price'];
+                if ($price > 0) {
+                    return $price;
+                }
+            }
+        }
+
+        // If no ticket is marked, fall back to the lowest price
+        $min_price = null;
         foreach ($tickets as $ticket) {
             if (! is_array($ticket) || ! isset($ticket['price'])) {
                 continue;
             }
 
             $price = (float) $ticket['price'];
-            if ($price > 0) {
-                return $price;
+            if ($price > 0 && (null === $min_price || $price < $min_price)) {
+                $min_price = $price;
             }
         }
 
-        return null;
+        return $min_price;
     }
 
     /**

--- a/build/fp-experiences/src/Shortcodes/SimpleArchiveShortcode.php
+++ b/build/fp-experiences/src/Shortcodes/SimpleArchiveShortcode.php
@@ -243,18 +243,33 @@ final class SimpleArchiveShortcode extends BaseShortcode
             return null;
         }
 
-        // Use the price from the first valid ticket type instead of the minimum
+        // First, look for a ticket marked as "use_as_price_from"
+        foreach ($tickets as $ticket) {
+            if (! is_array($ticket) || ! isset($ticket['price'])) {
+                continue;
+            }
+
+            if (! empty($ticket['use_as_price_from'])) {
+                $price = (float) $ticket['price'];
+                if ($price > 0) {
+                    return $price;
+                }
+            }
+        }
+
+        // If no ticket is marked, fall back to the lowest price
+        $min_price = null;
         foreach ($tickets as $ticket) {
             if (! is_array($ticket) || ! isset($ticket['price'])) {
                 continue;
             }
 
             $price = (float) $ticket['price'];
-            if ($price > 0) {
-                return $price;
+            if ($price > 0 && (null === $min_price || $price < $min_price)) {
+                $min_price = $price;
             }
         }
 
-        return null;
+        return $min_price;
     }
 }

--- a/build/fp-experiences/src/Shortcodes/WidgetShortcode.php
+++ b/build/fp-experiences/src/Shortcodes/WidgetShortcode.php
@@ -567,6 +567,17 @@ final class WidgetShortcode extends BaseShortcode
             return (float) $rules['base_price'];
         }
 
+        // First, look for a ticket marked as "use_as_price_from"
+        foreach ($tickets as $ticket) {
+            if (! empty($ticket['use_as_price_from'])) {
+                $price = $ticket['price'] ?? 0;
+                if (is_numeric($price) && $price > 0) {
+                    return (float) $price;
+                }
+            }
+        }
+
+        // If no ticket is marked, fall back to the lowest price
         $price_from = null;
         foreach ($tickets as $ticket) {
             $price = $ticket['price'] ?? 0;

--- a/build/fp-experiences/templates/front/widget.php
+++ b/build/fp-experiences/templates/front/widget.php
@@ -141,18 +141,35 @@ foreach ($slots as $slot) {
     $price_from_value = null === $price_from_value ? $price : min($price_from_value, $price);
 }
 
-// Use the price from the first valid ticket type instead of the minimum
+// If no slot prices available, look for tickets
 if (null === $price_from_value) {
+    // First, check for a ticket marked as "use_as_price_from"
     foreach ($tickets as $ticket) {
         if (! is_array($ticket)) {
             continue;
         }
 
-        $price = isset($ticket['price']) ? (float) $ticket['price'] : 0.0;
+        if (! empty($ticket['use_as_price_from'])) {
+            $price = isset($ticket['price']) ? (float) $ticket['price'] : 0.0;
+            if ($price > 0) {
+                $price_from_value = $price;
+                break;
+            }
+        }
+    }
 
-        if ($price > 0) {
-            $price_from_value = $price;
-            break;
+    // If no ticket is marked, fall back to the lowest price
+    if (null === $price_from_value) {
+        foreach ($tickets as $ticket) {
+            if (! is_array($ticket)) {
+                continue;
+            }
+
+            $price = isset($ticket['price']) ? (float) $ticket['price'] : 0.0;
+
+            if ($price > 0 && (null === $price_from_value || $price < $price_from_value)) {
+                $price_from_value = $price;
+            }
         }
     }
 }

--- a/src/Admin/ExperienceMetaBoxes.php
+++ b/src/Admin/ExperienceMetaBoxes.php
@@ -1609,6 +1609,8 @@ final class ExperienceMetaBoxes
         $price_name = $is_template ? 'fp_exp_pricing[tickets][__INDEX__][price]' : $name_prefix . '[price]';
         $capacity_name = $is_template ? 'fp_exp_pricing[tickets][__INDEX__][capacity]' : $name_prefix . '[capacity]';
         $slug_name = $is_template ? 'fp_exp_pricing[tickets][__INDEX__][slug]' : $name_prefix . '[slug]';
+        $use_as_price_from_name = $is_template ? 'fp_exp_pricing[tickets][__INDEX__][use_as_price_from]' : $name_prefix . '[use_as_price_from]';
+        $use_as_price_from_checked = ! empty($ticket['use_as_price_from']);
         ?>
         <div class="fp-exp-repeater-row" data-repeater-item draggable="true">
             <div class="fp-exp-repeater-row__fields">
@@ -1627,6 +1629,10 @@ final class ExperienceMetaBoxes
                 <label>
                     <span class="fp-exp-field__label"><?php esc_html_e('Capienza', 'fp-experiences'); ?></span>
                     <input type="number" min="0" step="1" <?php echo $this->field_name_attribute($capacity_name, $is_template); ?> value="<?php echo esc_attr((string) ($ticket['capacity'] ?? '')); ?>" />
+                </label>
+                <label style="display: flex; align-items: center; gap: 0.5rem;">
+                    <input type="checkbox" <?php echo $this->field_name_attribute($use_as_price_from_name, $is_template); ?> value="1" <?php checked($use_as_price_from_checked); ?> />
+                    <span class="fp-exp-field__label" style="margin: 0;"><?php esc_html_e('Prezzo "da..."', 'fp-experiences'); ?></span>
                 </label>
             </div>
             <p class="fp-exp-repeater-row__remove">
@@ -2439,6 +2445,7 @@ final class ExperienceMetaBoxes
                 $price = isset($ticket['price']) ? max(0.0, (float) $ticket['price']) : 0.0;
                 $capacity = isset($ticket['capacity']) ? absint((string) $ticket['capacity']) : 0;
                 $slug = isset($ticket['slug']) ? sanitize_key((string) $ticket['slug']) : '';
+                $use_as_price_from = ! empty($ticket['use_as_price_from']);
                 if ('' === $slug && '' !== $label) {
                     $slug = sanitize_key($label);
                 }
@@ -2452,6 +2459,7 @@ final class ExperienceMetaBoxes
                     'price' => $price,
                     'capacity' => $capacity,
                     'slug' => $slug,
+                    'use_as_price_from' => $use_as_price_from,
                 ];
 
                 $legacy_tickets[] = [
@@ -2462,6 +2470,7 @@ final class ExperienceMetaBoxes
                     'max' => $capacity,
                     'capacity' => $capacity,
                     'description' => '',
+                    'use_as_price_from' => $use_as_price_from,
                 ];
 
                 if ($price > 0) {

--- a/src/Shortcodes/ExperienceShortcode.php
+++ b/src/Shortcodes/ExperienceShortcode.php
@@ -493,19 +493,34 @@ final class ExperienceShortcode extends BaseShortcode
             return null;
         }
 
-        // Use the price from the first valid ticket type instead of the minimum
+        // First, look for a ticket marked as "use_as_price_from"
+        foreach ($tickets as $ticket) {
+            if (! is_array($ticket) || ! isset($ticket['price'])) {
+                continue;
+            }
+
+            if (! empty($ticket['use_as_price_from'])) {
+                $price = (float) $ticket['price'];
+                if ($price > 0) {
+                    return $price;
+                }
+            }
+        }
+
+        // If no ticket is marked, fall back to the lowest price
+        $min_price = null;
         foreach ($tickets as $ticket) {
             if (! is_array($ticket) || ! isset($ticket['price'])) {
                 continue;
             }
 
             $price = (float) $ticket['price'];
-            if ($price > 0) {
-                return $price;
+            if ($price > 0 && (null === $min_price || $price < $min_price)) {
+                $min_price = $price;
             }
         }
 
-        return null;
+        return $min_price;
     }
 
     /**

--- a/src/Shortcodes/ListShortcode.php
+++ b/src/Shortcodes/ListShortcode.php
@@ -1102,19 +1102,34 @@ final class ListShortcode extends BaseShortcode
             return null;
         }
 
-        // Use the price from the first valid ticket type instead of the minimum
+        // First, look for a ticket marked as "use_as_price_from"
+        foreach ($tickets as $ticket) {
+            if (! is_array($ticket) || ! isset($ticket['price'])) {
+                continue;
+            }
+
+            if (! empty($ticket['use_as_price_from'])) {
+                $price = (float) $ticket['price'];
+                if ($price > 0) {
+                    return $price;
+                }
+            }
+        }
+
+        // If no ticket is marked, fall back to the lowest price
+        $min_price = null;
         foreach ($tickets as $ticket) {
             if (! is_array($ticket) || ! isset($ticket['price'])) {
                 continue;
             }
 
             $price = (float) $ticket['price'];
-            if ($price > 0) {
-                return $price;
+            if ($price > 0 && (null === $min_price || $price < $min_price)) {
+                $min_price = $price;
             }
         }
 
-        return null;
+        return $min_price;
     }
 
     /**

--- a/src/Shortcodes/SimpleArchiveShortcode.php
+++ b/src/Shortcodes/SimpleArchiveShortcode.php
@@ -243,18 +243,33 @@ final class SimpleArchiveShortcode extends BaseShortcode
             return null;
         }
 
-        // Use the price from the first valid ticket type instead of the minimum
+        // First, look for a ticket marked as "use_as_price_from"
+        foreach ($tickets as $ticket) {
+            if (! is_array($ticket) || ! isset($ticket['price'])) {
+                continue;
+            }
+
+            if (! empty($ticket['use_as_price_from'])) {
+                $price = (float) $ticket['price'];
+                if ($price > 0) {
+                    return $price;
+                }
+            }
+        }
+
+        // If no ticket is marked, fall back to the lowest price
+        $min_price = null;
         foreach ($tickets as $ticket) {
             if (! is_array($ticket) || ! isset($ticket['price'])) {
                 continue;
             }
 
             $price = (float) $ticket['price'];
-            if ($price > 0) {
-                return $price;
+            if ($price > 0 && (null === $min_price || $price < $min_price)) {
+                $min_price = $price;
             }
         }
 
-        return null;
+        return $min_price;
     }
 }

--- a/src/Shortcodes/WidgetShortcode.php
+++ b/src/Shortcodes/WidgetShortcode.php
@@ -567,6 +567,17 @@ final class WidgetShortcode extends BaseShortcode
             return (float) $rules['base_price'];
         }
 
+        // First, look for a ticket marked as "use_as_price_from"
+        foreach ($tickets as $ticket) {
+            if (! empty($ticket['use_as_price_from'])) {
+                $price = $ticket['price'] ?? 0;
+                if (is_numeric($price) && $price > 0) {
+                    return (float) $price;
+                }
+            }
+        }
+
+        // If no ticket is marked, fall back to the lowest price
         $price_from = null;
         foreach ($tickets as $ticket) {
             $price = $ticket['price'] ?? 0;

--- a/templates/front/widget.php
+++ b/templates/front/widget.php
@@ -141,18 +141,35 @@ foreach ($slots as $slot) {
     $price_from_value = null === $price_from_value ? $price : min($price_from_value, $price);
 }
 
-// Use the price from the first valid ticket type instead of the minimum
+// If no slot prices available, look for tickets
 if (null === $price_from_value) {
+    // First, check for a ticket marked as "use_as_price_from"
     foreach ($tickets as $ticket) {
         if (! is_array($ticket)) {
             continue;
         }
 
-        $price = isset($ticket['price']) ? (float) $ticket['price'] : 0.0;
+        if (! empty($ticket['use_as_price_from'])) {
+            $price = isset($ticket['price']) ? (float) $ticket['price'] : 0.0;
+            if ($price > 0) {
+                $price_from_value = $price;
+                break;
+            }
+        }
+    }
 
-        if ($price > 0) {
-            $price_from_value = $price;
-            break;
+    // If no ticket is marked, fall back to the lowest price
+    if (null === $price_from_value) {
+        foreach ($tickets as $ticket) {
+            if (! is_array($ticket)) {
+                continue;
+            }
+
+            $price = isset($ticket['price']) ? (float) $ticket['price'] : 0.0;
+
+            if ($price > 0 && (null === $price_from_value || $price < $price_from_value)) {
+                $price_from_value = $price;
+            }
         }
     }
 }


### PR DESCRIPTION
Add a backend checkbox to select the "from" price for ticket types to allow users to explicitly choose which ticket price is displayed as the starting price ("Da...").

Previously, the "from" price defaulted to the lowest or first available ticket price, which was often the child price. This change provides a user-configurable option to override this automatic selection, giving more control over price presentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-89e653fe-0fb2-46cb-ae18-7a7591e398cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-89e653fe-0fb2-46cb-ae18-7a7591e398cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

