### PR TITLE
Simplify and reposition trust list section

### DIFF
--- a/build/fp-experiences/templates/front/experience.php
+++ b/build/fp-experiences/templates/front/experience.php
@@ -471,41 +471,6 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
                         </div>
                     <?php endif; ?>
 
-                    <?php if (! empty($overview_biases)) : ?>
-                        <ul class="fp-exp-overview__trust-list" role="list">
-                            <?php foreach ($overview_biases as $bias) :
-                                $label = isset($bias['label']) ? (string) $bias['label'] : '';
-                                if ('' === $label) {
-                                    continue;
-                                }
-
-                                $tagline = isset($bias['tagline']) ? (string) $bias['tagline'] : '';
-                                $description = isset($bias['description']) ? (string) $bias['description'] : '';
-                                $icon_name = isset($bias['icon']) ? (string) $bias['icon'] : '';
-                                $icon_svg = \FP_Exp\Utils\Helpers::cognitive_bias_icon_svg($icon_name);
-                                $chip_label_parts = array_values(array_filter([$label, $tagline, $description]));
-                                $chip_label_text = ! empty($chip_label_parts)
-                                    ? implode(' – ', array_unique($chip_label_parts))
-                                    : '';
-                                ?>
-                                <li
-                                    class="fp-exp-overview__chip"
-                                    <?php if ('' !== $chip_label_text) : ?>title="<?php echo esc_attr($chip_label_text); ?>" aria-label="<?php echo esc_attr($chip_label_text); ?>"<?php endif; ?>
-                                >
-                                    <span class="fp-exp-overview__chip-icon" aria-hidden="true"><?php echo $icon_svg; ?></span>
-                                    <span class="fp-exp-overview__chip-body">
-                                        <span class="fp-exp-overview__chip-label"><?php echo esc_html($label); ?></span>
-                                        <?php if ('' !== $tagline) : ?>
-                                            <span class="fp-exp-overview__chip-tagline"><?php echo esc_html($tagline); ?></span>
-                                        <?php endif; ?>
-                                        <?php if ('' !== $description) : ?>
-                                            <span class="fp-exp-overview__chip-description"><?php echo esc_html($description); ?></span>
-                                        <?php endif; ?>
-                                    </span>
-                                </li>
-                            <?php endforeach; ?>
-                        </ul>
-                    <?php endif; ?>
                 </section>
             <?php endif; ?>
 

--- a/build/fp-experiences/templates/front/widget.php
+++ b/build/fp-experiences/templates/front/widget.php
@@ -523,6 +523,53 @@ $price_from_display = null !== $price_from_value && $price_from_value > 0
                 </div>
             </li>
         </ol>
+
+        <?php
+        $overview = isset($overview) && is_array($overview) ? $overview : [];
+        $overview_biases = isset($overview['cognitive_biases']) && is_array($overview['cognitive_biases'])
+            ? array_values(array_filter(array_map(
+                static function ($bias) {
+                    if (! is_array($bias)) {
+                        $bias = [
+                            'label' => (string) $bias,
+                        ];
+                    }
+
+                    $label = isset($bias['label']) ? (string) $bias['label'] : '';
+                    if ('' === $label) {
+                        return null;
+                    }
+
+                    $icon = isset($bias['icon']) ? (string) $bias['icon'] : '';
+
+                    return [
+                        'label' => $label,
+                        'icon' => $icon,
+                    ];
+                },
+                $overview['cognitive_biases']
+            )))
+            : [];
+        ?>
+
+        <?php if (! empty($overview_biases)) : ?>
+            <ul class="fp-exp-overview__trust-list" role="list">
+                <?php foreach ($overview_biases as $bias) :
+                    $label = isset($bias['label']) ? (string) $bias['label'] : '';
+                    if ('' === $label) {
+                        continue;
+                    }
+
+                    $icon_name = isset($bias['icon']) ? (string) $bias['icon'] : '';
+                    $icon_svg = \FP_Exp\Utils\Helpers::cognitive_bias_icon_svg($icon_name);
+                    ?>
+                    <li class="fp-exp-overview__chip" title="<?php echo esc_attr($label); ?>" aria-label="<?php echo esc_attr($label); ?>">
+                        <span class="fp-exp-overview__chip-icon" aria-hidden="true"><?php echo $icon_svg; ?></span>
+                        <span class="fp-exp-overview__chip-label"><?php echo esc_html($label); ?></span>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
     </div>
     <?php if (! empty($schema_json)) : ?>
         <script type="application/ld+json" class="fp-exp-schema">

