### PR TITLE
Handle line breaks as bullet points

### DIFF
--- a/build/fp-experiences/templates/front/experience.php
+++ b/build/fp-experiences/templates/front/experience.php
@@ -797,14 +797,15 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
                             <?php if (! empty($notes)) : ?>
                                 <article class="fp-exp-essentials__card">
                                     <h3 class="fp-exp-essentials__title"><?php esc_html_e('Note', 'fp-experiences'); ?></h3>
-                                    <?php if (is_array($notes)) : ?>
+                                    <?php
+                                    $notes_items = is_array($notes) ? $notes : array_filter(array_map('trim', explode("\n", $notes)));
+                                    if (! empty($notes_items)) :
+                                        ?>
                                         <ul class="fp-exp-essentials__list">
-                                            <?php foreach ($notes as $note) : ?>
+                                            <?php foreach ($notes_items as $note) : ?>
                                                 <li><?php echo esc_html($note); ?></li>
                                             <?php endforeach; ?>
                                         </ul>
-                                    <?php else : ?>
-                                        <p class="fp-exp-essentials__copy"><?php echo esc_html($notes); ?></p>
                                     <?php endif; ?>
                                 </article>
                             <?php endif; ?>
@@ -812,7 +813,18 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
                             <?php if ('' !== $children_rules) : ?>
                                 <article class="fp-exp-essentials__card">
                                     <h3 class="fp-exp-essentials__title"><?php esc_html_e('Regole bambini', 'fp-experiences'); ?></h3>
-                                    <p class="fp-exp-essentials__copy"><?php echo esc_html($children_rules); ?></p>
+                                    <?php
+                                    $children_rules_items = array_filter(array_map('trim', explode("\n", $children_rules)));
+                                    if (count($children_rules_items) > 1) :
+                                        ?>
+                                        <ul class="fp-exp-essentials__list">
+                                            <?php foreach ($children_rules_items as $rule) : ?>
+                                                <li><?php echo esc_html($rule); ?></li>
+                                            <?php endforeach; ?>
+                                        </ul>
+                                    <?php else : ?>
+                                        <p class="fp-exp-essentials__copy"><?php echo esc_html($children_rules); ?></p>
+                                    <?php endif; ?>
                                 </article>
                             <?php endif; ?>
 

--- a/templates/front/experience.php
+++ b/templates/front/experience.php
@@ -797,14 +797,15 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
                             <?php if (! empty($notes)) : ?>
                                 <article class="fp-exp-essentials__card">
                                     <h3 class="fp-exp-essentials__title"><?php esc_html_e('Note', 'fp-experiences'); ?></h3>
-                                    <?php if (is_array($notes)) : ?>
+                                    <?php
+                                    $notes_items = is_array($notes) ? $notes : array_filter(array_map('trim', explode("\n", $notes)));
+                                    if (! empty($notes_items)) :
+                                        ?>
                                         <ul class="fp-exp-essentials__list">
-                                            <?php foreach ($notes as $note) : ?>
+                                            <?php foreach ($notes_items as $note) : ?>
                                                 <li><?php echo esc_html($note); ?></li>
                                             <?php endforeach; ?>
                                         </ul>
-                                    <?php else : ?>
-                                        <p class="fp-exp-essentials__copy"><?php echo esc_html($notes); ?></p>
                                     <?php endif; ?>
                                 </article>
                             <?php endif; ?>
@@ -812,7 +813,18 @@ $sticky_price_display = '' !== $price_from_display ? $format_currency($price_fro
                             <?php if ('' !== $children_rules) : ?>
                                 <article class="fp-exp-essentials__card">
                                     <h3 class="fp-exp-essentials__title"><?php esc_html_e('Regole bambini', 'fp-experiences'); ?></h3>
-                                    <p class="fp-exp-essentials__copy"><?php echo esc_html($children_rules); ?></p>
+                                    <?php
+                                    $children_rules_items = array_filter(array_map('trim', explode("\n", $children_rules)));
+                                    if (count($children_rules_items) > 1) :
+                                        ?>
+                                        <ul class="fp-exp-essentials__list">
+                                            <?php foreach ($children_rules_items as $rule) : ?>
+                                                <li><?php echo esc_html($rule); ?></li>
+                                            <?php endforeach; ?>
+                                        </ul>
+                                    <?php else : ?>
+                                        <p class="fp-exp-essentials__copy"><?php echo esc_html($children_rules); ?></p>
+                                    <?php endif; ?>
                                 </article>
                             <?php endif; ?>
 


### PR DESCRIPTION
Rende il testo separato da a capo come elenchi puntati nelle sezioni "Note" e "Regole bambini" delle card `fp-exp-essentials__card`.

Questo permette agli utenti del backend di creare elenchi puntati nel frontend semplicemente usando gli a capo nei campi di testo, migliorando la formattazione e la leggibilità.

---
<a href="https://cursor.com/background-agent?bcId=bc-09ec4306-54ce-46d9-87e3-5645469f13d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-09ec4306-54ce-46d9-87e3-5645469f13d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

