### PR TITLE
Remove border and color from fp-exp-quantity

### DIFF
--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -2009,7 +2009,6 @@
     justify-content: flex-end;
     gap: 0.5rem;
     padding: 0.35rem;
-    border: 1px solid color-mix(in srgb, var(--fp-color-primary) 18%, rgba(15, 23, 42, 0.12));
     flex-wrap: nowrap;
     min-width: 0;
 }


### PR DESCRIPTION
Remove the border property from `.fp-exp-quantity` to align with the user's request.

---
<a href="https://cursor.com/background-agent?bcId=bc-37ef0439-1943-462d-a5a7-35bbacc9d801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-37ef0439-1943-462d-a5a7-35bbacc9d801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