--- a/templates/front/experience.php
+++ b/templates/front/experience.php
@@ -471,41 +471,6 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
                         </div>
                     <?php endif; ?>
 
-                    <?php if (! empty($overview_biases)) : ?>
-                        <ul class="fp-exp-overview__trust-list" role="list">
-                            <?php foreach ($overview_biases as $bias) :
-                                $label = isset($bias['label']) ? (string) $bias['label'] : '';
-                                if ('' === $label) {
-                                    continue;
-                                }
-
-                                $tagline = isset($bias['tagline']) ? (string) $bias['tagline'] : '';
-                                $description = isset($bias['description']) ? (string) $bias['description'] : '';
-                                $icon_name = isset($bias['icon']) ? (string) $bias['icon'] : '';
-                                $icon_svg = \FP_Exp\Utils\Helpers::cognitive_bias_icon_svg($icon_name);
-                                $chip_label_parts = array_values(array_filter([$label, $tagline, $description]));
-                                $chip_label_text = ! empty($chip_label_parts)
-                                    ? implode(' – ', array_unique($chip_label_parts))
-                                    : '';
-                                ?>
-                                <li
-                                    class="fp-exp-overview__chip"
-                                    <?php if ('' !== $chip_label_text) : ?>title="<?php echo esc_attr($chip_label_text); ?>" aria-label="<?php echo esc_attr($chip_label_text); ?>"<?php endif; ?>
-                                >
-                                    <span class="fp-exp-overview__chip-icon" aria-hidden="true"><?php echo $icon_svg; ?></span>
-                                    <span class="fp-exp-overview__chip-body">
-                                        <span class="fp-exp-overview__chip-label"><?php echo esc_html($label); ?></span>
-                                        <?php if ('' !== $tagline) : ?>
-                                            <span class="fp-exp-overview__chip-tagline"><?php echo esc_html($tagline); ?></span>
-                                        <?php endif; ?>
-                                        <?php if ('' !== $description) : ?>
-                                            <span class="fp-exp-overview__chip-description"><?php echo esc_html($description); ?></span>
-                                        <?php endif; ?>
-                                    </span>
-                                </li>
-                            <?php endforeach; ?>
-                        </ul>
-                    <?php endif; ?>
                 </section>
             <?php endif; ?>
 

--- a/templates/front/widget.php
+++ b/templates/front/widget.php
@@ -523,6 +523,53 @@ $price_from_display = null !== $price_from_value && $price_from_value > 0
                 </div>
             </li>
         </ol>
+
+        <?php
+        $overview = isset($overview) && is_array($overview) ? $overview : [];
+        $overview_biases = isset($overview['cognitive_biases']) && is_array($overview['cognitive_biases'])
+            ? array_values(array_filter(array_map(
+                static function ($bias) {
+                    if (! is_array($bias)) {
+                        $bias = [
+                            'label' => (string) $bias,
+                        ];
+                    }
+
+                    $label = isset($bias['label']) ? (string) $bias['label'] : '';
+                    if ('' === $label) {
+                        return null;
+                    }
+
+                    $icon = isset($bias['icon']) ? (string) $bias['icon'] : '';
+
+                    return [
+                        'label' => $label,
+                        'icon' => $icon,
+                    ];
+                },
+                $overview['cognitive_biases']
+            )))
+            : [];
+        ?>
+
+        <?php if (! empty($overview_biases)) : ?>
+            <ul class="fp-exp-overview__trust-list" role="list">
+                <?php foreach ($overview_biases as $bias) :
+                    $label = isset($bias['label']) ? (string) $bias['label'] : '';
+                    if ('' === $label) {
+                        continue;
+                    }
+
+                    $icon_name = isset($bias['icon']) ? (string) $bias['icon'] : '';
+                    $icon_svg = \FP_Exp\Utils\Helpers::cognitive_bias_icon_svg($icon_name);
+                    ?>
+                    <li class="fp-exp-overview__chip" title="<?php echo esc_attr($label); ?>" aria-label="<?php echo esc_attr($label); ?>">
+                        <span class="fp-exp-overview__chip-icon" aria-hidden="true"><?php echo $icon_svg; ?></span>
+                        <span class="fp-exp-overview__chip-label"><?php echo esc_html($label); ?></span>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
     </div>
     <?php if (! empty($schema_json)) : ?>
         <script type="application/ld+json" class="fp-exp-schema">


### PR DESCRIPTION
Simplify and relocate the trust list section to display only icons and labels after the summary in the booking widget.

---
<a href="https://cursor.com/background-agent?bcId=bc-0af2a7be-66dd-4581-badb-9a91da158639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0af2a7be-66dd-4581-badb-9a91da158639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

