### PR TITLE
Fix blast button z-index over sticky

### DIFF
--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -4158,7 +4158,7 @@ body.fp-modal-open {
     justify-content: space-between;
     gap: 0.75rem;
     flex-wrap: wrap;
-    z-index: 999;
+    z-index: 999999;
     opacity: 1;
     transform: translateY(0);
     transition: transform 0.3s ease, opacity 0.3s ease;


### PR DESCRIPTION
Increase `z-index` of sticky bar to prevent overlap with other elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7ae18e9-8809-4f08-ae3a-0737964514be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e7ae18e9-8809-4f08-ae3a-0737964514be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

