### PR TITLE
Remove list left margin

### DIFF
--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -1806,6 +1806,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.6rem;
+    margin-left: 0;
 }
 
 /* Slot item cliccabile + stato selezionato */

--- a/build/fp-experiences/assets/css/front.css
+++ b/build/fp-experiences/assets/css/front.css
@@ -1806,6 +1806,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.6rem;
+    margin-left: 0;
 }
 
 /* Slot item cliccabile + stato selezionato */


### PR DESCRIPTION
Remove left margin from `.fp-exp-slots__list` to override default browser `ul`/`ol` styles.

---
<a href="https://cursor.com/background-agent?bcId=bc-a44ce7e5-e48f-45ce-b687-900543228276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a44ce7e5-e48f-45ce-b687-900543228276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

